### PR TITLE
[deb-armhf, rpm-armhf, windows] Update Python 2.7 pip url

### DIFF
--- a/setup_python.sh
+++ b/setup_python.sh
@@ -11,7 +11,7 @@ case $DD_TARGET_ARCH in
     ;;
 *)
     echo "Using system python since DD_TARGET_ARCH is $DD_TARGET_ARCH"
-    curl "https://bootstrap.pypa.io/2.7/get-pip.py" | python2.7 - pip==${DD_PIP_VERSION} setuptools==${DD_SETUPTOOLS_VERSION}
+    curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" | python2.7 - pip==${DD_PIP_VERSION} setuptools==${DD_SETUPTOOLS_VERSION}
     pip install invoke==1.4.1 distro==1.4.0 awscli==1.16.240
     exit 0
 esac

--- a/windows/install_embedded_pythons.ps1
+++ b/windows/install_embedded_pythons.ps1
@@ -65,7 +65,7 @@ setx TEST_EMBEDDED_PY2 $py2Target
 setx TEST_EMBEDDED_PY3 $py3Target
 
 cd $py2Target
-curl https://bootstrap.pypa.io/2.7/get-pip.py -o get-pip.py
+curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
 .\python get-pip.py pip==${Env:EMBEDDED_PIP_VERSION}
 
 


### PR DESCRIPTION
# What does this PR do?

Updates the pip install URL for Python 2.7 to the new correct one.

# Motivation

We're getting this error in the CI:

```
The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:
    https://bootstrap.pypa.io/pip/2.7/get-pip.py
```