### PR TITLE
Activate py3 env by default

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -l
 set -e
 
+source /root/.bashrc && conda activate ddpy3
 eval "$(gimme)"
 
 exec "$@"


### PR DESCRIPTION
So we can call invoke/pip straight away.