### PR TITLE
Push images to the correct dockerhub account

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,10 +36,10 @@ build_rpm_x64:
     - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:latest
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
-    - docker tag $SRC_IMAGE datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
-    - docker push datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
-    - docker tag $SRC_IMAGE datadog-agent-buildimages/$IMAGE:latest
-    - docker push datadog-agent-buildimages/$IMAGE:latest
+    - docker tag $SRC_IMAGE datadog/datadog-agent-buildimages:$IMAGE-${CI_COMMIT_SHA:0:7}
+    - docker push datadog/datadog-agent-buildimages:$IMAGE-${CI_COMMIT_SHA:0:7}
+    - docker tag $SRC_IMAGE datadog/datadog-agent-buildimages:$IMAGE-latest
+    - docker push datadog/datadog-agent-buildimages:$IMAGE-latest
 
 release_deb_x64:
   <<: *release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ build_rpm_x64:
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
     - docker tag $SRC_IMAGE datadog/datadog-agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
     - docker push datadog/datadog-agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
-    - docker tag datadog/datadog-agent-buildimages-$IMAGE:latest
+    - docker tag $SRC_IMAGE datadog/datadog-agent-buildimages-$IMAGE:latest
     - docker push datadog/datadog-agent-buildimages-$IMAGE:latest
 
 release_deb_x64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,10 +36,10 @@ build_rpm_x64:
     - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:latest
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
-    - docker tag $SRC_IMAGE datadog/datadog-agent-buildimages:$IMAGE-${CI_COMMIT_SHA:0:7}
-    - docker push datadog/datadog-agent-buildimages:$IMAGE-${CI_COMMIT_SHA:0:7}
-    - docker tag $SRC_IMAGE datadog/datadog-agent-buildimages:$IMAGE-latest
-    - docker push datadog/datadog-agent-buildimages:$IMAGE-latest
+    - docker tag $SRC_IMAGE datadog/datadog-agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    - docker push datadog/datadog-agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    - docker tag datadog/datadog-agent-buildimages-$IMAGE:latest
+    - docker push datadog/datadog-agent-buildimages-$IMAGE:latest
 
 release_deb_x64:
   <<: *release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,10 +36,10 @@ build_rpm_x64:
     - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:latest
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
-    - docker tag $SRC_IMAGE datadog/datadog-agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
-    - docker push datadog/datadog-agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
-    - docker tag $SRC_IMAGE datadog/datadog-agent-buildimages-$IMAGE:latest
-    - docker push datadog/datadog-agent-buildimages-$IMAGE:latest
+    - docker tag $SRC_IMAGE datadog/agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    - docker push datadog/agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    - docker tag $SRC_IMAGE datadog/agent-buildimages-$IMAGE:latest
+    - docker push datadog/agent-buildimages-$IMAGE:latest
 
 release_deb_x64:
   <<: *release


### PR DESCRIPTION
There is no `datadog-agent-buildimages` in dockerhub. Push to `datadog/datadog-agent-buildimages-<IMAGE_NAME>` instead.