### PR TITLE
Pin Clang 8 since the system-probe fails to build on Clang 9

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -4,13 +4,13 @@ RUN apt update && apt full-upgrade -y
 RUN apt install -y \
         awscli \
         bison \
-        clang \
+        clang-8 \
         cmake \
         flex \
         git \
         go-dep \
         golang \
-        libclang-dev \
+        libclang-8-dev \
         libelf-dev \
         linux-headers-arm64 \
         llvm \

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -4,13 +4,13 @@ RUN apt update && apt full-upgrade -y
 RUN apt install -y \
         awscli \
         bison \
-        clang \
+        clang-8 \
         cmake \
         flex \
         git \
         go-dep \
         golang \
-        libclang-dev \
+        libclang-8-dev \
         libelf-dev \
         linux-headers-amd64 \
         llvm \


### PR DESCRIPTION
Clang 9 errors with:

```
LLVM ERROR: Cannot select: 0x21a0d090: i64,ch = AtomicLoadOr<(load store seq_cst 8 on %ir.229)> 0x219edfd8:1, 0x21a108c0, Constant:i64<0>
```