### PR TITLE
[Gitlab] Remove --dep-vendor-only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,7 +101,7 @@ build_system-probe_arm64:
     - VERSION="nightly"
     - git checkout master
     - source /root/.bashrc && conda activate ddpy3
-    - inv -e deps --verbose --dep-vendor-only
+    - inv -e deps --verbose
   script:
     - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
 
@@ -112,7 +112,7 @@ build_system-probe_arm64:
     - VERSION="nightly"
     - git checkout master
     - source /root/.bashrc
-    - inv -e deps --verbose --dep-vendor-only
+    - inv -e deps --verbose
   script:
     - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
 
@@ -145,7 +145,7 @@ test_rpm_arm64:
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
     - git checkout master
-    - inv -e deps --verbose --dep-vendor-only
+    - inv -e deps --verbose
   script:
     - inv -e system-probe.build --go-version=1.13.11 --no-with-bcc
 


### PR DESCRIPTION
### What does this PR do?

Remove `--dep-vendor-only` flag from `deps` task which no longer exists after DataDog/datadog-agent#5939. 