### PR TITLE
Update buildimage with deps for building newer libbcc

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -15,18 +15,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         g++ \
         gcc \
         git \
+        libbpf-dev \
+        libedit-dev \
         libelf-dev \
+        libfl-dev \
         libstdc++-8-dev \
         libtinfo-dev \
         libtinfo5 \
         libxml2-dev \
+        libzip-dev \
         linux-headers-arm64 \
+        linux-libc-dev \
         ninja-build \
         python \
         python3-distro \
         python3-distutils \
+        python3-netaddr \
         python3-setuptools \
         python3-pip \
+        python3-pyroute2 \
         wget \
         xz-utils
 

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         linux-headers-arm64 \
         linux-libc-dev \
         ninja-build \
+        patch \
         python \
         python3-distro \
         python3-distutils \

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         libzip-dev \
         linux-headers-arm64 \
         linux-libc-dev \
+        make \
         ninja-build \
         patch \
         python \

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -15,18 +15,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         g++ \
         gcc \
         git \
+        libbpf-dev \
+        libedit-dev \
         libelf-dev \
+        libfl-dev \
         libstdc++-8-dev \
         libtinfo-dev \
         libtinfo5 \
         libxml2-dev \
+        libzip-dev \
         linux-headers-amd64 \
+        linux-libc-dev \
         ninja-build \
         python \
         python3-distro \
         python3-distutils \
+        python3-netaddr \
         python3-setuptools \
         python3-pip \
+        python3-pyroute2 \
         wget \
         xz-utils
 

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         linux-headers-amd64 \
         linux-libc-dev \
         ninja-build \
+        patch \
         python \
         python3-distro \
         python3-distutils \

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         libzip-dev \
         linux-headers-amd64 \
         linux-libc-dev \
+        make \
         ninja-build \
         patch \
         python \


### PR DESCRIPTION
I haven't been able to verify this fixes `arm64` because Gitlab seems to be backed up on ARM builds today, but I don't see any reason why it wouldn't work.