### PR TITLE
[deb-x64, rpm-x64] Force umask to 0022 within containers

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -110,4 +110,7 @@ RUN chmod +x /entrypoint.sh
 # create the agent build folder within $GOPATH
 RUN mkdir -p /go/src/github.com/DataDog/datadog-agent
 
+# Force umask to 0022
+RUN echo "umask 0022" >> /root/.bashrc
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -117,4 +117,7 @@ RUN chmod +x /entrypoint.sh
 # create the agent build folder within $GOPATH
 RUN mkdir -p /go/src/github.com/DataDog/datadog-agent
 
+# Force umask to 0022
+RUN echo "umask 0022" >> /root/.bashrc
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The latest rvm update (1.29.9) introduced a change in the shell script preparing the rvm environment at login. 
As a result, the umask in the container has changed, which changes the permissions of all files created within the containers. 
Because of this, the files included in the deb and rpm packages had their permissions changed, which can lead to installation issues.
