### PR TITLE
[windows] Add WebBuildTools Visual Studio Workload to build image

### DIFF
--- a/windows/install_dotnetcore.ps1
+++ b/windows/install_dotnetcore.ps1
@@ -14,7 +14,14 @@ $out = "$($PSScriptRoot)\dotnetcoresdk.exe"
 Write-Host -ForegroundColor Green Downloading $Url to $out
 (New-Object System.Net.WebClient).DownloadFile($Url, $out)
 
+# Skip extraction of XML docs - generally not useful within an image/container - helps performance
+setx NUGET_XMLDOC_MODE skip
+
 start-process -FilePath $out -ArgumentList "/install /quiet /norestart" -wait
 
 Remove-Item $out
+
+# Trigger first run experience by running arbitrary cmd
+dotnet help
+
 Write-Host -ForegroundColor Green Done with DotNet Core SDK $Version

--- a/windows/install_vstudio.ps1
+++ b/windows/install_vstudio.ps1
@@ -25,6 +25,7 @@ $VSPackages = @(
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Workload.NetCoreTools",
     "Microsoft.VisualStudio.Workload.NativeDesktop",
+    "Microsoft.VisualStudio.Workload.WebBuildTools",
     "Microsoft.NetCore.Component.SDK",
     "Microsoft.Net.Component.4.7.TargetingPack",
     "Microsoft.Net.Component.4.5.TargetingPack",


### PR DESCRIPTION
This installs the web build tools as part of the Visual Studio installation, as required by the .NET APM team. 

It also makes a slight performance optimisation to the .NET Core installation to avoid NuGet document extraction, and to prime the "first-time experience" so that this doesn't need to run on every build