### PR TITLE
Support in-house CPython

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -180,6 +180,7 @@ RUN [Environment]::SetEnvironmentVariable(\"Path\", [Environment]::GetEnvironmen
 # Set 32-bit flag env var
 RUN if ($Env:TARGET_ARCH -eq 'x86') { setx WINDOWS_BUILD_32_BIT 1 }
 
+COPY ./windows/set_cpython_compiler.cmd set_cpython_compiler.cmd
 RUN .\set_cpython_compiler.cmd
 
 COPY ./windows/entrypoint.bat /entrypoint.bat

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -180,6 +180,8 @@ RUN [Environment]::SetEnvironmentVariable(\"Path\", [Environment]::GetEnvironmen
 # Set 32-bit flag env var
 RUN if ($Env:TARGET_ARCH -eq 'x86') { setx WINDOWS_BUILD_32_BIT 1 }
 
+RUN .\set_cpython_compiler.cmd
+
 COPY ./windows/entrypoint.bat /entrypoint.bat
 COPY ./windows/aws_networking.ps1 /aws_networking.ps1
 

--- a/windows/set_cpython_compiler.cmd
+++ b/windows/set_cpython_compiler.cmd
@@ -1,0 +1,6 @@
+REM
+REM This is a tweak for the in-house CPython build which requests a weird compiler version.
+REM The registry keys will redirect the nonexisting v13.2 compiler to the local VS 2019 toolchain.
+REM
+reg add "HKEY_CURRENT_USER\Software\Microsoft\DevDiv\VCForPython\13.2" /v InstallDir     /t REG_SZ    /d C:\devtools\vstudio\VC\Auxiliary\Build\ /f
+reg add "HKEY_CURRENT_USER\Software\Microsoft\DevDiv\VCForPython\13.2" /v StartMenuItems /t REG_DWORD /d 1                                       /f


### PR DESCRIPTION
This commit creates a fake VCForPython 13.2 and point it to the local VS 2019 toolchain.