### PR TITLE
[windows] Install go without chocolatey

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -118,7 +118,12 @@ RUN if ($Env:TARGET_ARCH -eq 'x86') { [Environment]::SetEnvironmentVariable(\"Pa
 RUN if ($Env:TARGET_ARCH -eq 'x64') { [Environment]::SetEnvironmentVariable(\"Path\", [Environment]::GetEnvironmentVariable(\"Path\", [EnvironmentVariableTarget]::Machine) + \";${env:ProgramFiles}\CMake\bin\", [System.EnvironmentVariableTarget]::Machine) }
 
 # Install golang and set GOPATH to the dev path used in builds & tests
-RUN cinst -y --no-progress golang $ENV:CHOCO_ARCH_FLAG --version $ENV:GO_VERSION
+# RUN cinst -y --no-progress golang $ENV:CHOCO_ARCH_FLAG --version $ENV:GO_VERSION
+
+# Some go point releases are not available as chocolatey packages, we have to install them directly
+COPY ./windows/install_go.ps1 install_go.ps1
+RUN powershell -C .\install_go.ps1
+
 RUN setx GOPATH C:\dev\go
 
 # Install system Python 3 (to use invoke).

--- a/windows/install_go.ps1
+++ b/windows/install_go.ps1
@@ -1,0 +1,31 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+Write-Host -ForegroundColor Green "Installing go $ENV:GO_VERSION"
+
+$gozip = "https://dl.google.com/go/go$ENV:GO_VERSION.windows-amd64.zip"
+if ($Env:TARGET_ARCH -eq "x86") {
+    $gozip = "https://dl.google.com/go/go$ENV:GO_VERSION.windows-386.zip"
+}
+
+$out = 'go.zip'
+
+Write-Host -ForegroundColor Green "Downloading $gozip to $out"
+
+(New-Object System.Net.WebClient).DownloadFile($gozip, $out)
+
+Write-Host -ForegroundColor Green "Extracting $out to c:\"
+
+Start-Process "7z" -ArgumentList 'x -oc:\ go.zip' -Wait
+
+Write-Host -ForegroundColor Green "Removing temporary file $out"
+
+Remove-Item $out
+
+setx GOROOT c:\go
+$Env:GOROOT="c:\go"
+setx PATH "$Env:Path;c:\go\bin;"
+$Env:Path="$Env:Path;c:\go\bin;"
+
+Write-Host -ForegroundColor Green "Installed go $ENV:GO_VERSION"
+


### PR DESCRIPTION
### What does this PR do

Install go directly from the zip file available at https://dl.google.com/go.

### Motivation

Some point releases of go aren't packaged by chocolatey maintainers, eg. point releases of a minor version when a newer minor version exists.

### Test plan

Tested building Windows builders with go 1.14.7 and go 1.14.12 successfully.