### PR TITLE
[system-probe] clang lib paths should also be linked to something that cmake can find.

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -30,3 +30,4 @@ ENV GOPATH=/go
 RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 
 RUN ln /usr/bin/clang-8  /usr/bin/clang
+RUN ln -s /usr/lib/llvm-8 /usr/lib/llvm

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -30,3 +30,4 @@ ENV GOPATH=/go
 RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 
 RUN ln /usr/bin/clang-8  /usr/bin/clang
+RUN ln -s /usr/lib/llvm-8 /usr/lib/llvm


### PR DESCRIPTION
The same way that https://github.com/DataDog/datadog-agent-buildimages/pull/34 link the binary, we need to link the clang library directory to help cmake find it during the build jobs.
I did it here and this way because we already have a fix here to link the clang binary.