### PR TITLE
Use python3

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -14,9 +14,12 @@ RUN apt install -y \
         libelf-dev \
         linux-headers-arm64 \
         llvm \
+        python \
+        python-pip \
+        python3-distro \
         python3-distutils \
         python3-invoke \
-        python-pip
+        python3-pip
 
 
 ENV GOPATH=/go

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -14,9 +14,12 @@ RUN apt install -y \
         libelf-dev \
         linux-headers-amd64 \
         llvm \
+        python \
+        python-pip \
+        python3-distro \
         python3-distutils \
         python3-invoke \
-        python-pip
+        python3-pip
 
 
 ENV GOPATH=/go


### PR DESCRIPTION
Since the bump of python to 3.8 (#26 and DataDog/datadog-agent#4464) `system-probe` build also needs python 3.
This PR does the appropriate change in the `system-probe` specific build images that are use in DataDog/datadog-agent#4871.