### PR TITLE
Db/test new builders

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,7 +165,6 @@ test_system-probe_arm64:
   stage: build
   except: [ tags, schedules ]
   script:
-    - cmd /c ver
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"
     - $SRC_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:${SRC_TAG}"
@@ -179,7 +178,7 @@ test_system-probe_arm64:
 
 build_windows_1809_x64:
   extends: .winbuild
-  tags: [ "runner:windows-docker", "windowsversion:1809_test" ]
+  tags: [ "runner:windows-docker", "windowsversion:1809" ]
   variables:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_1809_x64
@@ -190,7 +189,7 @@ build_windows_1809_x64:
 
 build_windows_1809_x86:
   extends: .winbuild
-  tags: [ "runner:windows-docker", "windowsversion:1809_test" ]
+  tags: [ "runner:windows-docker", "windowsversion:1809" ]
   variables:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_1809_x86
@@ -201,7 +200,7 @@ build_windows_1809_x86:
 
 build_windows_1909_x64:
   extends: .winbuild
-  tags: [ "runner:windows-docker", "windowsversion:1909_test" ]
+  tags: [ "runner:windows-docker", "windowsversion:1909" ]
   variables:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_1909_x64
@@ -212,7 +211,7 @@ build_windows_1909_x64:
 
 build_windows_1909_x86:
   extends: .winbuild
-  tags: [ "runner:windows-docker", "windowsversion:1909_test" ]
+  tags: [ "runner:windows-docker", "windowsversion:1909" ]
   variables:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_1909_x86
@@ -238,7 +237,7 @@ build_windows_1909_x86:
 
 test_windows_1809_x64:
   extends: .test_windows
-  tags: ["windows_release:1809_2020_09_test"]
+  tags: [ "runner:windows-docker", "windowsversion:1809" ]
   needs: [ "build_windows_1809_x64" ]
   variables:
     ARCH: x64
@@ -246,7 +245,7 @@ test_windows_1809_x64:
 
 test_windows_1809_x86:
   extends: .test_windows
-  tags: [ "runner:windows-docker", "windowsversion:1809_test" ]
+  tags: [ "runner:windows-docker", "windowsversion:1809" ]
   needs: [ "build_windows_1809_x86" ]
   variables:
     ARCH: x86
@@ -254,7 +253,7 @@ test_windows_1809_x86:
 
 test_windows_1909_x64:
   extends: .test_windows
-  tags: [ "runner:windows-docker", "windowsversion:1909_test" ]
+  tags: [ "runner:windows-docker", "windowsversion:1909" ]
   needs: [ "build_windows_1909_x64" ]
   variables:
     ARCH: x64
@@ -262,7 +261,7 @@ test_windows_1909_x64:
 
 test_windows_1909_x86:
   extends: .test_windows
-  tags: [ "runner:windows-docker", "windowsversion:1909_test" ]
+  tags: [ "runner:windows-docker", "windowsversion:1909" ]
   needs: [ "build_windows_1909_x86" ]
   variables:
     ARCH: x86
@@ -292,7 +291,7 @@ test_windows_1909_x86:
   stage: release
   except: [ tags, schedules ]
   only: [ master ]
-  tags: [ "runner:windows-docker", "windowsversion:1909_test" ]
+  tags: [ "runner:windows-docker", "windowsversion:1909" ]
   script:
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -178,44 +178,44 @@ test_system-probe_arm64:
 
 build_windows_1809_x64:
   extends: .winbuild
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  tags: [ "runner:windows-docker", "windowsversion:1809_test" ]
   variables:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_1809_x64
-    BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-20200114-windowsservercore-ltsc2019
+    BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
     DD_TARGET_ARCH: x64
     WINDOWS_VERSION: 1809
   resource_group: windows_x64
 
 build_windows_1809_x86:
   extends: .winbuild
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  tags: [ "runner:windows-docker", "windowsversion:1809_test" ]
   variables:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_1809_x86
-    BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-20200114-windowsservercore-ltsc2019
+    BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
     DD_TARGET_ARCH: x86
     WINDOWS_VERSION: 1809
   resource_group: windows_x86
 
 build_windows_1909_x64:
   extends: .winbuild
-  tags: [ "runner:windows-docker", "windowsversion:1909" ]
+  tags: [ "runner:windows-docker", "windowsversion:1909_test" ]
   variables:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_1909_x64
-    BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-20200310-windowsservercore-1909
+    BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-1909
     DD_TARGET_ARCH: x64
     WINDOWS_VERSION: 1909
   resource_group: windows_x64
 
 build_windows_1909_x86:
   extends: .winbuild
-  tags: [ "runner:windows-docker", "windowsversion:1909" ]
+  tags: [ "runner:windows-docker", "windowsversion:1909_test" ]
   variables:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_1909_x86
-    BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-20200310-windowsservercore-1909
+    BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-1909
     DD_TARGET_ARCH: x86
     WINDOWS_VERSION: 1909
   resource_group: windows_x86
@@ -237,7 +237,7 @@ build_windows_1909_x86:
 
 test_windows_1809_x64:
   extends: .test_windows
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  tags: ["windows_release:1809_2020_09_test"]
   needs: [ "build_windows_1809_x64" ]
   variables:
     ARCH: x64
@@ -245,7 +245,7 @@ test_windows_1809_x64:
 
 test_windows_1809_x86:
   extends: .test_windows
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  tags: [ "runner:windows-docker", "windowsversion:1809_test" ]
   needs: [ "build_windows_1809_x86" ]
   variables:
     ARCH: x86
@@ -253,7 +253,7 @@ test_windows_1809_x86:
 
 test_windows_1909_x64:
   extends: .test_windows
-  tags: [ "runner:windows-docker", "windowsversion:1909" ]
+  tags: [ "runner:windows-docker", "windowsversion:1909_test" ]
   needs: [ "build_windows_1909_x64" ]
   variables:
     ARCH: x64
@@ -261,7 +261,7 @@ test_windows_1909_x64:
 
 test_windows_1909_x86:
   extends: .test_windows
-  tags: [ "runner:windows-docker", "windowsversion:1909" ]
+  tags: [ "runner:windows-docker", "windowsversion:1909_test" ]
   needs: [ "build_windows_1909_x86" ]
   variables:
     ARCH: x86
@@ -291,7 +291,7 @@ test_windows_1909_x86:
   stage: release
   except: [ tags, schedules ]
   only: [ master ]
-  tags: [ "runner:windows-docker", "windowsversion:1909" ]
+  tags: [ "runner:windows-docker", "windowsversion:1909_test" ]
   script:
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,6 +165,7 @@ test_system-probe_arm64:
   stage: build
   except: [ tags, schedules ]
   script:
+    - cmd /c ver
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"
     - $SRC_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:${SRC_TAG}"

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -11,7 +11,7 @@
 # On the contrary, since our 1909 windows-docker host image does have this update,
 # we use a base container image that does have this update.
 # TODO: Once the 1809 windows-docker host image is updated, update the base container image.
-ARG BASE_IMAGE=mcr.microsoft.com/dotnet/framework/runtime:4.8-20200114-windowsservercore-ltsc2019
+ARG BASE_IMAGE=mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
 
 FROM ${BASE_IMAGE}
 


### PR DESCRIPTION
Update .gitlab-ci.yml and dockerfile to pull latest servercore rather tha image
pinned to feb2020