### PR TITLE
Use runner images from ECR to avoid Dockerhub ratelimit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,14 +38,11 @@ variables:
   stage: build
   except: [ tags, schedules ]
   tags: ["runner:docker-arm", "platform:arm64"]
-  image: arm64v8/docker:18.04
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.09.6-arm64-py3
   variables:
     BASE_IMAGE: arm64v8/ubuntu:16.04
     DD_TARGET_ARCH: aarch64
   script:
-    - apk add --update python py-pip
-    - pip install awscli
-    - aws --version
     # Dockerhub login
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io


### PR DESCRIPTION
### What does this PR do?
Use an image from our private registry as the runner image.

### Motivation
Dockerhub rate-limits us if we pull images from there. We authenticate against Dockerhub within the job itself, but the runner image is pulled before that.