### PR TITLE
Run test build before releasing image to Dockerhub

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -235,12 +235,14 @@ build_windows_1909_x86:
 .test_windows:
   extends: .test
   script:
+    - if (Test-Path /go/src/github.com/DataDog/datadog-agent) { remove-item -recurse -force /go/src/github.com/DataDog/datadog-agent }
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
     - cd /go/src/github.com/DataDog/datadog-agent
     - $VERSION="nightly"
     - git checkout master
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
+    - if (Test-Path /go/src/github.com/DataDog/datadog-agent) { remove-item -recurse -force /go/src/github.com/DataDog/datadog-agent }
 
 test_windows_1809_x64:
   extends: .test_windows

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,8 +101,7 @@ test_deb_x64:
   tags: [ "runner:main", "size:2xlarge" ]
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - VERSION=$(git --no-pager tag --list | grep -E "^6\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
-    - git checkout $VERSION
+    - git checkout master
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --no-checks --verbose --dep-vendor-only
   script:
@@ -115,8 +114,7 @@ test_deb_arm64:
   tags: [ "runner:docker-arm", "platform:arm64" ]
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - VERSION=$(git --no-pager tag --list | grep -E "^6\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
-    - git checkout $VERSION
+    - git checkout master
     - source /root/.bashrc
     - inv -e deps --no-checks --verbose --dep-vendor-only
   script:
@@ -129,8 +127,7 @@ test_rpm_x64:
   tags: [ "runner:main", "size:2xlarge" ]
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - VERSION=$(git --no-pager tag --list | grep -E "^6\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
-    - git checkout $VERSION
+    - git checkout master
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --no-checks --verbose --dep-vendor-only
   script:
@@ -143,8 +140,7 @@ test_rpm_arm64:
   tags: [ "runner:docker-arm", "platform:arm64" ]
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - VERSION=$(git --no-pager tag --list | grep -E "^6\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
-    - git checkout $VERSION
+    - git checkout master
     - source /root/.bashrc
     - inv -e deps --no-checks --verbose --dep-vendor-only
   script:
@@ -157,8 +153,7 @@ test_system-probe_x64:
   tags: [ "runner:main", "size:2xlarge" ]
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - VERSION=$(git --no-pager tag --list | grep -E "^6\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
-    - git checkout $VERSION
+    - git checkout master
     - inv -e deps --no-checks --verbose --dep-vendor-only
   script:
     - inv -e system-probe.build --go-version=1.13.8 --no-with-bcc
@@ -170,8 +165,7 @@ test_system-probe_arm64:
   tags: [ "runner:docker-arm", "platform:arm64" ]
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - VERSION=$(git --no-pager tag --list | grep -E "^6\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
-    - git checkout $VERSION
+    - git checkout master
     - inv -e deps --no-checks --verbose --dep-vendor-only
   script:
     - inv -e system-probe.build --go-version=1.13.8 --no-with-bcc
@@ -238,8 +232,7 @@ build_windows_1909_x86:
   extends: .test
   script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - $VERSION=(git --no-pager tag --list | Select-String "^6\.\d+\.\d+$" | Sort-Object { [version] $_.ToString() } | Select-Object -Last 1 | Out-String).Trim()
-    - git checkout $VERSION
+    - git checkout master
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
 
@@ -264,7 +257,7 @@ test_windows_1909_x64:
     ARCH: x86
     IMAGE: windows_1909_x64
 
-test_windows_1909_x64:
+test_windows_1909_x86:
   extends: .test_windows
   tags: [ "runner:windows-docker", "windowsversion:1909" ]
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,85 +94,72 @@ build_system-probe_arm64:
   stage: test
   except: [ tags, schedules ]
 
-test_deb_x64:
+.test_agent6_x64:
   extends: .test
+  before_script:
+    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION="nightly"
+    - git checkout master
+    - source /root/.bashrc && conda activate ddpy3
+    - inv -e deps --no-checks --verbose --dep-vendor-only
+  script:
+    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
+
+.test_agent6_arm64:
+  extends: .test
+  before_script:
+    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION="nightly"
+    - git checkout master
+    - source /root/.bashrc
+    - inv -e deps --no-checks --verbose --dep-vendor-only
+  script:
+    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
+
+test_deb_x64:
+  extends: .test_agent6_x64
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:v$CI_PIPELINE_ID
   needs: [ "build_deb_x64" ]
   tags: [ "runner:main", "size:2xlarge" ]
-  before_script:
-    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - VERSION="nightly"
-    - git checkout master
-    - source /root/.bashrc && conda activate ddpy3
-    - inv -e deps --no-checks --verbose --dep-vendor-only
-  script:
-    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
 
 test_deb_arm64:
-  extends: .test
+  extends: .test_agent6_arm64
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:v$CI_PIPELINE_ID
   needs: [ "build_deb_arm64" ]
   tags: [ "runner:docker-arm", "platform:arm64" ]
-  before_script:
-    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - VERSION="nightly"
-    - git checkout master
-    - source /root/.bashrc
-    - inv -e deps --no-checks --verbose --dep-vendor-only
-  script:
-    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
 
 test_rpm_x64:
-  extends: .test
+  extends: .test_agent6_x64
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:v$CI_PIPELINE_ID
   needs: [ "build_rpm_x64" ]
   tags: [ "runner:main", "size:2xlarge" ]
-  before_script:
-    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - VERSION="nightly"
-    - git checkout master
-    - source /root/.bashrc && conda activate ddpy3
-    - inv -e deps --no-checks --verbose --dep-vendor-only
-  script:
-    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
 
 test_rpm_arm64:
-  extends: .test
+  extends: .test_agent6_arm64
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:v$CI_PIPELINE_ID
   needs: [ "build_rpm_arm64" ]
   tags: [ "runner:docker-arm", "platform:arm64" ]
+
+.test_system_probe:
+  extends: .test
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - VERSION="nightly"
     - git checkout master
-    - source /root/.bashrc
     - inv -e deps --no-checks --verbose --dep-vendor-only
   script:
-    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
+    - inv -e system-probe.build --go-version=1.13.8 --no-with-bcc
 
 test_system-probe_x64:
-  extends: .test
+  extends: .test_system_probe
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:v$CI_PIPELINE_ID
   needs: [ "build_system-probe_x64" ]
   tags: [ "runner:main", "size:2xlarge" ]
-  before_script:
-    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - git checkout master
-    - inv -e deps --no-checks --verbose --dep-vendor-only
-  script:
-    - inv -e system-probe.build --go-version=1.13.8 --no-with-bcc
 
 test_system-probe_arm64:
-  extends: .test
+  extends: .test_system_probe
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:v$CI_PIPELINE_ID
   needs: [ "build_system-probe_arm64" ]
   tags: [ "runner:docker-arm", "platform:arm64" ]
-  before_script:
-    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
-    - git checkout master
-    - inv -e deps --no-checks --verbose --dep-vendor-only
-  script:
-    - inv -e system-probe.build --go-version=1.13.8 --no-with-bcc
 
 .winbuild: &winbuild
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -234,6 +234,7 @@ build_windows_1909_x86:
 
 .test_windows:
   extends: .test
+  timeout: 2h 00m
   script:
     - if (Test-Path go/src/github.com/DataDog/datadog-agent) { remove-item -recurse -force go/src/github.com/DataDog/datadog-agent }
     - git clone https://github.com/DataDog/datadog-agent go/src/github.com/DataDog/datadog-agent

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,7 +172,7 @@ test_system-probe_arm64:
     - powershell -Command "docker build --no-cache --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg TARGET_ARCH=$TARGET_ARCH --build-arg WINDOWS_VERSION=$WINDOWS_VERSION --tag $SRC_IMAGE --file $DOCKERFILE ."
     - docker push $SRC_IMAGE
   after_script:
-    - docker image prune -a -f
+    - docker image prune -f
     - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
 
 build_windows_1809_x64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -229,8 +229,8 @@ build_windows_1909_x86:
     - $VERSION="nightly"
     - git checkout master
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
-    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
   after_script:
+    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
     - docker image prune -f
     - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,7 +172,7 @@ test_system-probe_arm64:
     - powershell -Command "docker build --no-cache --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg TARGET_ARCH=$TARGET_ARCH --build-arg WINDOWS_VERSION=$WINDOWS_VERSION --tag $SRC_IMAGE --file $DOCKERFILE ."
     - docker push $SRC_IMAGE
   after_script:
-    - docker image prune -f
+    - docker image prune -a -f
     - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
 
 build_windows_1809_x64:
@@ -230,6 +230,9 @@ build_windows_1909_x86:
     - git checkout master
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
     - if (Test-Path go/src/github.com/DataDog/datadog-agent) { remove-item -recurse -force go/src/github.com/DataDog/datadog-agent }
+  after_script:
+    - docker image prune -f
+    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
 
 test_windows_1809_x64:
   extends: .test_windows

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -330,30 +330,36 @@ test_windows_1909_x86:
 
 release_deb_x64:
   extends: .release
+  needs: [ "test_deb_x64" ]
   variables:
     IMAGE: deb_x64
 
 release_rpm_x64:
   extends: .release
+  needs: [ "test_rpm_x64" ]
   variables:
     IMAGE: rpm_x64
 
 release_windows_1809_x64:
   extends: .winrelease
+  needs: [ "test_windows_1809_x64" ]
   variables:
     IMAGE: windows_1809_x64
 
 release_windows_1809_x86:
   extends: .winrelease
+  needs: [ "test_windows_1809_x86" ]
   variables:
     IMAGE: windows_1809_x86
 
 release_windows_1909_x64:
   extends: .winrelease
+  needs: [ "test_windows_1909_x64" ]
   variables:
     IMAGE: windows_1909_x64
 
 release_windows_1909_x86:
   extends: .winrelease
+  needs: [ "test_windows_1909_x86" ]
   variables:
     IMAGE: windows_1909_x86

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -240,7 +240,6 @@ build_windows_1909_x86:
     - cd /go/src/github.com/DataDog/datadog-agent
     - $VERSION="nightly"
     - git checkout master
-    - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
     - if (Test-Path /go/src/github.com/DataDog/datadog-agent) { remove-item -recurse -force /go/src/github.com/DataDog/datadog-agent }
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -244,6 +244,7 @@ build_windows_1909_x86:
 test_windows_1809_x64:
   extends: .test_windows
   tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  needs: [ "build_windows_1809_x64" ]
   variables:
     ARCH: x64
     IMAGE: windows_1809_x64
@@ -251,6 +252,7 @@ test_windows_1809_x64:
 test_windows_1809_x86:
   extends: .test_windows
   tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  needs: [ "build_windows_1809_x86" ]
   variables:
     ARCH: x64
     IMAGE: windows_1809_x86
@@ -258,6 +260,7 @@ test_windows_1809_x86:
 test_windows_1909_x64:
   extends: .test_windows
   tags: [ "runner:windows-docker", "windowsversion:1909" ]
+  needs: [ "build_windows_1909_x64" ]
   variables:
     ARCH: x86
     IMAGE: windows_1909_x64
@@ -265,6 +268,7 @@ test_windows_1909_x64:
 test_windows_1909_x86:
   extends: .test_windows
   tags: [ "runner:windows-docker", "windowsversion:1909" ]
+  needs: [ "build_windows_1909_x86" ]
   variables:
     ARCH: x86
     IMAGE: windows_1909_x86

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -235,13 +235,13 @@ build_windows_1909_x86:
 .test_windows:
   extends: .test
   script:
-    - if (Test-Path /go/src/github.com/DataDog/datadog-agent) { remove-item -recurse -force /go/src/github.com/DataDog/datadog-agent }
-    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
-    - cd /go/src/github.com/DataDog/datadog-agent
+    - if (Test-Path go/src/github.com/DataDog/datadog-agent) { remove-item -recurse -force go/src/github.com/DataDog/datadog-agent }
+    - git clone https://github.com/DataDog/datadog-agent go/src/github.com/DataDog/datadog-agent
+    - cd go/src/github.com/DataDog/datadog-agent
     - $VERSION="nightly"
     - git checkout master
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
-    - if (Test-Path /go/src/github.com/DataDog/datadog-agent) { remove-item -recurse -force /go/src/github.com/DataDog/datadog-agent }
+    - if (Test-Path go/src/github.com/DataDog/datadog-agent) { remove-item -recurse -force go/src/github.com/DataDog/datadog-agent }
 
 test_windows_1809_x64:
   extends: .test_windows

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
   - build
+  - test
   - release
 
 variables:
@@ -13,6 +14,9 @@ variables:
   script:
     - docker build --tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7} --file $DOCKERFILE .
     - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    # For testing purposes
+    - docker tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7} 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID
+    - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID
 
 build_deb_x64:
   extends: .build
@@ -41,6 +45,9 @@ build_rpm_x64:
     - eval "$(aws ecr get-login --region us-east-1 --no-include-email --registry-ids 486234852809)"
     - docker build --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg TARGET_ARCH=$TARGET_ARCH --tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7} --file $DOCKERFILE .
     - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    # For testing purposes
+    - docker tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7} 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID
+    - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID
 
 build_deb_arm64:
   extends: .armbuild
@@ -82,6 +89,92 @@ build_system-probe_arm64:
   variables:
     DOCKERFILE: system-probe_arm64/Dockerfile
     IMAGE: system-probe_arm64
+
+.test:
+  stage: test
+  except: [ tags, schedules ]
+
+test_deb_x64:
+  extends: .test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:v$CI_PIPELINE_ID
+  needs: [ "build_deb_x64" ]
+  tags: [ "runner:main", "size:2xlarge" ]
+  before_script:
+    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION=$(git --no-pager tag --list | grep -E "^6\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
+    - git checkout $VERSION
+    - source /root/.bashrc && conda activate ddpy3
+    - inv -e deps --no-checks --verbose --dep-vendor-only
+  script:
+    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
+
+test_deb_arm64:
+  extends: .test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:v$CI_PIPELINE_ID
+  needs: [ "build_deb_arm64" ]
+  tags: [ "runner:docker-arm", "platform:arm64" ]
+  before_script:
+    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION=$(git --no-pager tag --list | grep -E "^6\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
+    - git checkout $VERSION
+    - source /root/.bashrc
+    - inv -e deps --no-checks --verbose --dep-vendor-only
+  script:
+    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
+
+test_rpm_x64:
+  extends: .test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:v$CI_PIPELINE_ID
+  needs: [ "build_rpm_x64" ]
+  tags: [ "runner:main", "size:2xlarge" ]
+  before_script:
+    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION=$(git --no-pager tag --list | grep -E "^6\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
+    - git checkout $VERSION
+    - source /root/.bashrc && conda activate ddpy3
+    - inv -e deps --no-checks --verbose --dep-vendor-only
+  script:
+    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
+
+test_rpm_arm64:
+  extends: .test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:v$CI_PIPELINE_ID
+  needs: [ "build_rpm_arm64" ]
+  tags: [ "runner:docker-arm", "platform:arm64" ]
+  before_script:
+    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION=$(git --no-pager tag --list | grep -E "^6\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
+    - git checkout $VERSION
+    - source /root/.bashrc
+    - inv -e deps --no-checks --verbose --dep-vendor-only
+  script:
+    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
+
+test_system-probe_x64:
+  extends: .test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:v$CI_PIPELINE_ID
+  needs: [ "build_system-probe_x64" ]
+  tags: [ "runner:main", "size:2xlarge" ]
+  before_script:
+    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION=$(git --no-pager tag --list | grep -E "^6\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
+    - git checkout $VERSION
+    - inv -e deps --no-checks --verbose --dep-vendor-only
+  script:
+    - inv -e system-probe.build --go-version=1.13.8 --no-with-bcc
+
+test_system-probe_arm64:
+  extends: .test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:v$CI_PIPELINE_ID
+  needs: [ "build_system-probe_arm64" ]
+  tags: [ "runner:docker-arm", "platform:arm64" ]
+  before_script:
+    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION=$(git --no-pager tag --list | grep -E "^6\.[0-9]+\.[0-9]+$" | sort -V | tail -n1)
+    - git checkout $VERSION
+    - inv -e deps --no-checks --verbose --dep-vendor-only
+  script:
+    - inv -e system-probe.build --go-version=1.13.8 --no-with-bcc
 
 .winbuild: &winbuild
   stage: build
@@ -140,6 +233,43 @@ build_windows_1909_x86:
     TARGET_ARCH: x86
     WINDOWS_VERSION: 1909
   resource_group: windows_x86
+
+.test_windows:
+  extends: .test
+  script:
+    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - $VERSION=(git --no-pager tag --list | Select-String "^6\.\d+\.\d+$" | Sort-Object { [version] $_.ToString() } | Select-Object -Last 1 | Out-String).Trim()
+    - git checkout $VERSION
+    - if (Test-Path build-out) { remove-item -recurse -force build-out }
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
+
+test_windows_1809_x64:
+  extends: .test_windows
+  tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  variables:
+    ARCH: x64
+    IMAGE: windows_1809_x64
+
+test_windows_1809_x86:
+  extends: .test_windows
+  tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  variables:
+    ARCH: x64
+    IMAGE: windows_1809_x86
+
+test_windows_1909_x64:
+  extends: .test_windows
+  tags: [ "runner:windows-docker", "windowsversion:1909" ]
+  variables:
+    ARCH: x86
+    IMAGE: windows_1909_x64
+
+test_windows_1909_x64:
+  extends: .test_windows
+  tags: [ "runner:windows-docker", "windowsversion:1909" ]
+  variables:
+    ARCH: x86
+    IMAGE: windows_1909_x86
 
 .release:
   stage: release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -235,7 +235,8 @@ build_windows_1909_x86:
 .test_windows:
   extends: .test
   script:
-    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
+    - cd /go/src/github.com/DataDog/datadog-agent
     - $VERSION="nightly"
     - git checkout master
     - if (Test-Path build-out) { remove-item -recurse -force build-out }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,6 +101,7 @@ test_deb_x64:
   tags: [ "runner:main", "size:2xlarge" ]
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION="nightly"
     - git checkout master
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --no-checks --verbose --dep-vendor-only
@@ -114,6 +115,7 @@ test_deb_arm64:
   tags: [ "runner:docker-arm", "platform:arm64" ]
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION="nightly"
     - git checkout master
     - source /root/.bashrc
     - inv -e deps --no-checks --verbose --dep-vendor-only
@@ -127,6 +129,7 @@ test_rpm_x64:
   tags: [ "runner:main", "size:2xlarge" ]
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION="nightly"
     - git checkout master
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps --no-checks --verbose --dep-vendor-only
@@ -140,6 +143,7 @@ test_rpm_arm64:
   tags: [ "runner:docker-arm", "platform:arm64" ]
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION="nightly"
     - git checkout master
     - source /root/.bashrc
     - inv -e deps --no-checks --verbose --dep-vendor-only
@@ -232,6 +236,7 @@ build_windows_1909_x86:
   extends: .test
   script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - $VERSION="nightly"
     - git checkout master
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,13 +223,13 @@ build_windows_1909_x86:
   extends: .test
   timeout: 2h 00m
   script:
-    - if (Test-Path go/src/github.com/DataDog/datadog-agent) { remove-item -recurse -force go/src/github.com/DataDog/datadog-agent }
-    - git clone https://github.com/DataDog/datadog-agent go/src/github.com/DataDog/datadog-agent
-    - cd go/src/github.com/DataDog/datadog-agent
+    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
+    - git clone https://github.com/DataDog/datadog-agent datadog-agent
+    - cd datadog-agent
     - $VERSION="nightly"
     - git checkout master
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
-    - if (Test-Path go/src/github.com/DataDog/datadog-agent) { remove-item -recurse -force go/src/github.com/DataDog/datadog-agent }
+    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
   after_script:
     - docker image prune -f
     - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -256,7 +256,7 @@ test_windows_1809_x86:
   tags: [ "runner:windows-docker", "windowsversion:1809" ]
   needs: [ "build_windows_1809_x86" ]
   variables:
-    ARCH: x64
+    ARCH: x86
     IMAGE: windows_1809_x86
 
 test_windows_1909_x64:
@@ -264,7 +264,7 @@ test_windows_1909_x64:
   tags: [ "runner:windows-docker", "windowsversion:1909" ]
   needs: [ "build_windows_1909_x64" ]
   variables:
-    ARCH: x86
+    ARCH: x64
     IMAGE: windows_1909_x64
 
 test_windows_1909_x86:


### PR DESCRIPTION
### What does this PR do?

Adds a test stage where newly-created images do a test Agent build.
All images must now succeed a test A6 build (except for the system-probe images, which must succeed a system-probe build) before being released to Dockerhub.

The test is made against master of datadog-agent; while this is not perfect (master can be broken at times, there are flakes), we are sure that the published images will work when used on master.

### Motivation

Avoid publishing (obviously) broken images.

### Additional notes

The arm64 test builds fail because the arm64 builders are currently broken on master (fix on separate PR). Same for the x86 builds (currently being repaired).
The armhf builds are not tested yet because there's no existing build job yet for them.

Future improvement: instead of copy-pasting jobs from the datadog-agent repo, there should be a template yaml with common job definitions, that could be included here and in the datadog-agent repo.