### PR TITLE
Add 20H2 builders, update msys2 to 20201109

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -239,6 +239,16 @@ build_windows_2004_x64:
     DD_TARGET_ARCH: x64
     WINDOWS_VERSION: 2004
 
+build_windows_20h2_x64:
+  extends: .winbuild
+  tags: [ "runner:windows-docker", "windowsversion:20h2" ]
+  variables:
+    DOCKERFILE: windows/Dockerfile
+    IMAGE: windows_20h2_x64
+    BASE_IMAGE: mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-20H2
+    DD_TARGET_ARCH: x64
+    WINDOWS_VERSION: 20H2
+
 .test_windows:
   extends: .test
   timeout: 2h 00m
@@ -286,6 +296,14 @@ test_windows_2004_x64:
     ARCH: x64
     IMAGE: windows_2004_x64
 
+test_windows_20h2_x64:
+  extends: .test_windows
+  tags: [ "runner:windows-docker", "windowsversion:20h2" ]
+  needs: [ "build_windows_20h2_x64" ]
+  variables:
+    ARCH: x64
+    IMAGE: windows_20h2_x64
+
 test_windows_1909_x86:
   extends: .test_windows
   tags: [ "runner:windows-docker", "windowsversion:1909" ]
@@ -319,7 +337,7 @@ test_windows_1909_x86:
   except: [ tags, schedules ]
   only: [ master ]
   ## this always needs to be the newest available builder version
-  tags: [ "runner:windows-docker", "windowsversion:2004" ]
+  tags: [ "runner:windows-docker", "windowsversion:20h2" ]
   script:
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"
@@ -394,3 +412,9 @@ release_windows_2004_x64:
   needs: [ "test_windows_2004_x64" ]
   variables:
     IMAGE: windows_2004_x64
+
+release_windows_20h2_x64:
+  extends: .winrelease
+  needs: [ "test_windows_20h2_x64" ]
+  variables:
+    IMAGE: windows_202h_x64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -417,4 +417,4 @@ release_windows_20h2_x64:
   extends: .winrelease
   needs: [ "test_windows_20h2_x64" ]
   variables:
-    IMAGE: windows_202h_x64
+    IMAGE: windows_20h2_x64

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -79,10 +79,11 @@ RUN setx SSL_CERT_FILE \"C:\cacert.pem\"
 COPY ./windows/install_net35_1809.bat install_net35_1809.bat
 COPY ./windows/install_net35_1909.bat install_net35_1909.bat
 COPY ./windows/install_net35_2004.bat install_net35_2004.bat
+COPY ./windows/install_net35_20h2.bat install_net35_20h2.bat
 RUN if ($Env:WINDOWS_VERSION -eq '1809') { .\install_net35_1809.bat }
 RUN if ($Env:WINDOWS_VERSION -eq '1909') { .\install_net35_1909.bat }
 RUN if ($Env:WINDOWS_VERSION -eq '2004') { .\install_net35_2004.bat }
-
+RUN if ($Env:WINDOWS_VERSION -eq '20H2') { .\install_net35_20h2.bat }
 ### End of preliminary step
 
 # Install 7-zip

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -34,8 +34,7 @@ ENV RUBY_VERSION "2.4.3.1"
 ENV PYTHON_VERSION "3.8.2"
 ENV WIX_VERSION "3.11.2"
 ENV CMAKE_VERSION "3.17.2"
-ENV MSYS_VERSION "20200903.0.0"
-
+ENV MSYS_VERSION "20201109.0.0"
 ENV EMBEDDED_PYTHON_2_VERSION "2.7.17"
 ENV EMBEDDED_PYTHON_3_VERSION "3.8.1"
 
@@ -141,9 +140,7 @@ RUN powershell -C .\install_ruby.ps1 -Version $ENV:RUBY_VERSION
 copy ./windows/install_msys.ps1 install_msys.ps1
 RUN powershell -C .\install_msys.ps1 -Version $ENV:MSYS_VERSION
 
-# TODO: as soon as a new msys distribution (with working packages) is available, use it
-# and stop doing ridk install 2, which force-upgrades packages to the latest available.
-RUN ridk install 2 3
+RUN ridk install 3
 
 # (32-bit only) Install 32-bit C/C++ compilation toolchain
 RUN if ($Env:TARGET_ARCH -eq 'x86') { ridk enable; bash -c \"pacman -S --needed --noconfirm mingw-w64-i686-binutils mingw-w64-i686-crt-git mingw-w64-i686-gcc mingw-w64-i686-gcc-libs mingw-w64-i686-headers-git mingw-w64-i686-libmangle-git mingw-w64-i686-libwinpthread-git mingw-w64-i686-make mingw-w64-i686-pkg-config mingw-w64-i686-tools-git mingw-w64-i686-winpthreads-git\" }

--- a/windows/install_net35_20h2.bat
+++ b/windows/install_net35_20h2.bat
@@ -1,0 +1,21 @@
+::
+:: Installs .NET Runtime 3.5, used by Wix 3.11 and the Visual C++ Compiler for Python 2.7
+:: Taken from the mcr.microsoft.com/dotnet/framework/runtime:3.5 Dockerfile:
+;; https://github.com/microsoft/dotnet-framework-docker/blob/e0b59f4aeb47bd6bf13e4c7ec6676a1935306df9/src/runtime/3.5/windowsservercore-20H2/Dockerfile
+::
+
+set DOTNET_RUNNING_IN_CONTAINER true
+
+curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-2009.zip
+tar -zxf microsoft-windows-netfx3.zip
+del /F /Q microsoft-windows-netfx3.zip
+DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab
+del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab
+powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580419-x64-ndp48_197efbd77177abe76a587359cea77bda5398c594.msu
+mkdir patch
+expand patch.msu patch -F:*
+del /F /Q patch.msu
+DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\Windows10.0-KB4580419-x64-NDP48.cab
+rmdir /S /Q patch

--- a/windows/install_net35_20h2.bat
+++ b/windows/install_net35_20h2.bat
@@ -1,7 +1,7 @@
 ::
 :: Installs .NET Runtime 3.5, used by Wix 3.11 and the Visual C++ Compiler for Python 2.7
 :: Taken from the mcr.microsoft.com/dotnet/framework/runtime:3.5 Dockerfile:
-;; https://github.com/microsoft/dotnet-framework-docker/blob/e0b59f4aeb47bd6bf13e4c7ec6676a1935306df9/src/runtime/3.5/windowsservercore-20H2/Dockerfile
+:: https://github.com/microsoft/dotnet-framework-docker/blob/e0b59f4aeb47bd6bf13e4c7ec6676a1935306df9/src/runtime/3.5/windowsservercore-20H2/Dockerfile
 ::
 
 set DOTNET_RUNNING_IN_CONTAINER true


### PR DESCRIPTION
Adds 20H2 builders to the set of windows builders.
This commit also changes the MSYS version, which fixes the problem that the MSYS install intermittently hangs at build time.