### PR TITLE
[rpm-arm64] Add systemd development headers

### DIFF
--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -17,7 +17,7 @@ ENV CLANG_VERSION $CLANG_VERSION
 
 
 RUN yum groupinstall -y development && yum -y install which perl-ExtUtils-MakeMaker ncurses-compat-libs git procps \
-    curl-devel expat-devel gettext-devel openssl-devel zlib-devel bzip2 glibc-static python-devel tar pkgconfig  \
+    curl-devel expat-devel gettext-devel openssl-devel systemd-devel zlib-devel bzip2 glibc-static python-devel tar pkgconfig  \
     libtool autoconf policycoreutils-python
 
 # RVM


### PR DESCRIPTION
### What does this PR do?

Adds systemd development headers to the rpm-arm64, needed for the systemd integration.