### PR TITLE
Increase timeout and add timestamps on Windows builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -197,6 +197,7 @@ test_system-probe_arm64:
 .winbuild: &winbuild
   stage: build
   except: [ tags ]
+  timeout: 2h 00m
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))

--- a/build-container.ps1
+++ b/build-container.ps1
@@ -36,4 +36,5 @@ if( -not $Cache) {
 $buildcommand = "build $buildcommandparams"
 # Write-Host -ForegroundColor Green "Building with the following command:"
 # Write-Host -ForegroundColor Green "$buildcommand `n"
-& docker $buildcommand.split()
+filter timestamp {"$(Get-Date -Format o): $_"}
+& docker $buildcommand.split() | timestamp


### PR DESCRIPTION
### What does this PR do?

- Increase timeout for Windows builds
- Add timestamps to Docker build steps on Windows builds

### Motivation

We are seeing timeouts when building some of the windows images ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/105193510)). 

The timeout increase will reduce the chance of further timeouts. The timestamp logging will allow us to understand what is taking the most time if we have further timeout issues.