### PR TITLE
Fixes stray resource group left behind in merge of previous commit.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -229,7 +229,6 @@ build_windows_2004_x64:
     BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-2004
     DD_TARGET_ARCH: x64
     WINDOWS_VERSION: 2004
-  resource_group: windows_x64
 
 .test_windows:
   extends: .test


### PR DESCRIPTION
The merge of the 2004 target & and removal of chocolatey left behind a stray `resource_group` entry, which was causing the 2004 container build to never get built.