### PR TITLE
Update OpenSSL to fix connection errors after Let's Encrypt root cert expiration

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -32,6 +32,13 @@ RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
     gettext libtool autopoint autoconf libtool-bin \
     selinux-basics
 
+# CONDA
+COPY ./setup_python.sh /setup_python.sh
+RUN ./setup_python.sh
+COPY ./conda.sh /etc/profile.d/conda.sh
+ENV PATH "${CONDA_PATH}/bin:${PATH}"
+ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+
 # RVM
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
@@ -39,18 +46,11 @@ RUN rm -rf /gpg-keys
 RUN curl -sSL https://get.rvm.io | bash -s stable
 RUN /bin/bash -l -c "rvm requirements"
 RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then \
-        /bin/bash -l -c "rvm install 2.7 && rvm cleanup all" ; \
+        /bin/bash -l -c "rvm install --with-openssl-dir=${CONDA_PATH} 2.7 && rvm cleanup all" ; \
     else \
-        /bin/bash -l -c "rvm install --with-arch='armv7-a' -C '--build' -C 'arm-linux-gnueabihf' 2.7 && rvm cleanup all" ; \
+        /bin/bash -l -c "rvm install --with-openssl-dir=${CONDA_PATH} --with-arch='armv7-a' -C '--build' -C 'arm-linux-gnueabihf' 2.7 && rvm cleanup all" ; \
     fi
 RUN /bin/bash -l -c "gem install bundler --no-document"
-
-# CONDA
-COPY ./setup_python.sh /setup_python.sh
-RUN ./setup_python.sh
-COPY ./conda.sh /etc/profile.d/conda.sh
-ENV PATH "${CONDA_PATH}/bin:${PATH}"
-ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
 # Gimme
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -1,3 +1,8 @@
+FROM ubuntu as CURL_GETTER
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-armv7
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-aarch64
+
 ## Valid archs are
 # amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 ARG BASE_IMAGE=arm64v8/ubuntu:16.04
@@ -31,6 +36,16 @@ RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
     build-essential pkg-config tar libsystemd-dev libkrb5-dev \
     gettext libtool autopoint autoconf libtool-bin \
     selinux-basics
+
+# Update curl with a statically linked binary
+COPY --from=CURL_GETTER /curl-aarch64 /usr/bin/curl-aarch64
+COPY --from=CURL_GETTER /curl-armv7 /usr/bin/curl-armv7
+RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then \
+        cp /usr/bin/curl-aarch64 /usr/bin/curl; \
+    else \
+        cp /usr/bin/curl-armv7 /usr/bin/curl; \
+    fi
+RUN chmod +x /usr/bin/curl
 
 # CONDA
 COPY ./setup_python.sh /setup_python.sh

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_IMAGE=arm64v8/ubuntu:16.04
+
 FROM ubuntu as CURL_GETTER
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-armv7
@@ -5,7 +7,6 @@ RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1
 
 ## Valid archs are
 # amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-ARG BASE_IMAGE=arm64v8/ubuntu:16.04
 FROM ${BASE_IMAGE}
 
 # Build Args

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -1,3 +1,7 @@
+FROM ubuntu as CURL_GETTER
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-amd64
+
 FROM debian:wheezy-backports
 
 # Build Args
@@ -34,12 +38,16 @@ RUN echo "deb http://archive.debian.org/debian wheezy main contrib non-free" > /
  echo "deb http://archive.debian.org/debian wheezy-backports main contrib non-free" > /etc/apt/sources.list.d/backports.list && \
  echo "deb http://archive.debian.org/debian-security wheezy/updates main contrib non-free" > /etc/apt/sources.list.d/security.list
 
-RUN apt-get update && apt-get install -y fakeroot curl procps bzip2 \
+RUN apt-get update && apt-get install -y fakeroot procps bzip2 \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libz-dev \
   rpm tar gettext libtool autopoint autoconf pkg-config flex \
   selinux-basics
 
 RUN apt-get install -y libsystemd-journal-dev/wheezy-backports
+
+# Update curl with a statically linked binary
+COPY --from=CURL_GETTER /curl-amd64 /usr/bin/curl
+RUN chmod +x /usr/bin/curl
 
 # Git
 RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-2.10.1.tar.gz

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -58,21 +58,21 @@ RUN mkdir -p /opt/mqm \
     && tar -C /opt/mqm -xf /tmp/mq_client.tar.gz \
     && rm -rf /tmp/mq_client.tar.gz
 
-# RVM
-COPY ./rvm/gpg-keys /gpg-keys
-RUN gpg --import /gpg-keys/*
-RUN rm -rf /gpg-keys
-RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
-RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.7 && rvm cleanup all"
-RUN /bin/bash -l -c "gem install bundler --no-document"
-
 # CONDA
 COPY ./setup_python.sh /setup_python.sh
 RUN ./setup_python.sh
 COPY ./conda.sh /etc/profile.d/conda.sh
 ENV PATH "${CONDA_PATH}/bin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+
+# RVM
+COPY ./rvm/gpg-keys /gpg-keys
+RUN gpg --import /gpg-keys/*
+RUN rm -rf /gpg-keys
+RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
+RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
+RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Docker
 # Pin docker to before they broke wheezy

--- a/omnibus-nikos_arm64/Dockerfile
+++ b/omnibus-nikos_arm64/Dockerfile
@@ -1,3 +1,7 @@
+FROM ubuntu as CURL_GETTER
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-aarch64
+
 FROM arm64v8/ubuntu:16.04
 
 # Build Args
@@ -6,13 +10,16 @@ ARG CLANG_VERSION=8.0.0
 
 # Environment
 ENV GOPATH /go
-ENV CONDA_PATH /root/miniconda3
 ENV GIMME_GO_VERSION $GIMME_GO_VERSION
 ENV CLANG_VERSION $CLANG_VERSION
 
 RUN apt-get update && apt-get install -y fakeroot cmake curl bzip2 g++ gcc git \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libz-dev \
   tar pkg-config xz-utils zlib1g-dev
+
+# Update curl with a statically linked binary
+COPY --from=CURL_GETTER /curl-aarch64 /usr/bin/curl
+RUN chmod +x /usr/bin/curl
 
 # RVM
 COPY ./rvm/gpg-keys /gpg-keys

--- a/omnibus-nikos_arm64/Dockerfile
+++ b/omnibus-nikos_arm64/Dockerfile
@@ -12,7 +12,7 @@ ENV CLANG_VERSION $CLANG_VERSION
 
 RUN apt-get update && apt-get install -y fakeroot cmake curl bzip2 g++ gcc git \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libz-dev \
-  tar pkg-config wget xz-utils zlib1g-dev
+  tar pkg-config xz-utils zlib1g-dev
 
 # RVM
 COPY ./rvm/gpg-keys /gpg-keys

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -1,3 +1,7 @@
+FROM ubuntu as CURL_GETTER
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-amd64
+
 FROM debian:wheezy-backports
 
 # Build Args
@@ -26,9 +30,13 @@ RUN echo "deb http://archive.debian.org/debian wheezy main contrib non-free" > /
  echo "deb http://archive.debian.org/debian wheezy-backports main contrib non-free" > /etc/apt/sources.list.d/backports.list && \
  echo "deb http://archive.debian.org/debian-security wheezy/updates main contrib non-free" > /etc/apt/sources.list.d/security.list
 
-RUN apt-get update && apt-get install -y fakeroot cmake curl bzip2 g++ git \
+RUN apt-get update && apt-get install -y fakeroot cmake bzip2 g++ git \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libz-dev \
   tar pkg-config xz-utils zlib1g-dev
+
+# Update curl with a statically linked binary
+COPY --from=CURL_GETTER /curl-amd64 /usr/bin/curl
+RUN chmod +x /usr/bin/curl
 
 # CMake
 RUN set -ex \

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -28,7 +28,7 @@ RUN echo "deb http://archive.debian.org/debian wheezy main contrib non-free" > /
 
 RUN apt-get update && apt-get install -y fakeroot cmake curl bzip2 g++ git \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libz-dev \
-  tar pkg-config wget xz-utils zlib1g-dev
+  tar pkg-config xz-utils zlib1g-dev
 
 # CMake
 RUN set -ex \
@@ -57,7 +57,7 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 RUN conda install -c psi4 gcc-5
 
 # Install ssl in a custom location
-RUN wget http://www.openssl.org/source/openssl-1.1.1k.tar.gz
+RUN curl -L -O http://www.openssl.org/source/openssl-1.1.1k.tar.gz
 RUN tar -xzf openssl-1.1.1k.tar.gz
 RUN cd openssl-1.1.1k && ./config --prefix=/home/openssl --openssldir=/home/openssl
 RUN cd openssl-1.1.1k && make -j 8 && make install

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -46,15 +46,6 @@ RUN set -ex \
     && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake \
     && rm cmake.sh
 
-# RVM
-COPY ./rvm/gpg-keys /gpg-keys
-RUN gpg --import /gpg-keys/*
-RUN rm -rf /gpg-keys
-RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
-RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.6.6 && rvm cleanup all"
-RUN /bin/bash -l -c "gem install bundler --no-document"
-
 # Use conda to install gcc
 RUN curl -fsL -o ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py39_${CONDA_VERSION}-Linux-x86_64.sh
 RUN bash ~/miniconda.sh -b -p $CONDA_PATH
@@ -63,6 +54,15 @@ COPY ./conda.sh /etc/profile.d/conda.sh
 ENV PATH "${CONDA_PATH}/bin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 RUN conda install -c psi4 gcc-5
+
+# RVM
+COPY ./rvm/gpg-keys /gpg-keys
+RUN gpg --import /gpg-keys/*
+RUN rm -rf /gpg-keys
+RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
+RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm install 2.6.6 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
+RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Install ssl in a custom location
 RUN curl -L -O http://www.openssl.org/source/openssl-1.1.1k.tar.gz

--- a/rpm-arm/Dockerfile
+++ b/rpm-arm/Dockerfile
@@ -1,8 +1,9 @@
+ARG BASE_IMAGE=arm32v7/centos:7
+
 FROM ubuntu as CURL_GETTER
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-armv7
 
-ARG BASE_IMAGE=arm32v7/centos:7
 FROM ${BASE_IMAGE}
 
 # Build Args

--- a/rpm-arm/Dockerfile
+++ b/rpm-arm/Dockerfile
@@ -1,8 +1,9 @@
 ARG BASE_IMAGE=arm32v7/centos:7
 
-FROM ubuntu as CURL_GETTER
+FROM ubuntu as CERT_GETTER
+ENV CACERT_BUNDLE_VERSION=2021-09-30
 RUN apt-get update && apt-get install -y wget
-RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-armv7
+RUN wget https://curl.se/ca/cacert-${CACERT_BUNDLE_VERSION}.pem -O /cacert.pem
 
 FROM ${BASE_IMAGE}
 
@@ -41,9 +42,7 @@ RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-lib
     bzip2-devel e2fsprogs-devel file-devel libacl-devel libarchive-devel libattr-devel \
     libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel
 
-# Update curl with a statically linked binary
-COPY --from=CURL_GETTER /curl-armv7 /usr/bin/curl
-RUN chmod +x /usr/bin/curl
+COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
 
 # Build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp

--- a/rpm-arm/Dockerfile
+++ b/rpm-arm/Dockerfile
@@ -1,3 +1,7 @@
+FROM ubuntu as CURL_GETTER
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-armv7
+
 ARG BASE_IMAGE=arm32v7/centos:7
 FROM ${BASE_IMAGE}
 
@@ -35,6 +39,10 @@ RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-lib
     libtool autoconf policycoreutils-python \
     bzip2-devel e2fsprogs-devel file-devel libacl-devel libarchive-devel libattr-devel \
     libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel
+
+# Update curl with a statically linked binary
+COPY --from=CURL_GETTER /curl-armv7 /usr/bin/curl
+RUN chmod +x /usr/bin/curl
 
 # Build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -1,8 +1,9 @@
 ARG BASE_IMAGE=amazonlinux:2.0.20181114
 
-FROM ubuntu as CURL_GETTER
+FROM ubuntu as CERT_GETTER
+ENV CACERT_BUNDLE_VERSION=2021-09-30
 RUN apt-get update && apt-get install -y wget
-RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-aarch64
+RUN wget https://curl.se/ca/cacert-${CACERT_BUNDLE_VERSION}.pem -O /cacert.pem
 
 FROM ${BASE_IMAGE}
 
@@ -34,9 +35,7 @@ RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-lib
     bzip2-devel e2fsprogs-devel file-devel libacl-devel libarchive-devel libattr-devel \
     libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel
 
-# Update curl with a statically linked binary
-COPY --from=CURL_GETTER /curl-aarch64 /usr/bin/curl
-RUN chmod +x /usr/bin/curl
+COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
 
 # Build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -1,3 +1,7 @@
+FROM ubuntu as CURL_GETTER
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-aarch64
+
 ARG BASE_IMAGE=amazonlinux:2.0.20181114
 FROM ${BASE_IMAGE}
 
@@ -28,6 +32,10 @@ RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-lib
     libtool autoconf policycoreutils-python \
     bzip2-devel e2fsprogs-devel file-devel libacl-devel libarchive-devel libattr-devel \
     libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel
+
+# Update curl with a statically linked binary
+COPY --from=CURL_GETTER /curl-aarch64 /usr/bin/curl
+RUN chmod +x /usr/bin/curl
 
 # Build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -1,8 +1,9 @@
+ARG BASE_IMAGE=amazonlinux:2.0.20181114
+
 FROM ubuntu as CURL_GETTER
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-aarch64
 
-ARG BASE_IMAGE=amazonlinux:2.0.20181114
 FROM ${BASE_IMAGE}
 
 # Build Args

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -60,7 +60,7 @@ RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
 RUN curl -sSL https://get.rvm.io | bash -s stable
 RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=/root/miniconda3/envs/ddpy3/ && rvm cleanup all"
+RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Gimme

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -47,21 +47,21 @@ RUN mkdir -p /usr/local/var/lib/rpm \
     && cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages \
     && /usr/local/bin/rpm --rebuilddb
 
-# RVM
-COPY ./rvm/gpg-keys /gpg-keys
-RUN gpg --import /gpg-keys/*
-RUN rm -rf /gpg-keys
-RUN curl -sSL https://get.rvm.io | bash -s stable
-RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.7 && rvm cleanup all"
-RUN /bin/bash -l -c "gem install bundler --no-document"
-
 # CONDA
 COPY ./setup_python.sh /setup_python.sh
 RUN ./setup_python.sh
 COPY ./conda.sh /etc/profile.d/conda.sh
 ENV PATH "${CONDA_PATH}/bin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+
+# RVM
+COPY ./rvm/gpg-keys /gpg-keys
+RUN gpg --import /gpg-keys/*
+RUN rm -rf /gpg-keys
+RUN curl -sSL https://get.rvm.io | bash -s stable
+RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=/root/miniconda3/envs/ddpy3/ && rvm cleanup all"
+RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Gimme
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -96,7 +96,7 @@ RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
 RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
 RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=/root/miniconda3/envs/ddpy3/ && rvm cleanup all"
+RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Gimme

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -37,6 +37,9 @@ RUN yum -y install \
   bzip2-devel e2fsprogs-devel file-devel libacl-devel libattr-devel \
   libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel
 
+# We install our own ruby, let's remove the system one. It made rvm fail to build ruby for some reason
+RUN yum remove -y ruby
+
 # Autoconf
 # We need a newer version of autoconf to compile procps-ng and also new rpm version (installing 2.69 over 2.63).
 RUN curl -sL -o /tmp/autoconf-2.69.tar.gz https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -83,21 +83,21 @@ RUN rm -rf git-2.10.1 git-2.10.1.tar.gz
 RUN git config --global user.email "package@datadoghq.com"
 RUN git config --global user.name "Bits"
 
-# RVM
-COPY ./rvm/gpg-keys /gpg-keys
-RUN gpg --import /gpg-keys/*
-RUN rm -rf /gpg-keys
-RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
-RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.7 && rvm cleanup all"
-RUN /bin/bash -l -c "gem install bundler --no-document"
-
 # CONDA
 COPY ./setup_python.sh /setup_python.sh
 RUN ./setup_python.sh
 COPY ./conda.sh /etc/profile.d/conda.sh
 ENV PATH "${CONDA_PATH}/bin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+
+# RVM
+COPY ./rvm/gpg-keys /gpg-keys
+RUN gpg --import /gpg-keys/*
+RUN rm -rf /gpg-keys
+RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
+RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=/root/miniconda3/envs/ddpy3/ && rvm cleanup all"
+RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Gimme
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -1,3 +1,7 @@
+FROM ubuntu as CURL_GETTER
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-amd64
+
 FROM centos:6
 
 # Build Args
@@ -39,6 +43,10 @@ RUN yum -y install \
 
 # We install our own ruby, let's remove the system one. It made rvm fail to build ruby for some reason
 RUN yum remove -y ruby
+
+# Update curl with a statically linked binary
+COPY --from=CURL_GETTER /curl-amd64 /usr/bin/curl
+RUN chmod +x /usr/bin/curl
 
 # Autoconf
 # We need a newer version of autoconf to compile procps-ng and also new rpm version (installing 2.69 over 2.63).

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -96,7 +96,7 @@ RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
 RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
 RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
+RUN /bin/bash -l -c "rvm install 2.6 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Gimme

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu as CURL_GETTER
+FROM ubuntu as CERT_GETTER
 RUN apt-get update && apt-get install -y wget
-RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-amd64
+ENV CACERT_BUNDLE_VERSION=2021-09-30
+RUN wget https://curl.se/ca/cacert-${CACERT_BUNDLE_VERSION}.pem -O /cacert.pem
 
 FROM centos:6
 
@@ -41,12 +42,10 @@ RUN yum -y install \
   bzip2-devel e2fsprogs-devel file-devel libacl-devel libattr-devel \
   libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel
 
+COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
+
 # We install our own ruby, let's remove the system one. It made rvm fail to build ruby for some reason
 RUN yum remove -y ruby
-
-# Update curl with a statically linked binary
-COPY --from=CURL_GETTER /curl-amd64 /usr/bin/curl
-RUN chmod +x /usr/bin/curl
 
 # Autoconf
 # We need a newer version of autoconf to compile procps-ng and also new rpm version (installing 2.69 over 2.63).


### PR DESCRIPTION
Context:
The system openssl was old and due to a [bug](https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/) it was trying to use an expired cert and failing when connecting to sites that used letsencrypt after their root cert changed.

Fix:
- Update `curl` (using a statically-linked binary) to a newer version, which doesn't use the system certs.
- Make `rvm` build ruby to use openssl from miniconda (which is kept up-to-date, together with their its own cacerts) instead of the system openssl.
- Remove `wget` from all builders, which would use the old system openssl