### PR TITLE
Create a symlink for clang in the system probe builder

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -28,3 +28,5 @@ ENV GOPATH=/go
 
 # create the agent build folder within $GOPATH
 RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
+
+RUN ln /usr/bin/clang-8  /usr/bin/clang

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -23,6 +23,7 @@ RUN apt install -y \
         wget
 
 RUN wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme
+RUN ln /usr/bin/clang-8  /usr/bin/clang
 
 ENV GOPATH=/go
 

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -23,9 +23,10 @@ RUN apt install -y \
         wget
 
 RUN wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme
-RUN ln /usr/bin/clang-8  /usr/bin/clang
 
 ENV GOPATH=/go
 
 # create the agent build folder within $GOPATH
 RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
+
+RUN ln /usr/bin/clang-8  /usr/bin/clang


### PR DESCRIPTION
We recently started pinning clang-8. 

This PR creates a symlink for `clang`  which is the command the `system-probe.build` task expects.

See https://github.com/DataDog/datadog-agent/pull/5079 