### PR TITLE
Remove invoke from Python 2 env

### DIFF
--- a/setup_python.sh
+++ b/setup_python.sh
@@ -47,7 +47,7 @@ conda create -n ddpy3 python python=3.8
 conda activate ddpy2 \
     && pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION} \
     && pip install --ignore-installed setuptools==${DD_SETUPTOOLS_VERSION} \
-    && pip install invoke==1.4.1 distro==1.4.0 awscli==1.16.240
+    && pip install distro==1.4.0 awscli==1.16.240
 
 # Update pip, setuptools and misc deps
 conda activate ddpy3 \


### PR DESCRIPTION
We should only use invoke on Python 3 so that we don't have to be compatible with Python 2. Thanks to Kylian for the idea!