### PR TITLE
Remove unnecessary and buggy `&&`-chaining

### DIFF
--- a/setup_python.sh
+++ b/setup_python.sh
@@ -50,16 +50,16 @@ conda create -n ddpy2 python python=2
 conda create -n ddpy3 python python=$PY3_VERSION
 
 # Update pip, setuptools and misc deps
-conda activate ddpy2 \
-    && pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION} \
-    && pip install --ignore-installed setuptools==${DD_SETUPTOOLS_VERSION} \
-    && pip install distro==1.4.0 awscli==1.16.240
+conda activate ddpy2
+pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION}
+pip install --ignore-installed setuptools==${DD_SETUPTOOLS_VERSION}
+pip install distro==1.4.0 awscli==1.16.240
 
 # Update pip, setuptools and misc deps
-conda activate ddpy3 \
-    && pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION} \
-    && pip install --ignore-installed setuptools==${DD_SETUPTOOLS_VERSION} \
-    && pip install invoke==1.4.1 distro==1.4.0 awscli==1.16.240
+conda activate ddpy3
+pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION}
+pip install --ignore-installed setuptools==${DD_SETUPTOOLS_VERSION}
+pip install invoke==1.4.1 distro==1.4.0 awscli==1.16.240
 
 if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then
     # Conda creates "lib" but on Amazon Linux, the embedded Python2 we use in unit tests will look in "lib64" instead


### PR DESCRIPTION
The presence of `set -e` already implies that if a command fails, the
script will stop.  So there's no need to chain comamnds together with
`&&`.  And, such `&&` chains interact poorly with `set -e` and can cause
errors to be ignored.

https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/83605383 shows a _failed_ run that was still green.  It failed to install pip==19.1, and as a consequence didn't install invoke.

```shell
set -ex
false && true
echo UHOH
```
output:
```
+ false
+ echo UHOH
```