### PR TITLE
Switch x64 system-probe build to use debian buster

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         git \
         libelf-dev \
         libstdc++-8-dev \
+        libtinfo-dev \
         libtinfo5 \
         libxml2-dev \
         linux-headers-arm64 \

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         git \
         libelf-dev \
         libstdc++-8-dev \
-        libtinfo-dev \
         libtinfo5 \
         libxml2-dev \
         linux-headers-arm64 \

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 # install clang from the website since the package manager can change at any time
 RUN wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-aarch64-linux-gnu.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
 RUN mkdir -p /opt/clang
-RUN tar xf /tmp/clang.tar.xz  -C /opt/clang --strip-components=1
+RUN tar xf /tmp/clang.tar.xz --no-same-owner -C /opt/clang --strip-components=1
 ENV PATH "/opt/clang/bin:${PATH}"
 
 RUN python3 -m pip install invoke==1.4.1

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         python \
         python3-distro \
         python3-distutils \
+        python3-setuptools \
         python3-pip \
         wget \
         xz-utils

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         git \
         libelf-dev \
         libstdc++-8-dev \
+        libtinfo-dev \
         libtinfo5 \
         libxml2-dev \
         linux-headers-amd64 \

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:buster
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG GIMME_GO_VERSION=1.14.7
@@ -16,8 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         gcc \
         git \
         libelf-dev \
-        libstdc++-10-dev \
-        libtinfo-dev \
+        libstdc++-8-dev \
+        libtinfo5 \
         libxml2-dev \
         linux-headers-amd64 \
         ninja-build \
@@ -38,7 +38,7 @@ COPY ./gobin.sh /etc/profile.d/
 RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 
 # install clang from the website since the package manager can change at any time
-RUN wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
+RUN wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
 RUN mkdir -p /opt/clang
 RUN tar xf /tmp/clang.tar.xz  -C /opt/clang --strip-components=1
 ENV PATH "/opt/clang/bin:${PATH}"

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         python \
         python3-distro \
         python3-distutils \
+        python3-setuptools \
         python3-pip \
         wget \
         xz-utils

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 # install clang from the website since the package manager can change at any time
 RUN wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
 RUN mkdir -p /opt/clang
-RUN tar xf /tmp/clang.tar.xz  -C /opt/clang --strip-components=1
+RUN tar xf /tmp/clang.tar.xz --no-same-owner -C /opt/clang --strip-components=1
 ENV PATH "/opt/clang/bin:${PATH}"
 
 RUN python3 -m pip install invoke==1.4.1


### PR DESCRIPTION
This ran successfully in https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/3501374 including the clang build in https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/47087628