### PR TITLE
[macos] Use APPLE_ACCOUNT everywhere

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -33,7 +33,7 @@ Then follow these instructions:
 
 2. Add notarization password to keychain (XCode >= 11 only)
 
-`xcrun altool --store-password-in-keychain-item "AC_PASSWORD" -u "package@datadoghq.com" -p "$NOTARIZATION_PWD"`
+`xcrun altool --store-password-in-keychain-item "AC_PASSWORD" -u "$APPLE_ACCOUNT" -p "$NOTARIZATION_PWD"`
 
 3. Send notarization request
 


### PR DESCRIPTION
### What does this PR do?

Uses the `$APPLE_ACCOUNT` variable everywhere instead of hardcoding it in some places.