### PR TITLE
Allow building eBPF from the main builder image

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -103,6 +103,11 @@ RUN curl -O http://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION
     tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ && \
     rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
 
+# To build the EBPF code we need kernel headers for Linux 4.9
+RUN curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-deb-x64.tgz && \
+    tar xf kernel-4.9-headers-deb-x64.tgz --no-same-owner --strip 1 -C /usr && \
+    rm kernel-4.9-headers-deb-x64.tgz
+
 # Entrypoint
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -110,6 +110,12 @@ RUN curl -O http://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION
     tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ && \
     rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
 
+# To build the EBPF code we need kernel headers for Linux 4.9
+RUN rm -r /usr/src/kernels/* && \
+    curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-rpm-x64.tgz && \
+    tar xf kernel-4.9-headers-rpm-x64.tgz --no-same-owner --strip 1 -C /usr && \
+    rm kernel-4.9-headers-rpm-x64.tgz
+
 # Entrypoint
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Brings dependencies from the future into our builder images.

Kernel headers come from Debian 9 for the deb builder and Fedora 26 for rpm.

It's a bit of a hack.