### PR TITLE
Add one more Visual Studio feature for F# test build in dd-trace-dotnet

### DIFF
--- a/windows/install_vstudio.ps1
+++ b/windows/install_vstudio.ps1
@@ -32,6 +32,7 @@ $VSPackages = @(
     "Microsoft.Net.Component.4.6.1.TargetingPack",
     "Microsoft.Net.Component.4.8.SDK",
     "Microsoft.VisualStudio.Component.FSharp",
+    "Microsoft.VisualStudio.Component.FSharp.WebTemplates",
     "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81",
     "Microsoft.VisualStudio.Workload.VCTools",
     "Microsoft.VisualStudio.Component.VC.ATL",


### PR DESCRIPTION
Follow-up of https://github.com/DataDog/datadog-agent-buildimages/pull/174

Looks like we need an additional component to build a sample F# web application inside Visual Studio