### PR TITLE
Use a pre-compiled version of clang for x64 system-probe builders

### DIFF
--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -1,7 +1,6 @@
 FROM debian:bullseye
 
-RUN apt update && apt full-upgrade -y
-RUN apt install -y \
+RUN apt update && apt full-upgrade -y && apt install -y  \
         awscli \
         bison \
         clang-8 \
@@ -13,13 +12,13 @@ RUN apt install -y \
         libclang-8-dev \
         libelf-dev \
         linux-headers-amd64 \
-        llvm \
         python \
         python-pip \
         python3-distro \
         python3-distutils \
         python3-invoke \
         python3-pip \
+        libtinfo5 \
         wget
 
 RUN wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme
@@ -29,5 +28,8 @@ ENV GOPATH=/go
 # create the agent build folder within $GOPATH
 RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 
-RUN ln /usr/bin/clang-8  /usr/bin/clang
-RUN ln -s /usr/lib/llvm-8 /usr/lib/llvm
+# install clang from the website since the package manager can change at any time
+RUN wget "https://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
+RUN mkdir -p /opt/clang
+RUN tar xf /tmp/clang.tar.xz  -C /opt/clang --strip-components=1
+ENV PATH /opt/clang/bin:${PATH}


### PR DESCRIPTION
We need to keep the versions of clang for the development environment
and build environment in sync because we verify that the checked in
binaries match the binaries from CI.

The easiest way to do this is to use a pre-built version of clang
instead of whatever version is in the apt repositories.