### PR TITLE
remove chocolatey; install everything manually

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -185,7 +185,6 @@ build_windows_1809_x64:
     BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
     DD_TARGET_ARCH: x64
     WINDOWS_VERSION: 1809
-  resource_group: windows_x64
 
 build_windows_1809_x86:
   extends: .winbuild
@@ -196,7 +195,6 @@ build_windows_1809_x86:
     BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
     DD_TARGET_ARCH: x86
     WINDOWS_VERSION: 1809
-  resource_group: windows_x86
 
 build_windows_1909_x64:
   extends: .winbuild
@@ -207,7 +205,6 @@ build_windows_1909_x64:
     BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-1909
     DD_TARGET_ARCH: x64
     WINDOWS_VERSION: 1909
-  resource_group: windows_x64
 
 build_windows_1909_x86:
   extends: .winbuild
@@ -218,7 +215,6 @@ build_windows_1909_x86:
     BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-1909
     DD_TARGET_ARCH: x86
     WINDOWS_VERSION: 1909
-  resource_group: windows_x86
 
 .test_windows:
   extends: .test

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -171,4 +171,5 @@ RUN if ($Env:TARGET_ARCH -eq 'x86') { setx WINDOWS_BUILD_32_BIT 1 }
 COPY ./windows/entrypoint.bat /entrypoint.bat
 COPY ./windows/aws_networking.ps1 /aws_networking.ps1
 
+
 ENTRYPOINT ["/entrypoint.bat"]

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -25,8 +25,9 @@ ENV TARGET_ARCH=${DD_TARGET_ARCH:-x64}
 
 # Chocolatey package versions
 ENV GIT_VERSION "2.26.2"
-ENV SEVENZIP_VERSION "19.0"
+ENV SEVENZIP_VERSION "19.0.0" # now needs all 3 digits
 ENV VS2017BUILDTOOLS_VERSION "15.9.23.0"
+ENV VS2017BUILDTOOLS_DOWNLOAD_URL "https://download.visualstudio.microsoft.com/download/pr/d0eac510-174b-4241-b73b-93dc7cc1fbf7/9822b4c851e14d9658babd1533f66f518c6169196e985fe5713b2774128832ae/vs_BuildTools.exe"
 ENV VCPYTHON27_VERSION "9.0.0.30729"
 ENV GO_VERSION "1.14.12"
 ENV RUBY_VERSION "2.4.3.1"
@@ -82,40 +83,38 @@ RUN if ($Env:WINDOWS_VERSION -eq '1909') { .\install_net35_1909.bat }
 
 ### End of preliminary step
 
-RUN if ($Env:TARGET_ARCH -eq 'x86') { setx CHOCO_ARCH_FLAG '-x86' }
-
-# Install Chocolatey
-RUN $env:chocolateyUseWindowsCompression = 'true'; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+# Install 7-zip
+Copy ./windows/install_7zip.ps1 install_7zip.ps1
+RUN powershell -Command .\install_7zip.ps1 -Version $ENV:SEVENZIP_VERSION
 
 # Install git
-RUN $env:chocolateyUseWindowsCompression = 'true'; cinst -y --no-progress git $ENV:CHOCO_ARCH_FLAG --version $ENV:GIT_VERSION
+COPY ./windows/install_mingit.ps1 install_mingit.ps1
+RUN powershell -Command .\install_mingit.ps1 -Version $ENV:GIT_VERSION
+
 ### HACK: we disable symbolic links when cloning repositories
 ### to work around a symlink-related failure in the agent-binaries omnibus project
 ### when copying the datadog-agent project twice.
 RUN git config --system core.symlinks false
 
-# Install 7zip
-RUN $env:chocolateyUseWindowsCompression = 'true'; cinst -y --no-progress 7zip $ENV:CHOCO_ARCH_FLAG --version $ENV:SEVENZIP_VERSION
-
 # Install VS2017
-RUN cinst -y --no-progress visualstudio2017buildtools $ENV:CHOCO_ARCH_FLAG --version $ENV:VS2017BUILDTOOLS_VERSION --params \"--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81 --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre --add Microsoft.VisualStudio.Component.Windows10SDK.17763\"
-RUN setx VSTUDIO_ROOT \"${env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\BuildTools\"
+COPY ./windows/install_vstudio.ps1 install_vstudio.ps1
+RUN powershell -Command .\install_vstudio.ps1 -Version $ENV:VS2017BUILDTOOLS_VERSION $ENV:VS2017BUILDTOOLS_DOWNLOAD_URL
 
 # If x64, install the WDK for driver development
 COPY ./windows/install_wdk.ps1 install_wdk.ps1
 RUN if ($Env:TARGET_ARCH -eq 'x64') { powershell -Command .\install_wdk.ps1 }
 
 # Install VC compiler for Python 2.7
-RUN cinst -y --no-progress vcpython27 $ENV:CHOCO_ARCH_FLAG --version $ENV:VCPYTHON27_VERSION
+COPY ./windows/install_vcpython.ps1 install_vcpython.ps1
+RUN powershell -Command .\install_vcpython.ps1
 
 # Install Wix and update PATH to include it
-RUN cinst -y --no-progress wixtoolset $ENV:CHOCO_ARCH_FLAG --version $ENV:WIX_VERSION
-RUN [Environment]::SetEnvironmentVariable(\"Path\", [Environment]::GetEnvironmentVariable(\"Path\", [EnvironmentVariableTarget]::Machine) + \";${env:ProgramFiles(x86)}\WiX Toolset v3.11\bin\", [System.EnvironmentVariableTarget]::Machine)
+COPY ./windows/install_wix.ps1 install_wix.ps1
+RUN powershell -Command .\install_wix.ps1 -Version $ENV:WIX_VERSION
 
 # Install Cmake and update PATH to include it
-RUN cinst -y --no-progress cmake $ENV:CHOCO_ARCH_FLAG --version $ENV:CMAKE_VERSION
-RUN if ($Env:TARGET_ARCH -eq 'x86') { [Environment]::SetEnvironmentVariable(\"Path\", [Environment]::GetEnvironmentVariable(\"Path\", [EnvironmentVariableTarget]::Machine) + \";${Env:ProgramFiles(x86)}\CMake\bin\", [System.EnvironmentVariableTarget]::Machine) }
-RUN if ($Env:TARGET_ARCH -eq 'x64') { [Environment]::SetEnvironmentVariable(\"Path\", [Environment]::GetEnvironmentVariable(\"Path\", [EnvironmentVariableTarget]::Machine) + \";${env:ProgramFiles}\CMake\bin\", [System.EnvironmentVariableTarget]::Machine) }
+COPY ./windows/install_cmake.ps1 install_cmake.ps1
+RUN powershell -Command .\install_cmake.ps1 -Version $ENV:CMAKE_VERSION -Arch $ENV:TARGET_ARCH
 
 # Install golang and set GOPATH to the dev path used in builds & tests
 # RUN cinst -y --no-progress golang $ENV:CHOCO_ARCH_FLAG --version $ENV:GO_VERSION
@@ -128,15 +127,16 @@ RUN setx GOPATH C:\dev\go
 
 # Install system Python 3 (to use invoke).
 # We always install the 64 bit version because vcredist140 won't work otherwise
-RUN cinst -y --no-progress python3 --version $ENV:PYTHON_VERSION
+COPY ./windows/install_python.ps1 install_python.ps1
+RUN powershell -C .\install_python.ps1 -Version $ENV:PYTHON_VERSION
 
 # Install 64-bit ruby and bundler (for omnibus builds)
-RUN cinst -y --no-progress ruby --version $ENV:RUBY_VERSION
-RUN setx RIDK ((Get-Command ridk).Path)
-RUN gem install bundler
+COPY ./windows/install_ruby.ps1 install_ruby.ps1
+RUN powershell -C .\install_ruby.ps1 -Version $ENV:RUBY_VERSION
 
 # Install msys2 system & install 64-bit C/C++ compilation toolchain
-RUN cinst -y --no-progress msys2 --params \"/NoUpdate\" --version $ENV:MSYS_VERSION
+copy ./windows/install_msys.ps1 install_msys.ps1
+RUN powershell -C .\install_msys.ps1 -Version $ENV:MSYS_VERSION
 
 # TODO: as soon as a new msys distribution (with working packages) is available, use it
 # and stop doing ridk install 2, which force-upgrades packages to the latest available.

--- a/windows/install_7zip.ps1
+++ b/windows/install_7zip.ps1
@@ -1,0 +1,22 @@
+param (
+    [Parameter(Mandatory=$true)][string]$Version
+)
+
+# Enabled TLS12
+$ErrorActionPreference = 'Stop'
+
+# Script directory is $PSScriptRoot
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$shortenedver = $Version.Replace('.','')
+$sevenzip="https://www.7-zip.org/a/7z$($shortenedver)-x64.exe"
+
+Write-Host -ForegroundColor Green "Installing 7zip $sevenzip"
+$out = "$($PSScriptRoot)\7zip.exe"
+(New-Object System.Net.WebClient).DownloadFile($sevenzip, $out)
+Start-Process 7zip.exe -ArgumentList '/S' -Wait
+Remove-Item $out
+setx PATH "$Env:Path;c:\program files\7-zip"
+$Env:Path="$Env:Path;c:\program files\7-zip"
+Write-Host -ForegroundColor Green Done with 7zip

--- a/windows/install_cmake.ps1
+++ b/windows/install_cmake.ps1
@@ -1,0 +1,36 @@
+param (
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Arch
+)
+
+# Enabled TLS12
+$ErrorActionPreference = 'Stop'
+
+# Script directory is $PSScriptRoot
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$shortenedver = $Version.Replace('.','')
+$splitver = $Version.split(".")
+$majmin = "$($splitver[0])$($splitver[1])" 
+
+# https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-win64-x64.msi
+# https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-win32-x86.msi
+$cmakeurl = ""
+if($Arch -eq 'x64' ) {
+    $cmakeurl = "https://github.com/Kitware/CMake/releases/download/v$($Version)/cmake-$($Version)-win64-x64.msi"
+} else {
+    $cmakeurl = "https://github.com/Kitware/CMake/releases/download/v$($Version)/cmake-$($Version)-win32-x86.msi"
+}
+
+
+Write-Host  -ForegroundColor Green starting with CMake
+$out = "$($PSScriptRoot)\cmake.msi"
+(New-Object System.Net.WebClient).DownloadFile($cmakeurl, $out)
+
+
+Start-Process msiexec -ArgumentList "/q /i $($out) ADD_CMAKE_TO_PATH=System" -Wait
+
+Remove-Item $out
+
+Write-Host -ForegroundColor Green Done with CMake

--- a/windows/install_mingit.ps1
+++ b/windows/install_mingit.ps1
@@ -1,0 +1,27 @@
+param (
+    [Parameter(Mandatory=$true)][string]$Version
+)
+
+# Enabled TLS12
+$ErrorActionPreference = 'Stop'
+
+# Script directory is $PSScriptRoot
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$mingit = "https://github.com/git-for-windows/git/releases/download/v$($Version).windows.1/MinGit-$($Version)-64-bit.zip"
+
+Write-Host -ForegroundColor Green Installing MinGit
+$out = "$($PSScriptRoot)\mingit.zip"
+(New-Object System.Net.WebClient).DownloadFile($mingit, $out)
+md c:\devtools\git
+& '7z' x -oc:\devtools\git $out
+
+Remove-Item $out
+# set path locally so we can initialize git config
+setx PATH "$Env:Path;c:\devtools\git\cmd;c:\devtools\git\usr\bin"
+$Env:Path="$Env:Path;c:\devtools\git\cmd;c:\devtools\git\usr\bin"
+& 'git.exe' config --global user.name "Croissant Builder"
+& 'git.exe' config --global user.email "croissant@datadoghq.com"
+
+Write-Host -ForegroundColor Green Done with Git

--- a/windows/install_msys.ps1
+++ b/windows/install_msys.ps1
@@ -1,0 +1,54 @@
+param (
+    [Parameter(Mandatory=$true)][string]$Version
+)
+$InstallPath = "c:\tools"
+<#
+.SYNOPSIS
+ Invoke-Msys2Shell  Runs the shell once to do first-time startup.  
+
+.NOTES
+Taken from chocolatey installer.
+#>
+function Invoke-Msys2Shell($Arguments) {
+    if (![string]::IsNullOrWhiteSpace($Arguments)) { $Arguments += "; " }
+    $Arguments += "ps -ef | grep '[?]' | awk '{print `$2}' | xargs -r kill"
+    $basepath = Join-Path $InstallPath msys64
+
+    $params = @{
+        FilePath     = Join-Path $basepath msys2_shell.cmd
+        NoNewWindow  = $true
+        Wait         = $true
+        ArgumentList = "-defterm", "-no-start", "-c", "`"$Arguments`""
+    }
+    Write-Host "Invoking msys2 shell command:" $params.ArgumentList
+    Start-Process @params
+}
+# Enabled TLS12
+$ErrorActionPreference = 'Stop'
+
+# Script directory is $PSScriptRoot
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200629.tar.xz
+$splitver = $Version.split(".")
+$msysver = "$($splitver[0])" 
+
+$msyszip = "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-$($msysver).tar.xz"
+
+Write-Host  -ForegroundColor Green starting with MSYS
+$out = "$($PSScriptRoot)\msys.tar.xz"
+(New-Object System.Net.WebClient).DownloadFile($msyszip, $out)
+
+# uncompress the tar-xz into a tar
+$msystar = "msys.tar"
+& 7z x $out
+start-process 7z -ArgumentList "x -o$($InstallPath) $msystar" -Wait
+
+Remove-Item $out
+Remove-Item $msystar
+
+## invoke the first-run shell
+Invoke-Msys2Shell
+
+Write-Host -ForegroundColor Green Done with MSYS

--- a/windows/install_python.ps1
+++ b/windows/install_python.ps1
@@ -1,0 +1,28 @@
+param (
+    [Parameter(Mandatory=$true)][string]$Version
+)
+
+# Enabled TLS12
+$ErrorActionPreference = 'Stop'
+
+# Script directory is $PSScriptRoot
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+
+# https://www.python.org/ftp/python/3.9.1/python-3.9.1-amd64.exe
+$pyexe = "https://www.python.org/ftp/python/$($Version)/python-$($Version)-amd64.exe"
+
+Write-Host  -ForegroundColor Green starting with Python
+$out = "$($PSScriptRoot)\python.exe"
+(New-Object System.Net.WebClient).DownloadFile($pyexe, $out)
+
+Write-Host -ForegroundColor Green Done downloading wix, installing
+
+Start-Process $out -ArgumentList '/quiet InstallAllUsers=1' -Wait
+
+setx PATH "$($Env:PATH);c:\program files\Python38;c:\Program files\python38\scripts"
+$Env:PATH="$($Env:PATH);c:\program files\Python38;c:\Program files\python38\scripts"
+Remove-Item $out
+
+Write-Host -ForegroundColor Green Done with Python

--- a/windows/install_ruby.ps1
+++ b/windows/install_ruby.ps1
@@ -1,0 +1,32 @@
+param (
+    [Parameter(Mandatory=$true)][string]$Version
+)
+
+# Enabled TLS12
+$ErrorActionPreference = 'Stop'
+
+# Script directory is $PSScriptRoot
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-2.4.3-1/rubyinstaller-2.4.3-1-x64.exe
+
+$splitver = $Version.split(".")
+$majmin = "$($splitver[0]).$($splitver[1]).$($splitver[2])-$($splitver[3])" 
+
+$rubyexe = "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-$($majmin)/rubyinstaller-$($majmin)-x64.exe"
+
+Write-Host  -ForegroundColor Green starting with Ruby
+$out = "$($PSScriptRoot)\rubyinstaller.exe"
+(New-Object System.Net.WebClient).DownloadFile($rubyexe, $out)
+
+Write-Host -ForegroundColor Green Done downloading Ruby, installing
+Start-Process $out -ArgumentList '/verysilent /dir="c:\tools\ruby24" /tasks="assocfiles,noridkinstall,modpath"' -Wait
+$Env:PATH="$Env:PATH;c:\tools\ruby24\bin"
+setx RIDK ((Get-Command ridk).Path)
+Start-Process gem -ArgumentList  'install bundler' -Wait
+
+
+Remove-Item $out
+
+Write-Host -ForegroundColor Green Done with Ruby

--- a/windows/install_vcpython.ps1
+++ b/windows/install_vcpython.ps1
@@ -1,0 +1,18 @@
+# Enabled TLS12
+$ErrorActionPreference = 'Stop'
+
+# Script directory is $PSScriptRoot
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+
+$vcpmsi = 'https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi'
+
+Write-host -ForegroundColor Green Downloading VC++ for Python
+$out = "$($PSScriptRoot)\vcp.msi"
+
+(New-Object System.Net.WebClient).DownloadFile($vcpmsi, $out)
+Write-host -ForegroundColor Green VC++ for Python downloaded, installing...
+Start-Process msiexec -ArgumentList '/q /i vcp.msi' -Wait
+Remove-Item $out
+Write-Host -ForegroundColor Green Done with Visual C++ for Python

--- a/windows/install_vstudio.ps1
+++ b/windows/install_vstudio.ps1
@@ -18,7 +18,25 @@ Write-Host -ForegroundColor Green Downloading $Url to $out
 (New-Object System.Net.WebClient).DownloadFile($Url, $out)
 # write file size to make sure it worked
 Write-Host -ForegroundColor Green "File size is $((get-item $out).length)"
-Start-Process $out -ArgumentList  '--quiet --wait --norestart --nocache --installPath c:\devtools\vstudio --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64  --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81 --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre --add Microsoft.VisualStudio.Component.Windows10SDK.17763' -Wait
+
+$VSPackages = @(
+    "Microsoft.VisualStudio.Workload.NativeDesktop",
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64", 
+    "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81",
+    "Microsoft.VisualStudio.Workload.VCTools",
+    "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre",
+    "Microsoft.VisualStudio.Component.Windows10SDK.17763"
+)
+
+$VSPackageListParam = $VSPackages -join " --add "
+$processparams = @{
+    FilePath = $out
+    NoNewWindow = $true
+    Wait = $true
+    ArgumentList = "--quiet --wait --norestart --nocache --installPath c:\devtools\vstudio --add $VSPackageListParam"
+}
+Start-Process @processparams
+
 
 setx VSTUDIO_ROOT "c:\devtools\vstudio"
 

--- a/windows/install_vstudio.ps1
+++ b/windows/install_vstudio.ps1
@@ -1,0 +1,26 @@
+param (
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Url
+)
+
+# Enabled TLS12
+$ErrorActionPreference = 'Stop'
+
+# Script directory is $PSScriptRoot
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+Write-Host -ForegroundColor Green "Installing Visual Studio $($Version) from $($Url)"
+
+$out = "$($PSROOT)\vs_buildtools.exe"
+
+Write-Host -ForegroundColor Green Downloading $Url to $out
+(New-Object System.Net.WebClient).DownloadFile($Url, $out)
+# write file size to make sure it worked
+Write-Host -ForegroundColor Green "File size is $((get-item $out).length)"
+Start-Process $out -ArgumentList  '--quiet --wait --norestart --nocache --installPath c:\devtools\vstudio --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64  --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81 --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre --add Microsoft.VisualStudio.Component.Windows10SDK.17763' -Wait
+
+setx VSTUDIO_ROOT "c:\devtools\vstudio"
+
+Remove-Item $out
+Write-Host -ForegroundColor Green Done with Visual Studio

--- a/windows/install_wix.ps1
+++ b/windows/install_wix.ps1
@@ -25,10 +25,11 @@ Write-Host -ForegroundColor Green Done downloading wix, installing
 Start-Process $out -ArgumentList '/q' -Wait
 
 #Copy-Item c:\devtools\wix\sdk\inc -Destination c:\devtools\wix\sdk\vs2017\inc -Recurse
-#[Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";${env:ProgramFiles(x86)}\WiX Toolset v3.11\bin\", [System.EnvironmentVariableTarget]::Machine)
+[Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";${env:ProgramFiles(x86)}\WiX Toolset v3.11\bin\", [System.EnvironmentVariableTarget]::Machine)
 #setx PATH "$Env:Path;C:\devtools\wix"
 #$Env:Path="$Env:Path;c:\devtools\wix"
-#setx WIX "C:\devtools\wix\"
+#setx WIX "C:\Program Files (x86)\WiX Toolset v3.11\"
+[Environment]::SetEnvironmentVariable("WIX", "C:\Program Files (x86)\WiX Toolset v3.11\")
 Remove-Item $out
 
 Write-Host -ForegroundColor Green Done with WiX

--- a/windows/install_wix.ps1
+++ b/windows/install_wix.ps1
@@ -1,0 +1,34 @@
+param (
+    [Parameter(Mandatory=$true)][string]$Version
+)
+
+# Enabled TLS12
+$ErrorActionPreference = 'Stop'
+
+# Script directory is $PSScriptRoot
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$shortenedver = $Version.Replace('.','')
+$splitver = $Version.split(".")
+$majmin = "$($splitver[0])$($splitver[1])" 
+
+# https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311.exe
+$wixzip = "https://github.com/wixtoolset/wix3/releases/download/wix$($shortenedver)rtm/wix$($majmin).exe"
+
+Write-Host  -ForegroundColor Green starting with WiX
+$out = "$($PSScriptRoot)\wix.exe"
+(New-Object System.Net.WebClient).DownloadFile($wixzip, $out)
+
+Write-Host -ForegroundColor Green Done downloading wix, installing
+#Start-Process wix.exe -ArgumentList '/quiet' -Wait
+Start-Process $out -ArgumentList '/q' -Wait
+
+#Copy-Item c:\devtools\wix\sdk\inc -Destination c:\devtools\wix\sdk\vs2017\inc -Recurse
+#[Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";${env:ProgramFiles(x86)}\WiX Toolset v3.11\bin\", [System.EnvironmentVariableTarget]::Machine)
+#setx PATH "$Env:Path;C:\devtools\wix"
+#$Env:Path="$Env:Path;c:\devtools\wix"
+#setx WIX "C:\devtools\wix\"
+Remove-Item $out
+
+Write-Host -ForegroundColor Green Done with WiX


### PR DESCRIPTION
By removing chocolatey, we aren't rate-limited on installs/downloads.
Speeds full build from > 5 hours to ~ 1.5 hours
Will prevent intermittent build failures due to rate limiting.