### PR TITLE
Fix entrypoint on ARM

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,11 @@ set -e
 
 source /root/.bashrc
 
-conda activate ddpy3 || true # We use system python3 on some images, allow this to fail
+if command -v conda; then
+  # Only try to use conda if it's installed.
+  # On ARM images, we use the system Python 3 because conda is not supported.
+  conda activate ddpy3
+fi
 
 if [ "$DD_TARGET_ARCH" = "arm64v8" ] ; then
     export GIMME_ARCH=arm64


### PR DESCRIPTION
### What does this PR do?

Prevent misleading error line: `/entrypoint.sh: line 6: conda: command not found` from appearing on ARM jobs because `conda` is not installed.