### PR TITLE
[macos] Fix script after brew python update

### DIFF
--- a/macos/build_script.sh
+++ b/macos/build_script.sh
@@ -26,7 +26,7 @@ git pull
 git checkout $VERSION
 
 # Install python deps (invoke, etc.)
-pip install -r requirements.txt
+python3 -m pip install -r requirements.txt
 
 # Clean up previous builds
 sudo rm -rf /opt/datadog-agent ./vendor ./vendor-new /var/cache/omnibus/src/* ./omnibus/Gemfile.lock

--- a/macos/builder_setup.sh
+++ b/macos/builder_setup.sh
@@ -14,6 +14,8 @@ export IBM_MQ_VERSION=9.1.5.0
 # Install or upgrade brew (will also install Command Line Tools)
 CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
+brew uninstall python@2 || true # Uninstall python 2 if present
+
 # Install ruby & bundler
 brew install ruby@$RUBY_VERSION -f
 export PATH="/usr/local/opt/ruby@$RUBY_VERSION/bin:/usr/local/lib/ruby/gems/$RUBY_VERSION.0/bin:$PATH"
@@ -21,9 +23,7 @@ echo 'export PATH="/usr/local/opt/ruby@'$RUBY_VERSION'/bin:/usr/local/lib/ruby/g
 gem install bundle -f
 
 # Install build tools
-brew uninstall python@2 || true # Uninstall python 2 if present
 brew upgrade python -f || brew install python -f # If python 3 is already present, upgrade it. Otherwise install it.
-ln -s /usr/local/bin/pip3 /usr/local/bin/pip # Use pip3 by default
 
 brew install pkg-config -f
 brew install cmake -f


### PR DESCRIPTION
### What does this PR do?

Switch to using `python3 -m pip` to install dependencies (the `python` formula got updated, and doesn't update the `/usr/local/bin/pip3` symlink anymore).
Remove `python@2` as early as possible (to avoid losing time with brew trying to fix it).