### PR TITLE
[deb-armhf] Compile ruby from source

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -32,7 +32,11 @@ RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
 RUN curl -sSL https://get.rvm.io | bash -s stable
 RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.3 && rvm cleanup all"
+RUN if [ "$DD_TARGET_ARCH" = "arm64v8" ] ; then \
+        /bin/bash -l -c "rvm install 2.3 && rvm cleanup all" ; \
+    else \
+        /bin/bash -l -c "rvm install --disable-binary 2.3 && rvm cleanup all" ; \
+    fi
 RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Pip & Invoke


### PR DESCRIPTION
### What does this PR do?

Forces compilation of ruby from source in the 32-bit ARM image.

### Motivation

Inside the 32-bit ARM image, the kernel arch is  advertised as `aarch64` (as the host is an ARM64 machine). Thus `rvm` downloads the precompiled `aarch64` binary of `ruby 2.3.8` (which got added on Aug. 29), making the use of ruby fail due to incompatible archs.