### PR TITLE
[macos] Update Python & fix datadog-agent clone

### DIFF
--- a/macos/build_script.sh
+++ b/macos/build_script.sh
@@ -27,7 +27,8 @@ export KEYCHAIN_NAME=${KEYCHAIN_NAME:-"login.keychain"}
 source ~/.build_setup
 
 # Clone the repo
-go get github.com/DataDog/datadog-agent || true # Go get fails if the datadog-agent repo is already there
+mkdir -p $GOPATH/src/github.com/Datadog && cd $GOPATH/src/github.com/Datadog
+git clone https://github.com/DataDog/datadog-agent || true # git clone fails if the datadog-agent repo is already there
 cd $GOPATH/src/github.com/Datadog/datadog-agent
 
 # Checkout to correct version

--- a/macos/builder_setup.sh
+++ b/macos/builder_setup.sh
@@ -19,7 +19,7 @@ set -e
 # 2. Update here the version of the formula to use.
 export PKG_CONFIG_VERSION=0.29.2
 export RUBY_VERSION=2.4.10
-export PYTHON_VERSION=3.8.5
+export PYTHON_VERSION=3.8.11
 # Pin cmake version without sphinx-doc, which causes build issues
 export CMAKE_VERSION=3.18.2.2
 export GIMME_VERSION=1.5.4


### PR DESCRIPTION
### What does this PR do?

Updates the brew `Python@3.8` formula used to `3.8.11`, which doesn't have an issue when symlinking Python binaries.
Changes the way the datadog-agent repo is cloned (`go get` changed in go 1.16, and fails on the `datadog-agent` repo with:
```
go: downloading github.com/DataDog/datadog-agent v0.0.0-20210906104603-2ee12966bad6
go get: github.com/DataDog/datadog-agent@none updating to
	github.com/DataDog/datadog-agent@v0.0.0-20210906104603-2ee12966bad6 requires
	github.com/iovisor/gobpf@v0.0.0: reading github.com/iovisor/gobpf/go.mod at revision v0.0.0: unknown revision v0.0.0
```

Test run: https://github.com/DataDog/datadog-agent-macos-build/runs/3524423789?check_suite_focus=true