### PR TITLE
Fix clang download.

### DIFF
--- a/build-clang.sh
+++ b/build-clang.sh
@@ -2,9 +2,9 @@
 
 CLANG_VERSION=8.0.0
 
-curl -O http://releases.llvm.org/${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz
+curl -LO http://releases.llvm.org/${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz
 tar -xf llvm-${CLANG_VERSION}.src.tar.xz
-curl -O http://releases.llvm.org/${CLANG_VERSION}/cfe-${CLANG_VERSION}.src.tar.xz
+curl -LO http://releases.llvm.org/${CLANG_VERSION}/cfe-${CLANG_VERSION}.src.tar.xz
 tar -xf cfe-${CLANG_VERSION}.src.tar.xz
 mv cfe-${CLANG_VERSION}.src/ clang
 cd llvm-${CLANG_VERSION}.src

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -125,7 +125,7 @@ RUN set -ex \
 
 # Install clang and llvm version 8
 # Using build for sles11 because the versions built for other distros target glibcs that are too new to be used from this image
-RUN curl -O http://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
+RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
     tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ && \
     rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
 

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -127,7 +127,7 @@ RUN set -ex \
 
 # Install clang and llvm version 8
 # Using build for sles11 because the versions built for other distros target glibcs that are too new to be used from this image
-RUN curl -O http://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
+RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
     tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ && \
     rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
 


### PR DESCRIPTION
The `http://` uri was used but it has been moved to `https://`
I've switched the uri to the `https://` route and added the follow flag to
curl.
Note that the `-L` is optional now, but I've decided to add it because it's already used on many other curl calls.