### PR TITLE
[linux] Remove --no-checks option from inv deps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,7 +101,7 @@ build_system-probe_arm64:
     - VERSION="nightly"
     - git checkout master
     - source /root/.bashrc && conda activate ddpy3
-    - inv -e deps --no-checks --verbose --dep-vendor-only
+    - inv -e deps --verbose --dep-vendor-only
   script:
     - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
 
@@ -112,7 +112,7 @@ build_system-probe_arm64:
     - VERSION="nightly"
     - git checkout master
     - source /root/.bashrc
-    - inv -e deps --no-checks --verbose --dep-vendor-only
+    - inv -e deps --verbose --dep-vendor-only
   script:
     - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,7 +145,7 @@ test_rpm_arm64:
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
     - git checkout master
-    - inv -e deps --no-checks --verbose --dep-vendor-only
+    - inv -e deps --verbose --dep-vendor-only
   script:
     - inv -e system-probe.build --go-version=1.13.11 --no-with-bcc
 


### PR DESCRIPTION
### What does this PR do?

Fixes the test Agent builds (the `--no-checks` option got removed from the datadog-agent repository).