### PR TITLE
[windows] Fix Windows Dockerhub release jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,8 @@ variables:
   # (eg. updated versions of awscli, tools to sign images - if we decide to sign buildimages some day)
   # Thus, to release buildimages, we do the same thing as what we do in the Agent: we run the Docker publish script in
   # the buildimage for the highest Windows version supported.
-  WINDOWS_RELEASE_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_2004_x64:v5684002-3023c06
+  # This image must use the same Windows version as the Windows version of the Gitlab runner used in .winrelease
+  WINDOWS_RELEASE_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_ltsc2022_x64:v6165899-6f80cc5
   S3_CP_CMD: aws s3 cp $S3_CP_OPTIONS
   S3_PERMANENT_ARTIFACTS_URI: s3://dd-ci-persistent-artefacts-build-stable/datadog-agent
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded


### PR DESCRIPTION
Fixes failures in the Windows Dockerhub release jobs, as the job was running on ltsc2022, but was trying to run a 2004 Windows docker image.