### PR TITLE
[CWS] Install gcc-multilib in system-probe* images

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         flex \
         g++ \
         gcc \
-        gcc-multilib \
         git \
         libbpf-dev \
         libedit-dev \

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         flex \
         g++ \
         gcc \
+        gcc-multilib \
         git \
         libbpf-dev \
         libedit-dev \

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         flex \
         g++ \
         gcc \
+        gcc-multilib \
         git \
         libbpf-dev \
         libedit-dev \


### PR DESCRIPTION
The CWS functional tests use a x86 (32 bits) binary in the CI to test x86 specific syscalls and ways of doing syscalls. In order to build those binaries in the CI, we would need `gcc-multilib` installed in the build image.