### PR TITLE
[macos] Use custom tap to fetch pinned versions of dependencies

### DIFF
--- a/macos/builder_setup.sh
+++ b/macos/builder_setup.sh
@@ -7,26 +7,57 @@
 # Prerequisites:
 # - A MacOS 10.13.6 (High Sierra) box
 
+# About brew packages:
+# We use a custom homebrew tap (DataDog/datadog-agent-macos-build)
+# to keep pinned versions of the software we need.
+
+# How to update a version of a brew package:
+# 1. See the instructions of the DataDog/homebrew-datadog-agent-macos-build repo
+#    to add a formula for the new version you want to use.
+# 2. Update here the version of the formula to use.
+export PKG_CONFIG_VERSION=0.29.2
+export RUBY_VERSION=2.4.10
+export PYTHON_VERSION=3.8.5
+export CMAKE_VERSION=3.18.2
+export GIMME_VERSION=1.5.4
+
+export BUNDLER_VERSION=2.1.4
+
 export GO_VERSION=1.14.7
-export RUBY_VERSION=2.4
 export IBM_MQ_VERSION=9.1.5.0
 
 # Install or upgrade brew (will also install Command Line Tools)
 CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
-brew uninstall python@2 || true # Uninstall python 2 if present
+brew uninstall python@2 -f || true # Uninstall python 2 if present
+brew uninstall python -f || true # Uninstall python 3 if present
 
-# Install ruby & bundler
-brew install ruby@$RUBY_VERSION -f
-export PATH="/usr/local/opt/ruby@$RUBY_VERSION/bin:/usr/local/lib/ruby/gems/$RUBY_VERSION.0/bin:$PATH"
-echo 'export PATH="/usr/local/opt/ruby@'$RUBY_VERSION'/bin:/usr/local/lib/ruby/gems/'$RUBY_VERSION'.0/bin:$PATH"' >> ~/.build_setup
-gem install bundle -f
+# Install pkg-config
+brew install DataDog/datadog-agent-macos-build/pkg-config@$PKG_CONFIG_VERSION -f
+brew link --overwrite pkg-config@$PKG_CONFIG_VERSION
 
-# Install build tools
-brew upgrade python -f || brew install python -f # If python 3 is already present, upgrade it. Otherwise install it.
+# Install ruby (depends on pkg-config)
+brew install DataDog/datadog-agent-macos-build/ruby@$RUBY_VERSION -f
 
-brew install pkg-config -f
-brew install cmake -f
+# Brew link cannot be done, as there is a system ruby version (at least up to MacOS 10.14). You need to add the
+# new ruby to the PATH directly.
+
+# Note: ${RUBY_VERSION%.*} takes RUBY_VERSION but leaves out the shortest string (from the right) that
+# matches what's after the %. Here, that means we leave out the bugfix version.
+# That's needed because gems are stored in a folder named MAJOR.MINOR.0, whatever the bugfix version is.
+export PATH="/usr/local/opt/ruby@$RUBY_VERSION/bin:/usr/local/lib/ruby/gems/${RUBY_VERSION%.*}.0/bin:$PATH"
+echo 'export PATH="/usr/local/opt/ruby@'$RUBY_VERSION'/bin:/usr/local/lib/ruby/gems/'${RUBY_VERSION%.*}'.0/bin:$PATH"' >> ~/.build_setup
+
+# Install bundler
+gem install bundler -v $BUNDLER_VERSION -f
+
+# Install python
+brew install DataDog/datadog-agent-macos-build/python@$PYTHON_VERSION -f
+brew link --overwrite python@$PYTHON_VERSION
+
+# Install cmake (depends on python@3.8)
+brew install DataDog/datadog-agent-macos-build/cmake@$CMAKE_VERSION -f
+brew link --overwrite cmake@$CMAKE_VERSION
 
 mkdir -p $HOME/go
 export GOPATH=$HOME/go
@@ -34,7 +65,9 @@ echo 'export GOPATH=$HOME/go' >> ~/.build_setup
 export PATH="$GOPATH/bin:$PATH"
 echo 'export PATH="$GOPATH/bin:$PATH"' >> ~/.build_setup
 
-brew install gimme
+# Install gimme
+brew install DataDog/datadog-agent-macos-build/gimme@$GIMME_VERSION -f
+brew link --overwrite gimme@$GIMME_VERSION
 eval `gimme $GO_VERSION`
 echo 'eval `gimme '$GO_VERSION'`' >> ~/.build_setup
 


### PR DESCRIPTION
### What does this PR do?

Modifies the builder script to use our own tap: https://github.com/DataDog/homebrew-datadog-agent-macos-build, which has pinned versions of the formulae we need.

### Motivation

Have a stable building env.

### Additional notes

This makes the builder setup slower (because we're compiling from source instead of using the homebrew-core bottles), but that can be mitigated by caching dependencies and / or producing our own bottles.

### Test plan

Tested on the CircleCI build job of datadog-agent: https://app.circleci.com/pipelines/github/DataDog/datadog-agent/6840/workflows/8f2fd0fb-b247-4e33-bd26-f7f54f549481/jobs/267833
