### PR TITLE
[macos] Allow customizing the keychain name

### DIFF
--- a/macos/build_script.sh
+++ b/macos/build_script.sh
@@ -39,10 +39,10 @@ sudo mkdir -p /opt/datadog-agent /var/cache/omnibus && sudo chown "$USER" /opt/d
 
 # Launch omnibus build
 if [ "$SIGN" = "true" ]; then
-    # Unlock the login keychain to get access to the signing certificates
+    # Unlock the keychain to get access to the signing certificates
     security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_NAME"
     inv -e agent.omnibus-build --hardened-runtime --python-runtimes "$PYTHON_RUNTIMES" --major-version "$AGENT_MAJOR_VERSION" --release-version "$RELEASE_VERSION"
-    # Lock the login keychain once we're done
+    # Lock the keychain once we're done
     security lock-keychain "$KEYCHAIN_NAME"
 else
     inv -e agent.omnibus-build --skip-sign --python-runtimes "$PYTHON_RUNTIMES" --major-version "$AGENT_MAJOR_VERSION" --release-version "$RELEASE_VERSION"

--- a/macos/build_script.sh
+++ b/macos/build_script.sh
@@ -10,9 +10,12 @@
 # - $AGENT_MAJOR_VERSION contains the major version to release
 # - $PYTHON_RUNTIMES contains the included python runtimes
 # - $SIGN set to true if signing is enabled
-# - if $SIGN is set to true, $KEYCHAIN_PWD contains the keychain password
+# - if $SIGN is set to true:
+#   - $KEYCHAIN_NAME contains the keychain name. Defaults to login.keychain
+#   - $KEYCHAIN_PWD contains the keychain password
 
 export RELEASE_VERSION=${RELEASE_VERSION:-$VERSION}
+export KEYCHAIN_NAME=${KEYCHAIN_NAME:-"login.keychain"}
 
 # Load build setup vars
 source ~/.build_setup
@@ -23,7 +26,7 @@ cd $GOPATH/src/github.com/Datadog/datadog-agent
 
 # Checkout to correct version
 git pull
-git checkout $VERSION
+git checkout "$VERSION"
 
 # Install python deps (invoke, etc.)
 python3 -m pip install -r requirements.txt
@@ -32,15 +35,15 @@ python3 -m pip install -r requirements.txt
 sudo rm -rf /opt/datadog-agent ./vendor ./vendor-new /var/cache/omnibus/src/* ./omnibus/Gemfile.lock
 
 # Create target folders
-sudo mkdir -p /opt/datadog-agent /var/cache/omnibus && sudo chown $USER /opt/datadog-agent /var/cache/omnibus
+sudo mkdir -p /opt/datadog-agent /var/cache/omnibus && sudo chown "$USER" /opt/datadog-agent /var/cache/omnibus
 
 # Launch omnibus build
 if [ "$SIGN" = "true" ]; then
     # Unlock the login keychain to get access to the signing certificates
-    security unlock-keychain -p $KEYCHAIN_PWD "login.keychain"
-    inv -e agent.omnibus-build --hardened-runtime --python-runtimes $PYTHON_RUNTIMES --major-version $AGENT_MAJOR_VERSION --release-version $RELEASE_VERSION
+    security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_NAME"
+    inv -e agent.omnibus-build --hardened-runtime --python-runtimes "$PYTHON_RUNTIMES" --major-version "$AGENT_MAJOR_VERSION" --release-version "$RELEASE_VERSION"
     # Lock the login keychain once we're done
-    security lock-keychain "login.keychain"
+    security lock-keychain "$KEYCHAIN_NAME"
 else
-    inv -e agent.omnibus-build --skip-sign --python-runtimes $PYTHON_RUNTIMES --major-version $AGENT_MAJOR_VERSION --release-version $RELEASE_VERSION
+    inv -e agent.omnibus-build --skip-sign --python-runtimes "$PYTHON_RUNTIMES" --major-version "$AGENT_MAJOR_VERSION" --release-version "$RELEASE_VERSION"
 fi

--- a/macos/certificate_setup.sh
+++ b/macos/certificate_setup.sh
@@ -10,17 +10,20 @@
 # - developer_id_application.p12 signing certificate available in $HOME folder
 # - $INSTALLER_CERTIFICATE_PWD contains the password of the developer_id_installer.p12 file
 # - $APPLICATION_CERTIFICATE_PWD contains the password of the developer_id_application.p12 file
-# - $KEYCHAIN_PWD contains the login keychain password
+# - $KEYCHAIN_NAME contains the keychain name. Defaults to login.keychain
+# - $KEYCHAIN_PWD contains the keychain password
+
+export KEYCHAIN_NAME=${KEYCHAIN_NAME:-"login.keychain"}
 
 # Unlock login keychain
-security unlock-keychain -p $KEYCHAIN_PWD "login.keychain"
+security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_NAME"
 
 # Import signing certificates and allow relevant apps to use them
-security import ~/developer_id_installer.p12 -P $INSTALLER_CERTIFICATE_PWD -k "login.keychain" -T /usr/bin/productbuild
-security import ~/developer_id_application.p12 -P $APPLICATION_CERTIFICATE_PWD -k "login.keychain" -T /usr/bin/codesign
+security import ~/developer_id_installer.p12 -P "$INSTALLER_CERTIFICATE_PWD" -k "$KEYCHAIN_NAME" -T /usr/bin/productbuild
+security import ~/developer_id_application.p12 -P "$APPLICATION_CERTIFICATE_PWD" -k "$KEYCHAIN_NAME" -T /usr/bin/codesign
 
 # Update key partition list
-security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PWD login.keychain
+security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PWD" "$KEYCHAIN_NAME"
 
 # Lock login keychain
-security lock-keychain "login.keychain"
+security lock-keychain "$KEYCHAIN_NAME"


### PR DESCRIPTION
### What does this PR do?

Adds ability to specify on which keychain the signing certificates should be stored & used.
Adds quotes around variables to prevent word splitting.