### PR TITLE
Adding gettext and autoconf to the builder in order to build procps-ng in omnibus

### DIFF
--- a/deb-arm64/Dockerfile
+++ b/deb-arm64/Dockerfile
@@ -18,7 +18,7 @@ ENV CLANG_VERSION $CLANG_VERSION
 
 RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
     python2.7-dev build-essential pkg-config tar libsystemd-dev libkrb5-dev \
-    python3-dev
+    python3-dev gettext libtool autopoint autoconf libtool-bin
 
 
 # RVM

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -35,7 +35,7 @@ RUN echo "deb http://archive.debian.org/debian wheezy main contrib non-free" > /
 
 RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
   build-essential pkg-config\
-  rpm tar
+  rpm tar gettext libtool autopoint autoconf pkg-config
 
 RUN apt-get install -y libsystemd-journal-dev/wheezy-backports
 

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -17,7 +17,8 @@ ENV CLANG_VERSION $CLANG_VERSION
 
 
 RUN yum groupinstall -y development && yum -y install which perl-ExtUtils-MakeMaker ncurses-compat-libs git procps \
-    curl-devel expat-devel gettext-devel openssl-devel zlib-devel bzip2 glibc-static python-devel tar pkgconfig 
+    curl-devel expat-devel gettext-devel openssl-devel zlib-devel bzip2 glibc-static python-devel tar pkgconfig  \
+    libtool autoconf
 
 # RVM
 COPY ./rvm/gpg-keys /gpg-keys

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -25,7 +25,7 @@ RUN yum -y install \
   which perl-ExtUtils-MakeMaker \
   centos-release-scl pkgconfig \
   curl-devel expat-devel gettext-devel openssl-devel zlib-devel bzip2 \
-  glibc-static tar
+  glibc-static tar libtool
 
 # Git
 RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-2.10.1.tar.gz
@@ -64,6 +64,17 @@ ENV PKG_CONFIG_LIBDIR $PKG_CONFIG_LIBDIR:$CONDA_PATH/lib/pkgconfig
 # Setup pythons
 RUN conda create -n ddpy2 python python=2
 RUN conda create -n ddpy3 python python=3.7
+
+# Autoconf
+# We need a newer version of autoconf to compile procps-ng (installing 2.69 over 2.63).
+RUN curl -sL -o /tmp/autoconf-2.69.tar.gz https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \
+    && cd /tmp \
+    && tar -xvf /tmp/autoconf-2.69.tar.gz --no-same-owner \
+    && cd autoconf-2.69 \
+    && ./configure \
+    && make && make install \
+    && cd / \
+    && rm -rf /tmp/autoconf-2.69 /tmp/autoconf-2.69.tar.gz
 
 # IBM MQ
 # IBM MQ is required in the builder.


### PR DESCRIPTION
New dependencies are needed to build procps-ng latest version. Also autoconf 2.69 is not available for RPM so we have to build it manually.