### PR TITLE
[macos] Add builder & build scripts for the MacOS Agent

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -11,7 +11,7 @@ The scripts in this folder are made to create a build environment for the MacOS 
 ## Contents
 
 - `builder_setup.sh`: installs all required build dependencies
-- `certificate_setup.sh`: installs the developer certificates in keychain & allow automatic access to code-signing applications
+- `certificate_setup.sh`: installs the developer certificates in keychain & allow automatic access to code-signing applications. Only needed if you want to sign the resulting package.
 - `build_script.sh`: does the omnibus build of the Agent
 
 ## Notes on notarization

--- a/macos/README.md
+++ b/macos/README.md
@@ -7,7 +7,7 @@ The scripts in this folder are made to create a build environment for the MacOS 
 
 - A clean MacOS 10.13.6 (High Sierra) host
 
-**Note:** The MacOS Agent build is currently not compatible with MacOS releases 10.14.4 and higher. MacOS 10.14.4 and higher use XCode 10.2+ by default. XCode 10.2 obsoleted Swift 3 ([see XCode 10.2 changelog](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_release_notes/swift_5_release_notes_for_xcode_10_2?preferredLanguage=occ)), which [the Agent systray app targets](https://github.com/DataDog/datadog-agent/blob/73e744b71aa2b1395e3755ebcc4b0f0ca4105b29/omnibus/config/software/datadog-agent.rb#L226).
+**Note:** The MacOS Agent build is currently not compatible with MacOS releases 10.14.4 and higher. MacOS 10.14.4 and higher use XCode 10.2+ by default. XCode 10.2 obsoleted Swift 3 ([see XCode 10.2 changelog](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_release_notes/swift_5_release_notes_for_xcode_10_2?preferredLanguage=occ)), which [the Agent systray app targets](https://github.com/DataDog/datadog-agent/blob/master/omnibus/config/software/datadog-agent.rb#L226).
 
 - Varying environment variables & files present on the host (see individual files for specific requirements).
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,0 +1,43 @@
+# MacOS builder setup scripts
+
+The scripts in this folder are made to create a build environment for the MacOS Agent & create unsigned or signed builds of the MacOS Agent.
+
+
+## Prerequisites
+
+- A clean MacOS 10.13.6 (High Sierra) host
+- Varying environment variables & files present on the host (see individual files for specific requirements).
+
+## Contents
+
+- `builder_setup.sh`: installs all required build dependencies
+- `certificate_setup.sh`: installs the developer certificates in keychain & allow automatic access to code-signing applications
+- `build_script.sh`: does the omnibus build of the Agent
+
+## Notes on notarization
+
+To notarize a build:
+- you need a host running MacOS 10.13.6 or higher (not necessarily the builder), with XCode >= 10.1 installed.
+- the omnibus build must have been signed and run with the `--hardened-runtime` option (done by default by `build_script.sh` when `$SIGN == "true"`).
+- `$APPLE_ACCOUNT` must contain the Apple account name for the Agent.
+- `$NOTARIZATION_PWD` must contain the app-specific notarization password for the Agent.
+
+Then follow these instructions:
+
+1. Select XCode app to use
+
+`sudo xcode-select -s /Applications/Xcode.app`
+
+2. Add notarization password to keychain
+
+`xcrun altool --store-password-in-keychain-item "AC_PASSWORD" -u "package@datadoghq.com" -p "$NOTARIZATION_PWD"`
+
+3. Send notarization request
+
+`xcrun altool --notarize-app --primary-bundle-id "com.datadoghq.agent.$VERSION" --username "$APPLE_ACCOUNT" --password "@keychain:AC_PASSWORD" --file <dmg file>`
+
+This command will upload the dmg package to Apple and return a UUID identifying the notarization request (if successful).
+
+4. Use the provided UUID to check on the notarization status
+
+`xcrun altool --notarization-info <UUID> -u "$APPLE_ACCOUNT" -p "@keychain:AC_PASSWORD"`

--- a/macos/README.md
+++ b/macos/README.md
@@ -6,6 +6,9 @@ The scripts in this folder are made to create a build environment for the MacOS 
 ## Prerequisites
 
 - A clean MacOS 10.13.6 (High Sierra) host
+
+**Note:** The MacOS Agent build is currently not compatible with MacOS releases 10.14.4 and higher. MacOS 10.14.4 and higher use XCode 10.2+ by default. XCode 10.2 obsoleted Swift 3 ([see XCode 10.2 changelog](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_release_notes/swift_5_release_notes_for_xcode_10_2?preferredLanguage=occ)), which [the Agent systray app targets](https://github.com/DataDog/datadog-agent/blob/73e744b71aa2b1395e3755ebcc4b0f0ca4105b29/omnibus/config/software/datadog-agent.rb#L226).
+
 - Varying environment variables & files present on the host (see individual files for specific requirements).
 
 ## Contents

--- a/macos/build_script.sh
+++ b/macos/build_script.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Fetches the datadog-agent repo, checks out to the requested version
+# and does an omnibus build of the Agent.
+
+# Prerequisites:
+# - builder_setup.sh has been run
+# - $VERSION contains the datadog-agent git ref to target
+# - $RELEASE_VERSION contains the release.json version to package. Defaults to $VERSION
+# - $AGENT_MAJOR_VERSION contains the major version to release
+# - $PYTHON_RUNTIMES contains the included python runtimes
+# - $SIGN set to true if signing is enabled
+# - if $SIGN is set to true, $KEYCHAIN_PWD contains the keychain password
+
+export RELEASE_VERSION=${RELEASE_VERSION:-$VERSION}
+
+# Load build setup vars
+source ~/.build_setup
+
+# Clone the repo
+go get github.com/DataDog/datadog-agent
+cd go/src/github.com/Datadog/datadog-agent
+
+# Checkout to correct version
+git pull
+git checkout $VERSION
+
+# Install python deps (invoke, etc.)
+pip install -r requirements.txt
+
+# Clean up previous builds
+sudo rm -rf /opt/datadog-agent ./vendor ./vendor-new /var/cache/omnibus/src/* ./omnibus/Gemfile.lock
+
+# Create target folders
+sudo mkdir -p /opt/datadog-agent /var/cache/omnibus && sudo chown $USER /opt/datadog-agent /var/cache/omnibus
+
+# Launch omnibus build
+if [ "$SIGN" = "true" ]; then
+    # Unlock the login keychain to get access to the signing certificates
+    security unlock-keychain -p $KEYCHAIN_PWD "login.keychain"
+    inv -e agent.omnibus-build --hardened-runtime --python-runtimes $PYTHON_RUNTIMES --major-version $AGENT_MAJOR_VERSION --release-version $RELEASE_VERSION
+    # Lock the login keychain once we're done
+    security lock-keychain "login.keychain"
+else
+    inv -e agent.omnibus-build --skip-sign --python-runtimes $PYTHON_RUNTIMES --major-version $AGENT_MAJOR_VERSION --release-version $RELEASE_VERSION
+fi

--- a/macos/builder_setup.sh
+++ b/macos/builder_setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Setups a MacOS builder that can do unsigned builds of the MacOS Agent.
+# The .build_setup file is populated with the correct envvar definitions to do the build,
+# which are then used by the build script.
+
+# Prerequisites:
+# - A MacOS 10.13.6 (High Sierra) box
+
+export GO_VERSION=1.13.8
+export RUBY_VERSION=2.4
+
+# Install brew (will also install Command Line Tools)
+CI=1 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+# Install ruby & bundler
+brew install ruby@$RUBY_VERSION -f
+export PATH="/usr/local/opt/ruby@$RUBY_VERSION/bin:/usr/local/lib/ruby/gems/$RUBY_VERSION.0/bin:$PATH"
+echo 'export PATH="/usr/local/opt/ruby@'$RUBY_VERSION'/bin:/usr/local/lib/ruby/gems/'$RUBY_VERSION'.0/bin:$PATH"' >> ~/.build_setup
+gem install bundle -f
+
+# Install build tools
+brew install python -f
+ln -s /usr/local/bin/pip3 /usr/local/bin/pip # Use pip3 by default
+
+brew install pkg-config -f
+brew install cmake -f
+
+mkdir $HOME/go
+export GOPATH=$HOME/go
+echo 'export GOPATH=$HOME/go' >> ~/.build_setup
+export PATH="$GOPATH/bin:$PATH"
+echo 'export PATH="$GOPATH/bin:$PATH"' >> ~/.build_setup
+
+brew install gimme
+eval `gimme $GO_VERSION`
+echo 'eval `gimme '$GO_VERSION'`' >> ~/.build_setup

--- a/macos/certificate_setup.sh
+++ b/macos/certificate_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Installs the signing certificates and makes sure then can be used
+# Installs the signing certificates and makes sure they can be used
 # in a CI environment (ie. without confirmation prompts) by code-signing apps.
 # Allows creating signed builds of the Agent.
 

--- a/macos/certificate_setup.sh
+++ b/macos/certificate_setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Installs the signing certificates and makes sure then can be used
+# in a CI environment (ie. without confirmation prompts) by code-signing apps.
+# Allows creating signed builds of the Agent.
+
+# Prerequisites:
+# - A MacOS 10.13.6 (High Sierra) box
+# - developer_id_installer.p12 signing cerificate available in $HOME folder
+# - developer_id_application.p12 signing certificate available in $HOME folder
+# - $CERTIFICATE_PWD contains the password of the .p12 files
+# - $KEYCHAIN_PWD contains the login keychain password
+
+# Unlock login keychain
+security unlock-keychain -p $KEYCHAIN_PWD "login.keychain"
+
+# Import signing certificates and allow relevant apps to use them
+security import ~/developer_id_installer.p12 -P $CERTIFICATE_PWD -k "login.keychain" -T /usr/bin/productbuild
+security import ~/developer_id_application.p12 -P $CERTIFICATE_PWD -k "login.keychain" -T /usr/bin/codesign
+
+# Update key partition list
+security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PWD login.keychain
+
+# Lock login keychain
+security lock-keychain "login.keychain"


### PR DESCRIPTION
### What does this PR do?

Adds builder & build scripts for the MacOS Agent, both for unsigned & signed builds.