### PR TITLE
[system-probe] Fix arm builder failures

### DIFF
--- a/entrypoint-sysprobe.sh
+++ b/entrypoint-sysprobe.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -l
+set -e
+
+source /root/.bashrc
+
+eval "$(gimme)"
+
+export PATH="/opt/clang/bin:$PATH"
+
+exec "$@"

--- a/entrypoint-sysprobe.sh
+++ b/entrypoint-sysprobe.sh
@@ -1,10 +1,8 @@
-#!/bin/bash -l
+#!/bin/bash
 set -e
 
 source /root/.bashrc
 
 eval "$(gimme)"
-
-export PATH="/opt/clang/bin:$PATH"
 
 exec "$@"

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -42,6 +42,7 @@ RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 RUN wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-aarch64-linux-gnu.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
 RUN mkdir -p /opt/clang
 RUN tar xf /tmp/clang.tar.xz  -C /opt/clang --strip-components=1
+ENV PATH "/opt/clang/bin:${PATH}"
 
 RUN python3 -m pip install invoke==1.4.1
 

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -1,6 +1,11 @@
-FROM debian:bullseye
+FROM debian:buster
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG GIMME_GO_VERSION=1.14.7
+
+ENV GIMME_GO_VERSION $GIMME_GO_VERSION
+ENV GOPATH=/go
+
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
         awscli \
         bison \
@@ -10,25 +15,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         g++ \
         gcc \
         git \
-        go-dep \
-        golang \
         libelf-dev \
-        libstdc++-10-dev \
+        libstdc++-8-dev \
         libtinfo-dev \
+        libtinfo5 \
         libxml2-dev \
         linux-headers-arm64 \
         ninja-build \
         python \
         python3-distro \
         python3-distutils \
-        python3-invoke \
         python3-pip \
         wget \
         xz-utils
 
 RUN wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme
+RUN chmod +x /bin/gimme
+RUN gimme $GIMME_GO_VERSION
 
-ENV GOPATH=/go
+COPY ./gobin.sh /etc/profile.d/
 
 # create the agent build folder within $GOPATH
 RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
@@ -37,4 +42,10 @@ RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 RUN wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-aarch64-linux-gnu.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
 RUN mkdir -p /opt/clang
 RUN tar xf /tmp/clang.tar.xz  -C /opt/clang --strip-components=1
-ENV PATH /opt/clang/bin:${PATH}
+
+RUN python3 -m pip install invoke==1.4.1
+
+COPY ./entrypoint-sysprobe.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -1,6 +1,11 @@
 FROM debian:bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG GIMME_GO_VERSION=1.14.7
+
+ENV GIMME_GO_VERSION $GIMME_GO_VERSION
+ENV GOPATH=/go
+
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
         awscli \
         bison \
@@ -10,8 +15,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         g++ \
         gcc \
         git \
-        go-dep \
-        golang \
         libelf-dev \
         libstdc++-10-dev \
         libtinfo-dev \
@@ -21,14 +24,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         python \
         python3-distro \
         python3-distutils \
-        python3-invoke \
         python3-pip \
         wget \
         xz-utils
 
 RUN wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme
+RUN chmod +x /bin/gimme
+RUN gimme $GIMME_GO_VERSION
 
-ENV GOPATH=/go
+COPY ./gobin.sh /etc/profile.d/
 
 # create the agent build folder within $GOPATH
 RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
@@ -37,4 +41,10 @@ RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 RUN wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
 RUN mkdir -p /opt/clang
 RUN tar xf /tmp/clang.tar.xz  -C /opt/clang --strip-components=1
-ENV PATH /opt/clang/bin:${PATH}
+
+RUN python3 -m pip install invoke==1.4.1
+
+COPY ./entrypoint-sysprobe.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -41,6 +41,7 @@ RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 RUN wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
 RUN mkdir -p /opt/clang
 RUN tar xf /tmp/clang.tar.xz  -C /opt/clang --strip-components=1
+ENV PATH "/opt/clang/bin:${PATH}"
 
 RUN python3 -m pip install invoke==1.4.1
 


### PR DESCRIPTION
### What does this PR do?

Switches the system-probe-arm64 builder to `debian:buster`.
Install go and invoke the same way on all builders (`debian:buster` has old versions of invoke and go, not compatible with the datadog-agent project).

### Motivation

Make system-probe ARM jobs pass.

The latest `debian:bullseye` image makes Gitlab fails when setting up the ARM Gitlab runners.
Using a pinned `debian:bullseye` also does not work, as the linux headers for this distro are 5.9.x, which `clang` 11 doesn't support on ARM.

### Additional notes

The x64 system-probe image is still on `debian:bullseye`, as switching back to `debian:bullseye` gives versions of `glibc6` and `libstdc++6` too old for `clang` 11.
Is having the two system-probe images using different headers (4.9 vs. 5.9) a problem?