### PR TITLE
[deb_x64] Build go1.16 from source

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -103,6 +103,7 @@ RUN curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-deb
 # the deb_x64 builder (the builder has 2.22, while go1.16 uses 2.26). Therefore, we need to
 # build go manually in the builder for it to work with the linker present in the builder image.
 # See: https://github.com/golang/go/issues/43996#issuecomment-782547917
+# TODO: investigate if we could use gvm to do this for us.
 COPY ./setup_go.sh /setup_go.sh
 RUN ./setup_go.sh
 COPY ./gobin.sh /etc/profile.d/

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -98,7 +98,11 @@ RUN curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-deb
     rm kernel-4.9-headers-deb-x64.tgz
 
 # Go
-# Install from source because the binary distros are not compatible with go1.16
+# Starting with go1.16, we need to build go from source, as the publicly distributed
+# go binaries are built with a linker (binutils) version that's higher than what we have in
+# the deb_x64 builder (the builder has 2.22, while go1.16 uses 2.26). Therefore, we need to
+# build go manually in the builder for it to work with the linker present in the builder image.
+# See: https://github.com/golang/go/issues/43996#issuecomment-782547917
 COPY ./setup_go.sh /setup_go.sh
 RUN ./setup_go.sh
 COPY ./gobin.sh /etc/profile.d/

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:wheezy-backports
 
 # Build Args
-ARG GIMME_GO_VERSION=1.16.7
+ARG GO_VERSION=1.16.7
 ARG DD_PIP_VERSION=19.1
 ARG DD_SETUPTOOLS_VERSION=44.1.1
 ARG DD_SETUPTOOLS_VERSION_PY3=52.0.0
@@ -12,7 +12,7 @@ ARG DD_TARGET_ARCH=x64
 
 # Environment
 ENV GOPATH /go
-ENV GIMME_GO_VERSION $GIMME_GO_VERSION
+ENV GO_VERSION $GO_VERSION
 ENV DD_PIP_VERSION $DD_PIP_VERSION
 ENV DD_SETUPTOOLS_VERSION $DD_SETUPTOOLS_VERSION
 ENV DD_SETUPTOOLS_VERSION_PY3 $DD_SETUPTOOLS_VERSION_PY3
@@ -74,12 +74,6 @@ COPY ./conda.sh /etc/profile.d/conda.sh
 ENV PATH "${CONDA_PATH}/bin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
-# Gimme
-RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-RUN chmod +x /bin/gimme
-RUN gimme $GIMME_GO_VERSION
-COPY ./gobin.sh /etc/profile.d/
-
 # Docker
 # Pin docker to before they broke wheezy
 RUN curl -fsSL https://raw.githubusercontent.com/docker/docker-install/a34555fc0214be705330911071a8c3357f26e40b/install.sh | sed -e 's/ftp\.debian\.org/archive.debian.org/g' | sh
@@ -102,6 +96,12 @@ RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSI
 RUN curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-deb-x64.tgz && \
     tar xf kernel-4.9-headers-deb-x64.tgz --no-same-owner --strip 1 -C /usr && \
     rm kernel-4.9-headers-deb-x64.tgz
+
+# Go
+# Install from source because the binary distros are not compatible with go1.16
+COPY ./setup_go.sh /setup_go.sh
+RUN ./setup_go.sh
+COPY ./gobin.sh /etc/profile.d/
 
 # Download and install golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOPATH/bin v1.21.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,9 @@ if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then
 elif [ "$DD_TARGET_ARCH" = "armhf" ] ; then
     export GIMME_ARCH=arm
 fi
-eval "$(gimme)"
+
+if [ -n "$GIMME_GO_VERSION" ] ; then
+    eval "$(gimme)"
+fi
 
 exec "$@"

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+# Install gimme to get go1.15
+curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+chmod +x /bin/gimme
+eval $(gimme 1.15.11)
+
+# Install gcc 4.9 (needed to compile go, as it introduces -fdiagnostics-color which is required
+# to compile go)
+apt-get update && apt-get install -y gcc-4.9-backport
+
+git clone https://go.googlesource.com/go goroot && cd goroot
+git checkout go$GO_VERSION
+cd src 
+
+# Use the bundled clang + go 1.15.11 to build the target go version
+CC=/usr/lib/gcc-4.9-backport/bin/gcc ./all.bash
+
+# Update PATH to include the built go binaries
+echo 'export PATH="/goroot/bin:$PATH"' >> /root/.bashrc

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -3,7 +3,9 @@
 set -ex
 
 # Install gimme to get go1.15.11
-curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme
+# Check sha256sum, fail otherwise
+echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin/gimme" | sha256sum --check
 chmod +x /bin/gimme
 eval "$(gimme 1.15.11)"
 
@@ -12,8 +14,7 @@ eval "$(gimme 1.15.11)"
 # We don't add it to the PATH so that it's not used in the Agent / rtloader builds
 apt-get update && apt-get install -y gcc-4.9-backport
 
-git clone --branch "go$GO_VERSION" --depth 1 https://go.googlesource.com/go goroot && cd goroot
-cd src 
+git clone --branch "go$GO_VERSION" --depth 1 https://go.googlesource.com/go goroot && cd goroot/src
 
 # Use gcc 4.9 + go1.15.11 to build the target go version
 CC=/usr/lib/gcc-4.9-backport/bin/gcc ./all.bash

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -2,20 +2,21 @@
 
 set -ex
 
-# Install gimme to get go1.15
+# Install gimme to get go1.15.11
 curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 chmod +x /bin/gimme
 eval $(gimme 1.15.11)
 
 # Install gcc 4.9 (needed to compile go, as it introduces -fdiagnostics-color which is required
-# to compile go)
+# in the post-compilation steps of go)
+# We don't add it to the PATH so that it's not used in the Agent / rtloader builds
 apt-get update && apt-get install -y gcc-4.9-backport
 
 git clone https://go.googlesource.com/go goroot && cd goroot
 git checkout go$GO_VERSION
 cd src 
 
-# Use the bundled clang + go 1.15.11 to build the target go version
+# Use gcc 4.9 + go1.15.11 to build the target go version
 CC=/usr/lib/gcc-4.9-backport/bin/gcc ./all.bash
 
 # Update PATH to include the built go binaries

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+# Installs go from source: https://golang.org/doc/install/source#go14 using the first documented option
+# (building go with a previous binary release of go).
+# Note: the official go build uses the fourth option (bootstrap the build using go1.4), but according to the documentation
+# this shouldn't make a difference.
+
 # Install gimme to get go1.15.11
 curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme
 # Check sha256sum, fail otherwise

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -18,5 +18,8 @@ cd src
 # Use gcc 4.9 + go1.15.11 to build the target go version
 CC=/usr/lib/gcc-4.9-backport/bin/gcc ./all.bash
 
+# Remove gcc 4.9 after building go
+apt-get remove -y gcc-4.9-backport
+
 # Update PATH to include the built go binaries
 echo 'export PATH="/goroot/bin:$PATH"' >> /root/.bashrc

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -12,8 +12,7 @@ eval $(gimme 1.15.11)
 # We don't add it to the PATH so that it's not used in the Agent / rtloader builds
 apt-get update && apt-get install -y gcc-4.9-backport
 
-git clone https://go.googlesource.com/go goroot && cd goroot
-git checkout go$GO_VERSION
+git clone --branch go$GO_VERSION --depth 1 https://go.googlesource.com/go goroot && cd goroot
 cd src 
 
 # Use gcc 4.9 + go1.15.11 to build the target go version

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -5,14 +5,14 @@ set -ex
 # Install gimme to get go1.15.11
 curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 chmod +x /bin/gimme
-eval $(gimme 1.15.11)
+eval "$(gimme 1.15.11)"
 
 # Install gcc 4.9 (needed to compile go, as it introduces -fdiagnostics-color which is required
 # in the post-compilation steps of go)
 # We don't add it to the PATH so that it's not used in the Agent / rtloader builds
 apt-get update && apt-get install -y gcc-4.9-backport
 
-git clone --branch go$GO_VERSION --depth 1 https://go.googlesource.com/go goroot && cd goroot
+git clone --branch "go$GO_VERSION" --depth 1 https://go.googlesource.com/go goroot && cd goroot
 cd src 
 
 # Use gcc 4.9 + go1.15.11 to build the target go version
@@ -26,7 +26,7 @@ apt-get remove -y gcc-4.9-backport
 # but here since CC is more specific, cgo will try to find gcc
 # in /usr/lib/gcc-4.9-backport/bin/gcc
 mkdir -p /usr/lib/gcc-4.9-backport/bin
-ln -s $(which gcc) /usr/lib/gcc-4.9-backport/bin/gcc
+ln -s "$(which gcc)" /usr/lib/gcc-4.9-backport/bin/gcc
 
 # Update PATH to include the built go binaries
 echo 'export PATH="/goroot/bin:$PATH"' >> /root/.bashrc

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -21,5 +21,12 @@ CC=/usr/lib/gcc-4.9-backport/bin/gcc ./all.bash
 # Remove gcc 4.9 after building go
 apt-get remove -y gcc-4.9-backport
 
+# HACK: cgo tries to look for gcc in the same place that CC
+# pointed to when go was compiled. By default, this is fine (since CC=gcc),
+# but here since CC is more specific, cgo will try to find gcc
+# in /usr/lib/gcc-4.9-backport/bin/gcc
+mkdir -p /usr/lib/gcc-4.9-backport/bin
+ln -s $(which gcc) /usr/lib/gcc-4.9-backport/bin/gcc
+
 # Update PATH to include the built go binaries
 echo 'export PATH="/goroot/bin:$PATH"' >> /root/.bashrc


### PR DESCRIPTION
### What does this PR do?

Builds `go1.16` from source in the `deb_x64` builder, using `gcc 4.9` and `go1.15.11`.


### Motivation

With the publicly distributed `go1.16` binaries, some weird linker errors appear. For instance, `inv -e install-tools` fails with:
```
/root/.gimme/versions/go1.16.7.linux.amd64/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-101083533/000010.o(.text+0x74): unresolvable AWAVAUATUSH��h�*H�T$(������ relocation against symbol `stderr@@GLIBC_2.2.5'
/usr/bin/ld: BFD (GNU Binutils for Debian) 2.22 internal error, aborting at ../../bfd/reloc.c line 443 in bfd_get_reloc_size
/usr/bin/ld: Please report this bug.
```

According to https://github.com/golang/go/issues/43996#issuecomment-782547917, this is due to the builder having a lower `binutils` version than what was used to build the publicly distributed go binaries.