### PR TITLE
Add rust to x64 builder images

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -106,6 +106,10 @@ RUN curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-deb
 # Download and install golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOPATH/bin v1.21.0
 
+# Rust is needed to compile the cryptography python lib
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.41.0
+ENV PATH "~/.cargo/bin:${PATH}"
+
 # Entrypoint
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -150,6 +150,10 @@ ENV CXX=/opt/rh/devtoolset-1.1/root/usr/bin/c++
 # Download and install golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOPATH/bin v1.21.0
 
+# Rust is needed to compile the cryptography python lib
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.41.0
+ENV PATH "~/.cargo/bin:${PATH}"
+
 # Entrypoint
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Rust is required to build the `cryptography` python dependency. However, we can currently still `pip install` the pre-compiled binary wheel of the library and avoid building it, so we don't really need Rust. At least while the binary wheel targets `manylinux2010` which these two platforms are compatible with, if in the future they start targeting only `manylinux2014` we will need Rust here.