### PR TITLE
[system-probe] use pip3

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -15,7 +15,7 @@ RUN apt install -y \
         linux-headers-arm64 \
         llvm \
         python \
-        python-pip \
+        python3-pip \
         python3-distro \
         python3-distutils \
         python3-invoke \

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -13,7 +13,7 @@ RUN apt update && apt full-upgrade -y && apt install -y  \
         libelf-dev \
         linux-headers-amd64 \
         python \
-        python-pip \
+        python3-pip \
         python3-distro \
         python3-distutils \
         python3-invoke \


### PR DESCRIPTION
python-pip has disappeared from the apt repositories.   