### PR TITLE
Install invoke even if we don't install conda

### DIFF
--- a/rpm-arm/Dockerfile
+++ b/rpm-arm/Dockerfile
@@ -51,8 +51,8 @@ RUN /bin/bash -l -c "rvm install 2.3 && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Pip & Invoke
-RUN curl "https://bootstrap.pypa.io/2.7/get-pip.py" | python2.7 - pip==${DD_PIP_VERSION} setuptools==${DD_SETUPTOOLS_VERSION}
-RUN pip install invoke==1.4.1 distro==1.4.0 awscli==1.16.240
+COPY ./setup_python.sh /setup_python.sh
+RUN ./setup_python.sh
 
 # Gimme
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -10,7 +10,9 @@ case $DD_TARGET_ARCH in
     CONDA_URL=https://github.com/conda-forge/miniforge/releases/download/${DD_CONDA_VERSION}/Miniforge3-Linux-aarch64.sh
     ;;
 *)
-    echo "Not installing conda"
+    echo "Using system python since DD_TARGET_ARCH is $DD_TARGET_ARCH"
+    curl "https://bootstrap.pypa.io/2.7/get-pip.py" | python2.7 - pip==${DD_PIP_VERSION} setuptools==${DD_SETUPTOOLS_VERSION}
+    pip install invoke==1.4.1 distro==1.4.0 awscli==1.16.240
     exit 0
 esac
 


### PR DESCRIPTION
It got removed by mistake in https://github.com/DataDog/datadog-agent-buildimages/pull/111 for armhf build images, given those don't have `conda` installed.