### PR TITLE
Adds windows WDK 

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -98,7 +98,7 @@ RUN git config --system core.symlinks false
 RUN $env:chocolateyUseWindowsCompression = 'true'; cinst -y --no-progress 7zip $ENV:CHOCO_ARCH_FLAG --version $ENV:SEVENZIP_VERSION
 
 # Install VS2017
-RUN cinst -y --no-progress visualstudio2017buildtools $ENV:CHOCO_ARCH_FLAG --version $ENV:VS2017BUILDTOOLS_VERSION --params \"--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81 --add Microsoft.VisualStudio.Workload.VCTools\"
+RUN cinst -y --no-progress visualstudio2017buildtools $ENV:CHOCO_ARCH_FLAG --version $ENV:VS2017BUILDTOOLS_VERSION --params \"--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81 --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre --add Microsoft.VisualStudio.Component.Windows10SDK.17763\"
 RUN setx VSTUDIO_ROOT \"${env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\BuildTools\"
 
 # If x64, install the WDK for driver development

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -101,6 +101,10 @@ RUN $env:chocolateyUseWindowsCompression = 'true'; cinst -y --no-progress 7zip $
 RUN cinst -y --no-progress visualstudio2017buildtools $ENV:CHOCO_ARCH_FLAG --version $ENV:VS2017BUILDTOOLS_VERSION --params \"--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81 --add Microsoft.VisualStudio.Workload.VCTools\"
 RUN setx VSTUDIO_ROOT \"${env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\BuildTools\"
 
+# If x64, install the WDK for driver development
+COPY ./windows/install_wdk.ps1 install_wdk.ps1
+RUN if ($Env:TARGET_ARCH -eq 'x64') { powershell -Command .\install_wdk.ps1 }
+
 # Install VC compiler for Python 2.7
 RUN cinst -y --no-progress vcpython27 $ENV:CHOCO_ARCH_FLAG --version $ENV:VCPYTHON27_VERSION
 

--- a/windows/install_wdk.ps1
+++ b/windows/install_wdk.ps1
@@ -21,7 +21,7 @@ Start-Process wdksetup.exe -ArgumentList '/q' -Wait
 mkdir c:\tmp
 copy "C:\Program Files (x86)\Windows Kits\10\Vsix\WDK.vsix" C:\TMP\wdkvsix.zip
 Expand-Archive C:\TMP\wdkvsix.zip -DestinationPath C:\TMP\wdkvsix
-robocopy /e "C:\TMP\wdkvsix\`$VCTargets\Platforms" "${Env:VSTUDIO_ROOT}Common7\IDE\VC\VCTargets\Platforms" 
+robocopy /e "C:\TMP\wdkvsix\`$VCTargets\Platforms" "${Env:VSTUDIO_ROOT}\Common7\IDE\VC\VCTargets\Platforms" 
 remove-item -Force -Recurse -Path "c:\tmp"
 
 #.`clean_tmps.ps1

--- a/windows/install_wdk.ps1
+++ b/windows/install_wdk.ps1
@@ -1,0 +1,28 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+
+$wdk ='https://go.microsoft.com/fwlink/?linkid=2026156'
+
+Write-Host -ForegroundColor Green Installing WDK
+$out = 'wdksetup.exe'
+Write-Host -ForegroundColor Green Downloading $wdk to $out
+(New-Object System.Net.WebClient).DownloadFile($wdk, $out)
+Get-ChildItem $out
+# write file size to make sure it worked
+Write-Host -ForegroundColor Green "File size is $((get-item $out).length)"
+
+
+
+Start-Process wdksetup.exe -ArgumentList '/q' -Wait
+
+#install WDK.vsix (hack)
+mkdir c:\tmp
+copy "C:\Program Files (x86)\Windows Kits\10\Vsix\WDK.vsix" C:\TMP\wdkvsix.zip
+Expand-Archive C:\TMP\wdkvsix.zip -DestinationPath C:\TMP\wdkvsix
+robocopy /e "C:\TMP\wdkvsix\`$VCTargets\Platforms" "${Env:VSTUDIO_ROOT}Common7\IDE\VC\VCTargets\Platforms" 
+remove-item -Force -Recurse -Path "c:\tmp"
+
+#.`clean_tmps.ps1
+Write-Host -ForegroundColor Green Done with WDK


### PR DESCRIPTION
Add windows WDK to windows builders so that the NPM driver can be built using the same image as the core agent.