### PR TITLE
builders: python 3.8 + install `distro` dep needed for our invoke tasks.

### DIFF
--- a/deb-arm64/Dockerfile
+++ b/deb-arm64/Dockerfile
@@ -33,7 +33,7 @@ RUN /bin/bash -l -c "gem install bundler --no-document"
 # Pip & Invoke
 RUN curl "https://bootstrap.pypa.io/get-pip.py" | python2.7 - pip==${DD_PIP_VERSION} setuptools==${DD_SETUPTOOLS_VERSION}
 RUN curl "https://bootstrap.pypa.io/get-pip.py" | python3 - pip==${DD_PIP_VERSION} setuptools==${DD_SETUPTOOLS_VERSION}
-RUN pip install invoke awscli==1.16.240
+RUN pip install invoke distro==1.4.0 awscli==1.16.240
 
 # Gimme
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -89,7 +89,7 @@ RUN conda init bash
 
 # Setup pythons
 RUN conda create -n ddpy2 python python=2
-RUN conda create -n ddpy3 python python=3.7
+RUN conda create -n ddpy3 python python=3.8
 
 # Update pip, setuptools and misc deps
 RUN source /root/.bashrc && conda activate ddpy2 \

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -95,13 +95,13 @@ RUN conda create -n ddpy3 python python=3.7
 RUN source /root/.bashrc && conda activate ddpy2 \
     && pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION} \
     && pip install --ignore-installed setuptools==${DD_SETUPTOOLS_VERSION} \
-    && pip install invoke awscli==1.16.240
+    && pip install invoke distro==1.4.0 awscli==1.16.240
 
 # Update pip, setuptools and misc deps
 RUN source /root/.bashrc && conda activate ddpy3 \
     && pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION} \
     && pip install --ignore-installed setuptools==${DD_SETUPTOOLS_VERSION} \
-    && pip install invoke awscli==1.16.240
+    && pip install invoke distro==1.4.0 awscli==1.16.240
 
 
 # Gimme

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -30,9 +30,7 @@ RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Pip & Invoke
 RUN curl "https://bootstrap.pypa.io/get-pip.py" | python2.7 - pip==${DD_PIP_VERSION} setuptools==${DD_SETUPTOOLS_VERSION}
-RUN pip install invoke awscli==1.16.240
-
-
+RUN pip install invoke distro==1.4.0 awscli==1.16.240
 
 # Gimme
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -95,13 +95,13 @@ RUN conda init bash
 RUN source /root/.bashrc && conda activate ddpy2 \
     && pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION} \
     && pip install --ignore-installed setuptools==${DD_SETUPTOOLS_VERSION} \
-    && pip install invoke awscli==1.16.240
+    && pip install invoke distro==1.4.0 awscli==1.16.240
 
 # Update pip, setuptools and misc deps
 RUN source /root/.bashrc && conda activate ddpy3 \
     && pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION} \
     && pip install --ignore-installed setuptools==${DD_SETUPTOOLS_VERSION} \
-    && pip install invoke awscli==1.16.240
+    && pip install invoke distro==1.4.0 awscli==1.16.240
 
 # Add systemd headers
 COPY ./rpm-headers/systemd /usr/include/systemd

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -63,7 +63,7 @@ ENV PKG_CONFIG_LIBDIR $PKG_CONFIG_LIBDIR:$CONDA_PATH/lib/pkgconfig
 
 # Setup pythons
 RUN conda create -n ddpy2 python python=2
-RUN conda create -n ddpy3 python python=3.7
+RUN conda create -n ddpy3 python python=3.8
 
 # IBM MQ
 # IBM MQ is required in the builder.


### PR DESCRIPTION
Bump Python 3 to 3.8, also add  `distro` dependency used in some of our invoke tasks which is needed to replace `platform.linux_distribution` since python 3.8.