### PR TITLE
improve(deb image) handle unix shell properly

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -1,5 +1,4 @@
 FROM debian:wheezy-backports
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 # Build Args
 ARG GIMME_GO_VERSION=1.13.11
@@ -93,16 +92,16 @@ RUN conda create -n ddpy2 python python=2
 RUN conda create -n ddpy3 python python=3.8
 
 # Update pip, setuptools and misc deps
-RUN source /root/.bashrc && conda activate ddpy2 \
+RUN  /bin/bash -c "source /root/.bashrc && conda activate ddpy2 \
     && pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION} \
     && pip install --ignore-installed setuptools==${DD_SETUPTOOLS_VERSION} \
-    && pip install invoke distro==1.4.0 awscli==1.16.240
+    && pip install invoke distro==1.4.0 awscli==1.16.240"
 
 # Update pip, setuptools and misc deps
-RUN source /root/.bashrc && conda activate ddpy3 \
+RUN  /bin/bash -c "source /root/.bashrc && conda activate ddpy3 \
     && pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION} \
     && pip install --ignore-installed setuptools==${DD_SETUPTOOLS_VERSION} \
-    && pip install invoke distro==1.4.0 awscli==1.16.240
+    && pip install invoke distro==1.4.0 awscli==1.16.240"
 
 
 # Gimme


### PR DESCRIPTION
eliminates erroneous replacing of sh with bash

```Dockerfile
RUN rm /bin/sh && ln -s /bin/bash /bin/sh
```

handles invoking bash properly later in Dockerfile

Fixes  https://github.com/DataDog/datadog-agent-buildimages/issues/64
