### PR TITLE
[macos] Update cmake & add -e to build scripts

### DIFF
--- a/macos/build_script.sh
+++ b/macos/build_script.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -e
 
+# FIXME: Uncomment this once we fix the way we cache the builder setup
+# in datadog-agent-macos-build, we have non-critical errors that make
+# the script fail with set -e.
+# set -e
+
+
 # Fetches the datadog-agent repo, checks out to the requested version
 # and does an omnibus build of the Agent.
 

--- a/macos/build_script.sh
+++ b/macos/build_script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Fetches the datadog-agent repo, checks out to the requested version
 # and does an omnibus build of the Agent.

--- a/macos/builder_setup.sh
+++ b/macos/builder_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Setups a MacOS builder that can do unsigned builds of the MacOS Agent.
 # The .build_setup file is populated with the correct envvar definitions to do the build,
@@ -18,7 +18,8 @@
 export PKG_CONFIG_VERSION=0.29.2
 export RUBY_VERSION=2.4.10
 export PYTHON_VERSION=3.8.5
-export CMAKE_VERSION=3.18.2
+# Pin cmake version without sphinx-doc, which causes build issues
+export CMAKE_VERSION=3.18.2.2
 export GIMME_VERSION=1.5.4
 
 export BUNDLER_VERSION=2.1.4
@@ -34,6 +35,10 @@ brew tap DataDog/datadog-agent-macos-build
 
 brew uninstall python@2 -f || true # Uninstall python 2 if present
 brew uninstall python -f || true # Uninstall python 3 if present
+
+# Install cmake
+brew install DataDog/datadog-agent-macos-build/cmake@$CMAKE_VERSION -f
+brew link --overwrite cmake@$CMAKE_VERSION
 
 # Install pkg-config
 brew install DataDog/datadog-agent-macos-build/pkg-config@$PKG_CONFIG_VERSION -f
@@ -57,10 +62,6 @@ gem install bundler -v $BUNDLER_VERSION -f
 # Install python
 brew install DataDog/datadog-agent-macos-build/python@$PYTHON_VERSION -f
 brew link --overwrite python@$PYTHON_VERSION
-
-# Install cmake (depends on python@3.8)
-brew install DataDog/datadog-agent-macos-build/cmake@$CMAKE_VERSION -f
-brew link --overwrite cmake@$CMAKE_VERSION
 
 mkdir -p $HOME/go
 export GOPATH=$HOME/go

--- a/macos/builder_setup.sh
+++ b/macos/builder_setup.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -e
 
 # Setups a MacOS builder that can do unsigned builds of the MacOS Agent.
 # The .build_setup file is populated with the correct envvar definitions to do the build,

--- a/macos/notarization_script.sh
+++ b/macos/notarization_script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Requests notarization of the Agent package to Apple.
 

--- a/macos/notarization_script.sh
+++ b/macos/notarization_script.sh
@@ -1,4 +1,9 @@
-#!/bin/bash -e
+#!/bin/bash
+
+# FIXME: Uncomment this once the build script is fixed, and we
+# check that this script doesn't accidentally exit early with set -e.
+
+# set -e
 
 # Requests notarization of the Agent package to Apple.
 


### PR DESCRIPTION
### What does this PR do?

Adds `-e` to the MacOS scripts to make them fail early.

Updates the `cmake` version we install in the builder to a version that doesn't depend on `sphinx-doc` (see [this formula](https://github.com/DataDog/homebrew-datadog-agent-macos-build/blob/master/Formula/cmake%403.18.2.2.rb)), as this dependency fails to install with `Given no hashes to check 169 links for project 'pip': discarding no candidates`.

Example run before change: https://github.com/DataDog/datadog-agent-macos-build/runs/3018046927?check_suite_focus=true
Example run after change: https://github.com/DataDog/datadog-agent-macos-build/runs/3027897093?check_suite_focus=true