### PR TITLE
Fix Windows release jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,8 +144,14 @@ build_windows_1909_x86:
     - docker pull $($Env:SRC_IMAGE)
     - docker tag $($Env:SRC_IMAGE) 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$($Env:IMAGE):latest
     - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$($Env:IMAGE):latest
-    - $Env:DOCKER_REGISTRY_LOGIN=(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$Env:DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
+    # ECR Login
+    - $Env:AWS_ECR_PASSWORD=aws ecr get-login-password --region us-east-1
+    - docker login --username AWS --password "$($Env:AWS_ECR_PASSWORD)" 486234852809.dkr.ecr.us-east-1.amazonaws.com
+    # DockerHub login
+    - $Env:DOCKER_REGISTRY_LOGIN = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text
+    - $Env:DOCKER_REGISTRY_PWD = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text
+    - docker login --username "$($Env:DOCKER_REGISTRY_LOGIN)" --password "$($Env:DOCKER_REGISTRY_PWD)" docker.io
+    # Tag & push to Dockerhub
     - docker tag $($Env:SRC_IMAGE) datadog/agent-buildimages-$($Env:IMAGE):v$($Env:CI_PIPELINE_ID)-$($Env:CI_COMMIT_SHA.SubString(0,7))
     - docker push datadog/agent-buildimages-$($Env:IMAGE):v$($Env:CI_PIPELINE_ID)-$($Env:CI_COMMIT_SHA.SubString(0,7))
     - docker tag $($Env:SRC_IMAGE) datadog/agent-buildimages-$($Env:IMAGE):latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,12 +64,15 @@ build_system-probe_arm64:
   stage: build
   except: [ tags, schedules ]
   script:
-    - echo  "build --build-arg BASE_IMAGE=$($Env:BASE_IMAGE) --build-arg TARGET_ARCH=$($Env:TARGET_ARCH) --build-arg WINDOWS_VERSION=$($Env:WINDOWS_VERSION) --tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$($Env:IMAGE):v$($Env:CI_PIPELINE_ID)-$($Env:CI_COMMIT_SHA.SubString(0,7)) --file $DOCKERFILE ."
-    - powershell -Command "docker build --no-cache --build-arg BASE_IMAGE=$($Env:BASE_IMAGE) --build-arg TARGET_ARCH=$($Env:TARGET_ARCH) --build-arg WINDOWS_VERSION=$($Env:WINDOWS_VERSION) --tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$($Env:IMAGE):v$($Env:CI_PIPELINE_ID)-$($Env:CI_COMMIT_SHA.SubString(0,7)) --file $DOCKERFILE ."
-    - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$($Env:IMAGE):v$($Env:CI_PIPELINE_ID)-$($Env:CI_COMMIT_SHA.SubString(0,7))
+    - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
+    - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"
+    - $SRC_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:$SRC_TAG"
+    - echo "build --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg TARGET_ARCH=$TARGET_ARCH --build-arg WINDOWS_VERSION=$WINDOWS_VERSION --tag $SRC_IMAGE --file $DOCKERFILE ."
+    - powershell -Command "docker build --no-cache --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg TARGET_ARCH=$TARGET_ARCH --build-arg WINDOWS_VERSION=$WINDOWS_VERSION --tag $SRC_IMAGE --file $DOCKERFILE ."
+    - docker push $SRC_IMAGE
   after_script:
     - docker image prune -f
-    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$($Env:IMAGE):v$($Env:CI_PIPELINE_ID)-$($Env:CI_COMMIT_SHA.SubString(0,7))
+    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-$($CI_COMMIT_SHA.SubString(0,7))
 
 build_windows_1809_x64:
   extends: .winbuild
@@ -138,26 +141,33 @@ build_windows_1909_x86:
 .winrelease:
   stage: release
   except: [ tags, schedules ]
-  only: [ master ]
+  tags: [ "runner:windows-docker", "windowsversion:1909" ]
   script:
-    - $Env:SRC_IMAGE="486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$($Env:IMAGE):v$($Env:CI_PIPELINE_ID)-$($Env:CI_COMMIT_SHA.SubString(0,7))"
-    - docker pull $($Env:SRC_IMAGE)
-    - docker tag $($Env:SRC_IMAGE) 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$($Env:IMAGE):latest
-    - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$($Env:IMAGE):latest
-    # ECR Login
-    - $Env:AWS_ECR_PASSWORD=aws ecr get-login-password --region us-east-1
-    - docker login --username AWS --password "$($Env:AWS_ECR_PASSWORD)" 486234852809.dkr.ecr.us-east-1.amazonaws.com
-    # DockerHub login
-    - $Env:DOCKER_REGISTRY_LOGIN = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text
-    - $Env:DOCKER_REGISTRY_PWD = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text
-    - docker login --username "$($Env:DOCKER_REGISTRY_LOGIN)" --password "$($Env:DOCKER_REGISTRY_PWD)" docker.io
-    # Tag & push to Dockerhub
-    - docker tag $($Env:SRC_IMAGE) datadog/agent-buildimages-$($Env:IMAGE):v$($Env:CI_PIPELINE_ID)-$($Env:CI_COMMIT_SHA.SubString(0,7))
-    - docker push datadog/agent-buildimages-$($Env:IMAGE):v$($Env:CI_PIPELINE_ID)-$($Env:CI_COMMIT_SHA.SubString(0,7))
-    - docker tag $($Env:SRC_IMAGE) datadog/agent-buildimages-$($Env:IMAGE):latest
-    - docker push datadog/agent-buildimages-$($Env:IMAGE):latest
+    - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
+    - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"
+    - $SRC_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:$SRC_TAG"
+    - mkdir ci-scripts
+    - docker pull $SRC_IMAGE
+    - |
+      @"
+      Set-PSDebug -Trace 1
+      `$ErrorActionPreference = "Stop"
+      # ECR Login
+      `$AWS_ECR_PASSWORD = aws ecr get-login-password --region us-east-1
+      docker login --username AWS --password "`$AWS_ECR_PASSWORD" 486234852809.dkr.ecr.us-east-1.amazonaws.com
+      # DockerHub login
+      `$DOCKER_REGISTRY_LOGIN = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text
+      `$DOCKER_REGISTRY_PWD = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text
+      docker login --username "`$DOCKER_REGISTRY_LOGIN" --password "`$DOCKER_REGISTRY_PWD" docker.io
+      docker tag $SRC_IMAGE 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:latest
+      docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:latest
+      docker tag $SRC_IMAGE datadog/agent-buildimages-$IMAGE:$SRC_TAG
+      docker push datadog/agent-buildimages-$IMAGE:$SRC_TAG
+      "@ | out-file ci-scripts/docker-publish.ps1
+    - cat ci-scripts/docker-publish.ps1
+    - docker run --rm -w C:\mnt -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine $RELEASE_IMAGE powershell -C C:\mnt\ci-scripts\docker-publish.ps1
   after_script:
-    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$($Env:IMAGE):v$($Env:CI_PIPELINE_ID)-$($Env:CI_COMMIT_SHA.SubString(0,7)) datadog/agent-buildimages-$($Env:IMAGE):v$($Env:CI_PIPELINE_ID)-$($Env:CI_COMMIT_SHA.SubString(0,7)) datadog/agent-buildimages-$($Env:IMAGE):latest
+    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-$($CI_COMMIT_SHA.SubString(0,7)) datadog/agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-$($CI_COMMIT_SHA.SubString(0,7)) datadog/agent-buildimages-$IMAGE:latest
 
 release_deb_x64:
   extends: .release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,9 @@ stages:
   - build
   - release
 
+variables:
+  WINDOWS_RELEASE_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/windows_1909_x64:v2348149-ba6640d
+
 .build:
   stage: build
   except: [ tags, schedules ]
@@ -66,13 +69,13 @@ build_system-probe_arm64:
   script:
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"
-    - $SRC_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:$SRC_TAG"
+    - $SRC_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:${SRC_TAG}"
     - echo "build --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg TARGET_ARCH=$TARGET_ARCH --build-arg WINDOWS_VERSION=$WINDOWS_VERSION --tag $SRC_IMAGE --file $DOCKERFILE ."
     - powershell -Command "docker build --no-cache --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg TARGET_ARCH=$TARGET_ARCH --build-arg WINDOWS_VERSION=$WINDOWS_VERSION --tag $SRC_IMAGE --file $DOCKERFILE ."
     - docker push $SRC_IMAGE
   after_script:
     - docker image prune -f
-    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-$($CI_COMMIT_SHA.SubString(0,7))
+    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
 
 build_windows_1809_x64:
   extends: .winbuild
@@ -121,7 +124,6 @@ build_windows_1909_x86:
 .release:
   stage: release
   except: [ tags, schedules ]
-  only: [ master ]
   tags: [ "runner:docker", "size:large" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-notary:0.6.1
   script:
@@ -141,11 +143,12 @@ build_windows_1909_x86:
 .winrelease:
   stage: release
   except: [ tags, schedules ]
+  only: [ master ]
   tags: [ "runner:windows-docker", "windowsversion:1909" ]
   script:
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"
-    - $SRC_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:$SRC_TAG"
+    - $SRC_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:${SRC_TAG}"
     - mkdir ci-scripts
     - docker pull $SRC_IMAGE
     - |
@@ -159,15 +162,17 @@ build_windows_1909_x86:
       `$DOCKER_REGISTRY_LOGIN = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text
       `$DOCKER_REGISTRY_PWD = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text
       docker login --username "`$DOCKER_REGISTRY_LOGIN" --password "`$DOCKER_REGISTRY_PWD" docker.io
-      docker tag $SRC_IMAGE 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:latest
-      docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:latest
-      docker tag $SRC_IMAGE datadog/agent-buildimages-$IMAGE:$SRC_TAG
-      docker push datadog/agent-buildimages-$IMAGE:$SRC_TAG
+      docker tag $SRC_IMAGE 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:latest
+      docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:latest
+      docker tag $SRC_IMAGE datadog/agent-buildimages-${IMAGE}:${SRC_TAG}
+      docker push datadog/agent-buildimages-${IMAGE}:${SRC_TAG}
+      docker tag $SRC_IMAGE datadog/agent-buildimages-${IMAGE}:latest
+      docker push datadog/agent-buildimages-${IMAGE}:latest
       "@ | out-file ci-scripts/docker-publish.ps1
     - cat ci-scripts/docker-publish.ps1
-    - docker run --rm -w C:\mnt -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine $RELEASE_IMAGE powershell -C C:\mnt\ci-scripts\docker-publish.ps1
+    - docker run --rm -w C:\mnt -e IS_AWS_CONTAINER=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine $WINDOWS_RELEASE_IMAGE powershell -C C:\mnt\ci-scripts\docker-publish.ps1
   after_script:
-    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-$($CI_COMMIT_SHA.SubString(0,7)) datadog/agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-$($CI_COMMIT_SHA.SubString(0,7)) datadog/agent-buildimages-$IMAGE:latest
+    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) datadog/agent-buildimages-${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) datadog/agent-buildimages-${IMAGE}:latest
 
 release_deb_x64:
   extends: .release
@@ -181,24 +186,20 @@ release_rpm_x64:
 
 release_windows_1809_x64:
   extends: .winrelease
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
   variables:
     IMAGE: windows_1809_x64
 
 release_windows_1809_x86:
   extends: .winrelease
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
   variables:
     IMAGE: windows_1809_x86
 
 release_windows_1909_x64:
   extends: .winrelease
-  tags: [ "runner:windows-docker", "windowsversion:1909" ]
   variables:
     IMAGE: windows_1909_x64
 
 release_windows_1909_x86:
   extends: .winrelease
-  tags: [ "runner:windows-docker", "windowsversion:1909" ]
   variables:
     IMAGE: windows_1909_x86

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,6 +124,7 @@ build_windows_1909_x86:
 .release:
   stage: release
   except: [ tags, schedules ]
+  only: [ master ]
   tags: [ "runner:docker", "size:large" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-notary:0.6.1
   script:

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -124,6 +124,10 @@ RUN if ($Env:TARGET_ARCH -eq 'x86') { [Environment]::SetEnvironmentVariable(\"Pa
 COPY ./windows/install_awscli.ps1 install_awscli.ps1
 RUN powershell -C .\install_awscli.ps1
 
+# Install docker, manifest-tool and notary
+COPY ./windows/install_docker.ps1 install_docker.ps1
+RUN powershell -Command .\install_docker.ps1
+
 # Install embedded pythons (for unit testing)
 COPY ./windows/install_embedded_pythons.ps1 install_embedded_pythons.ps1
 RUN powershell -C .\install_embedded_pythons.ps1

--- a/windows/install_docker.ps1
+++ b/windows/install_docker.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+mkdir C:\Docker
+
+# Docker CLI builds maintained by a Docker engineer
+$dockerVersion = "19.03.3"
+Invoke-WebRequest -Uri "https://github.com/StefanScherer/docker-cli-builder/releases/download/$dockerVersion/docker.exe" -OutFile "C:\Docker\docker.exe"
+
+# Install manifest-tool
+$manifestVersion = "v1.0.1"
+Invoke-WebRequest -Uri "https://github.com/estesp/manifest-tool/releases/download/$manifestVersion/manifest-tool-windows-amd64.exe" -OutFile "C:\Docker\manifest-tool.exe"
+
+# Install notary
+$notaryVersion = "v0.6.1"
+Invoke-WebRequest -Uri "https://github.com/theupdateframework/notary/releases/download/$notaryVersion/notary-Windows-amd64.exe" -OutFile "C:\Docker\notary.exe"
+
+# Add Docker to path
+setx PATH "$Env:Path;C:\Docker"
+$Env:Path="$Env:Path;C:\Docker"


### PR DESCRIPTION
Use the same process we use on `datadog-agent` to log in to dockerhub.

Adds docker to the image, so that we can use the public builders to release Agent images and builders.