### PR TITLE
[macos] Make builder setup more robust

### DIFF
--- a/macos/build_script.sh
+++ b/macos/build_script.sh
@@ -18,7 +18,7 @@ export RELEASE_VERSION=${RELEASE_VERSION:-$VERSION}
 source ~/.build_setup
 
 # Clone the repo
-go get github.com/DataDog/datadog-agent
+go get github.com/DataDog/datadog-agent || true # Go get fails if the datadog-agent repo is already there
 cd $GOPATH/src/github.com/Datadog/datadog-agent
 
 # Checkout to correct version

--- a/macos/builder_setup.sh
+++ b/macos/builder_setup.sh
@@ -10,8 +10,8 @@
 export GO_VERSION=1.13.8
 export RUBY_VERSION=2.4
 
-# Install brew (will also install Command Line Tools)
-CI=1 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+# Install or upgrade brew (will also install Command Line Tools)
+CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
 # Install ruby & bundler
 brew install ruby@$RUBY_VERSION -f
@@ -20,7 +20,8 @@ echo 'export PATH="/usr/local/opt/ruby@'$RUBY_VERSION'/bin:/usr/local/lib/ruby/g
 gem install bundle -f
 
 # Install build tools
-brew install python -f
+brew uninstall python@2 || true # Uninstall python 2 if present
+brew upgrade python -f || brew install python -f # If python 3 is already present, upgrade it. Otherwise install it.
 ln -s /usr/local/bin/pip3 /usr/local/bin/pip # Use pip3 by default
 
 brew install pkg-config -f


### PR DESCRIPTION
### What does this PR do?

Uses the newer homebrew installer.
Makes python install work whether there are already existing Python versions or not.