### PR TITLE
Upgrade msys then downgrade gcc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -198,14 +198,6 @@ build_windows_1809_x64:
     IMAGE: windows_1809_x64
     DD_TARGET_ARCH: x64
 
-build_windows_1809_x86:
-  extends: .winbuild
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
-  variables:
-    DOCKERFILE: windows/Dockerfile
-    IMAGE: windows_1809_x86
-    DD_TARGET_ARCH: x86
-
 build_windows_1909_x64:
   extends: .winbuild
   tags: [ "runner:windows-docker", "windowsversion:1909" ]
@@ -213,14 +205,6 @@ build_windows_1909_x64:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_1909_x64
     DD_TARGET_ARCH: x64
-
-build_windows_1909_x86:
-  extends: .winbuild
-  tags: [ "runner:windows-docker", "windowsversion:1909" ]
-  variables:
-    DOCKERFILE: windows/Dockerfile
-    IMAGE: windows_1909_x86
-    DD_TARGET_ARCH: x86
 
 build_windows_2004_x64:
   extends: .winbuild
@@ -261,14 +245,6 @@ test_windows_1809_x64:
     ARCH: x64
     IMAGE: windows_1809_x64
 
-test_windows_1809_x86:
-  extends: .test_windows
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
-  needs: [ "build_windows_1809_x86" ]
-  variables:
-    ARCH: x86
-    IMAGE: windows_1809_x86
-
 test_windows_1909_x64:
   extends: .test_windows
   tags: [ "runner:windows-docker", "windowsversion:1909" ]
@@ -292,14 +268,6 @@ test_windows_20h2_x64:
   variables:
     ARCH: x64
     IMAGE: windows_20h2_x64
-
-test_windows_1909_x86:
-  extends: .test_windows
-  tags: [ "runner:windows-docker", "windowsversion:1909" ]
-  needs: [ "build_windows_1909_x86" ]
-  variables:
-    ARCH: x86
-    IMAGE: windows_1909_x86
 
 .release:
   stage: release
@@ -399,12 +367,6 @@ release_windows_1809_x64:
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64
     DOCKERHUB_TAG_PREFIX: "1809"
 
-release_windows_1809_x86:
-  extends: .winrelease
-  needs: [ "test_windows_1809_x86" ]
-  variables:
-    IMAGE: windows_1809_x86
-
 release_windows_1909_x64:
   extends: .winrelease
   needs: [ "test_windows_1909_x64" ]
@@ -412,12 +374,6 @@ release_windows_1909_x64:
     IMAGE: windows_1909_x64
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64
     DOCKERHUB_TAG_PREFIX: "1909"
-
-release_windows_1909_x86:
-  extends: .winrelease
-  needs: [ "test_windows_1909_x86" ]
-  variables:
-    IMAGE: windows_1909_x86
 
 release_windows_2004_x64:
   extends: .winrelease

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -35,10 +35,7 @@ ENV RUBY_VERSION "2.6.6-1"
 ENV PYTHON_VERSION "3.8.2"
 ENV WIX_VERSION "3.11.2"
 ENV CMAKE_VERSION "3.17.2"
-# WARN: We currently can't update the msys distribution, as updating it gives us a version of go that's too new,
-# which makes go fail during -race tests. See the discussion in this PR: https://github.com/DataDog/datadog-agent/pull/9074
-# TODO: check when this issue is fixed in Go, then try updating again.
-ENV MSYS_VERSION "20201109.0.0"
+ENV MSYS_VERSION "20210725"
 ENV NUGET_VERSION "5.8.0"
 ENV EMBEDDED_PYTHON_2_VERSION "2.7.17"
 ENV EMBEDDED_PYTHON_3_VERSION "3.8.1"

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -154,9 +154,10 @@ RUN powershell -C .\install_msys.ps1 -Version $ENV:MSYS_VERSION
 
 RUN ridk install 3
 
-# (32-bit only) Install 32-bit C/C++ compilation toolchain
-RUN if ($Env:TARGET_ARCH -eq 'x86') { ridk enable; bash -c \"pacman -S --needed --noconfirm mingw-w64-i686-binutils mingw-w64-i686-crt-git mingw-w64-i686-gcc mingw-w64-i686-gcc-libs mingw-w64-i686-headers-git mingw-w64-i686-libmangle-git mingw-w64-i686-libwinpthread-git mingw-w64-i686-make mingw-w64-i686-pkg-config mingw-w64-i686-tools-git mingw-w64-i686-winpthreads-git\" }
-RUN if ($Env:TARGET_ARCH -eq 'x86') { [Environment]::SetEnvironmentVariable(\"Path\", [Environment]::GetEnvironmentVariable(\"Path\", [EnvironmentVariableTarget]::Machine) + \";C:\tools\msys64\mingw32\bin;C:\tools\msys64\usr\bin\", [System.EnvironmentVariableTarget]::Machine) }
+# Downgrade gcc due to an incompatibility between gcc 10.3 and go 1.15 and 1.16
+RUN (New-Object System.Net.WebClient).DownloadFile(\"https://s3.amazonaws.com/dd-agent-omnibus/mingw-w64-x86_64-gcc-10.2.0-11-any.pkg.tar.zst\", \"C:/mingw-w64-x86_64-gcc-10.2.0-11-any.pkg.tar.zst\")
+RUN (New-Object System.Net.WebClient).DownloadFile(\"https://s3.amazonaws.com/dd-agent-omnibus/mingw-w64-x86_64-gcc-libs-10.2.0-11-any.pkg.tar.zst\", \"C:/mingw-w64-x86_64-gcc-libs-10.2.0-11-any.pkg.tar.zst\")
+RUN C:\tools\msys64\msys2_shell.cmd -defterm -no-start -c \"pacman --noconfirm -U /c/mingw-w64-x86_64-gcc-libs-10.2.0-11-any.pkg.tar.zst /c/mingw-w64-x86_64-gcc-10.2.0-11-any.pkg.tar.zst\"
 
 # Install aws cli
 COPY ./windows/install_awscli.ps1 install_awscli.ps1

--- a/windows/install_msys.ps1
+++ b/windows/install_msys.ps1
@@ -31,10 +31,7 @@ $ErrorActionPreference = 'Stop'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 # http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200629.tar.xz
-$splitver = $Version.split(".")
-$msysver = "$($splitver[0])" 
-
-$msyszip = "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-$($msysver).tar.xz"
+$msyszip = "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-$($Version).tar.xz"
 
 Write-Host  -ForegroundColor Green starting with MSYS
 $out = "$($PSScriptRoot)\msys.tar.xz"


### PR DESCRIPTION
Changes to the Windows builders:
- Upgrade msys to 20210725
- Downgrade gcc to 10.2 due to an incompatibility between gcc 10.3 and go 1.15 and 1.16
- Remove unused x86 builders

Packages for gcc 10.2 are mirrored in the `dd-agent-omnibus` bucket.