### PR TITLE
Create omnibus-nikos_arm64 image & fix omnibus-nikos_x64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,6 +104,12 @@ build_omnibus-nikos_x64:
     DOCKERFILE: omnibus-nikos_x64/Dockerfile
     IMAGE: omnibus-nikos_x64
 
+build_omnibus-nikos_arm64:
+  extends: [ .build, .arm ]
+  variables:
+    DOCKERFILE: omnibus-nikos_arm64/Dockerfile
+    IMAGE: omnibus-nikos_arm64
+
 .test:
   stage: test
   except: [ tags, schedules ]

--- a/omnibus-nikos_arm64/Dockerfile
+++ b/omnibus-nikos_arm64/Dockerfile
@@ -1,0 +1,58 @@
+FROM arm64v8/ubuntu:16.04
+
+# Build Args
+ARG GIMME_GO_VERSION=1.16.7
+ARG CLANG_VERSION=8.0.0
+
+# Environment
+ENV GOPATH /go
+ENV CONDA_PATH /root/miniconda3
+ENV GIMME_GO_VERSION $GIMME_GO_VERSION
+ENV CLANG_VERSION $CLANG_VERSION
+
+RUN apt-get update && apt-get install -y fakeroot cmake curl bzip2 g++ gcc git \
+  build-essential pkg-config libssl-dev libcurl4-openssl-dev libz-dev \
+  tar pkg-config wget xz-utils zlib1g-dev
+
+# RVM
+COPY ./rvm/gpg-keys /gpg-keys
+RUN gpg --import /gpg-keys/*
+RUN rm -rf /gpg-keys
+RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
+RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm install 2.6.6 && rvm cleanup all"
+RUN /bin/bash -l -c "gem install bundler --no-document"
+
+# Install python 3.8
+RUN curl -O -k https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tar.xz && \
+        tar -xf Python-3.8.0.tar.xz -C /tmp/
+RUN cd /tmp/Python-3.8.0 && ./configure
+RUN cd /tmp/Python-3.8.0 && make -j 8 && make install
+
+RUN python3.8 -m pip install --upgrade pip --user
+RUN python3.8 -m pip install awscli meson ninja
+
+# Install clang and llvm version 8
+RUN curl -sL -o clang_llvm.tar.xz https://dd-agent-omnibus.s3.amazonaws.com/clang%2Bllvm-${CLANG_VERSION}-aarch64-linux.tar.xz && \
+    tar xf clang_llvm.tar.xz --no-same-owner -kC / && \
+    rm clang_llvm.tar.xz
+ENV PATH="/opt/clang/bin:$PATH"
+
+# Gimme
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN chmod +x /bin/gimme
+RUN gimme $GIMME_GO_VERSION
+COPY ./gobin.sh /etc/profile.d/
+
+# Automake
+RUN curl -OL https://ftp.gnu.org/gnu/automake/automake-1.16.tar.gz
+RUN tar xzf automake-1.16.tar.gz
+COPY ./omnibus-nikos_x64/automake.patch automake-1.16/automake.patch
+RUN cd automake-1.16 && patch -p1 < automake.patch
+RUN cd automake-1.16 && ./bootstrap && ./configure --prefix=/usr/local && make -j 5 && make install
+RUN rm -rf automake-1.16 automake-1.16.tar.gz
+
+COPY ./entrypoint-sysprobe.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -2,23 +2,17 @@ FROM debian:wheezy-backports
 
 # Build Args
 ARG GIMME_GO_VERSION=1.16.7
-ARG DD_PIP_VERSION=19.1
-ARG DD_SETUPTOOLS_VERSION=44.1.1
-ARG DD_SETUPTOOLS_VERSION_PY3=52.0.0
 ARG CMAKE_VERSION=3.14.4
 ARG CLANG_VERSION=8.0.0
-ARG DD_TARGET_ARCH=x64
+ARG CONDA_VERSION=4.9.2
 
 # Environment
 ENV GOPATH /go
+ENV CONDA_PATH /root/miniconda3
 ENV GIMME_GO_VERSION $GIMME_GO_VERSION
-ENV DD_PIP_VERSION $DD_PIP_VERSION
-ENV DD_SETUPTOOLS_VERSION $DD_SETUPTOOLS_VERSION
-ENV DD_SETUPTOOLS_VERSION_PY3 $DD_SETUPTOOLS_VERSION_PY3
 ENV CMAKE_VERSION $CMAKE_VERSION
 ENV CLANG_VERSION $CLANG_VERSION
-ENV CONDA_PATH /root/miniconda3
-ENV DD_TARGET_ARCH $DD_TARGET_ARCH
+ENV CONDA_VERSION $CONDA_VERSION
 
 # Mitigation for CVE-2019-3462
 RUN echo 'Acquire::http::AllowRedirect"false";' >> /etc/apt/apt.conf.d/20datadog
@@ -53,17 +47,28 @@ RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.6.6 && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 
-# CONDA
-COPY ./setup_python.sh /setup_python.sh
-RUN ./setup_python.sh
+# Use conda to install gcc
+RUN curl -fsL -o ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py39_${CONDA_VERSION}-Linux-x86_64.sh
+RUN bash ~/miniconda.sh -b -p $CONDA_PATH
+RUN rm ~/miniconda.sh
 COPY ./conda.sh /etc/profile.d/conda.sh
 ENV PATH "${CONDA_PATH}/bin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
-
 RUN conda install -c psi4 gcc-5
-RUN conda install -c anaconda python=3.8
 
-RUN python -m pip install awscli meson ninja
+# Install ssl in a custom location
+RUN wget http://www.openssl.org/source/openssl-1.1.1k.tar.gz
+RUN tar -xzf openssl-1.1.1k.tar.gz
+RUN cd openssl-1.1.1k && ./config --prefix=/home/openssl --openssldir=/home/openssl
+RUN cd openssl-1.1.1k && make -j 8 && make install
+
+# Install python3.8 with custom openssl
+RUN curl -O -k https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tar.xz
+RUN tar -xf Python-3.8.0.tar.xz -C /tmp/
+RUN cd /tmp/Python-3.8.0 && LDFLAGS="${LDFLAGS} -Wl,-rpath=/home/openssl/lib" ./configure --with-openssl=/home/openssl
+RUN cd /tmp/Python-3.8.0 && make -j 8 && make install
+
+RUN python3.8 -m pip install awscli meson ninja
 
 # Install clang and llvm version 8
 # Using build for sles11 because the versions built for other distros target glibcs that are too new to be used from this image

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         make \
         ninja-build \
         patch \
+        pkg-config \
         python \
         python3-distro \
         python3-distutils \


### PR DESCRIPTION
- Creates a new build image so we can build `omnibus-nikos` on arm
- Supercedes #159 with a better (less hacky) fix to the openssl issues affecting the `omnibus-nikos` build on x64
- Adds `pkg-config` to the system-probe arm build image