### PR TITLE
Build vcpkg-tool from source

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -117,10 +117,6 @@ RUN powershell -Command .\install_dotnetcore.ps1
 COPY ./windows/install_nuget.ps1 install_nuget.ps1
 RUN powershell -Command .\install_nuget.ps1 $ENV:NUGET_VERSION
 
-# install vcpkg
-COPY ./windows/install_vcpkg.ps1 install_vcpkg.ps1
-RUN powershell -Command .\install_vcpkg.ps1
-
 # Install VC compiler for Python 2.7
 COPY ./windows/install_vcpython.ps1 install_vcpython.ps1
 RUN powershell -Command .\install_vcpython.ps1
@@ -180,6 +176,10 @@ RUN powershell -C .\install_gcloud_sdk.ps1
 COPY ./python-packages-versions.txt python-packages-versions.txt
 COPY ./windows/install_embedded_pythons.ps1 install_embedded_pythons.ps1
 RUN powershell -C .\install_embedded_pythons.ps1
+
+# install vcpkg
+COPY ./windows/install_vcpkg.ps1 install_vcpkg.ps1
+RUN powershell -Command .\install_vcpkg.ps1
 
 # Add signtool to path
 RUN [Environment]::SetEnvironmentVariable(\"Path\", [Environment]::GetEnvironmentVariable(\"Path\", [EnvironmentVariableTarget]::Machine) + \";${env:ProgramFiles(x86)}\Windows Kits\8.1\bin\x64\", [System.EnvironmentVariableTarget]::Machine)

--- a/windows/install_vcpkg.ps1
+++ b/windows/install_vcpkg.ps1
@@ -3,14 +3,17 @@ $ErrorActionPreference = "Stop"
 # Do not use '--depth 1' since vcpkg needs to browse its git history for dependency retrieval
 git clone --branch 2021.05.12 https://github.com/microsoft/vcpkg
 
-git clone https://github.com/microsoft/vcpkg-tool
-Push-Location vcpkg-tool
-git checkout 2022-01-19
-cmake -DVCPKG_EMBED_GIT_SHA=ON .
+git clone https://github.com/microsoft/vcpkg-tool --branch 2022-01-19 C:\vcpkg-tool
+
+mkdir C:\vcpkg-build
+Push-Location C:\vcpkg-build
+cmake -DVCPKG_EMBED_GIT_SHA=ON C:\vcpkg-tool
 cmd /C "%VSTUDIO_ROOT%\VC\Auxiliary\Build\vcvars64.bat && msbuild /p:Configuration=Release vcpkg.sln"
-Move-Item .\Release\vcpkg.exe c:\vcpkg\
+Move-Item C:\vcpkg-build\Release\vcpkg.exe c:\vcpkg\
 Pop-Location
+
 Remove-Item -Recurse -Force C:\vcpkg-tool
+Remove-Item -Recurse -Force C:\vcpkg-build
 
 [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";C:\vcpkg\", [System.EnvironmentVariableTarget]::Machine)
 .\vcpkg\vcpkg.exe --version

--- a/windows/install_vcpkg.ps1
+++ b/windows/install_vcpkg.ps1
@@ -5,8 +5,9 @@ git clone --branch 2021.05.12 https://github.com/microsoft/vcpkg
 
 git clone https://github.com/microsoft/vcpkg-tool
 Push-Location vcpkg-tool
-cmake .
-cmd /C "%VSTUDIO_ROOT%\VC\Auxiliary\Build\vcvars64.bat & msbuild /p:Configuration=Release vcpkg.sln"
+git checkout 2022-01-19
+cmake -DVCPKG_EMBED_GIT_SHA=ON .
+cmd /C "%VSTUDIO_ROOT%\VC\Auxiliary\Build\vcvars64.bat && msbuild /p:Configuration=Release vcpkg.sln"
 Move-Item .\Release\vcpkg.exe c:\vcpkg\
 Pop-Location
 Remove-Item -Recurse -Force C:\vcpkg-tool

--- a/windows/install_vcpkg.ps1
+++ b/windows/install_vcpkg.ps1
@@ -7,7 +7,7 @@ git clone https://github.com/microsoft/vcpkg-tool --branch 2022-01-19 C:\vcpkg-t
 
 mkdir C:\vcpkg-build
 Push-Location C:\vcpkg-build
-cmake -DVCPKG_EMBED_GIT_SHA=ON C:\vcpkg-tool
+cmake -DVCPKG_EMBED_GIT_SHA=ON -DVCPKG_BASE_VERSION=2022-01-19 C:\vcpkg-tool
 cmd /C "%VSTUDIO_ROOT%\VC\Auxiliary\Build\vcvars64.bat && msbuild /p:Configuration=Release vcpkg.sln"
 Move-Item C:\vcpkg-build\Release\vcpkg.exe c:\vcpkg\
 Pop-Location

--- a/windows/install_vcpkg.ps1
+++ b/windows/install_vcpkg.ps1
@@ -2,6 +2,15 @@ $ErrorActionPreference = "Stop"
 
 # Do not use '--depth 1' since vcpkg needs to browse its git history for dependency retrieval
 git clone --branch 2021.05.12 https://github.com/microsoft/vcpkg
-.\vcpkg\scripts\bootstrap.ps1
+
+git clone https://github.com/microsoft/vcpkg-tool
+Push-Location vcpkg-tool
+cmake .
+cmd /C "%VSTUDIO_ROOT%\VC\Auxiliary\Build\vcvars64.bat & msbuild /p:Configuration=Release vcpkg.sln"
+Move-Item .\Release\vcpkg.exe c:\vcpkg\
+Pop-Location
+Remove-Item -Recurse -Force C:\vcpkg-tool
+
 [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";C:\vcpkg\", [System.EnvironmentVariableTarget]::Machine)
+.\vcpkg\vcpkg.exe --version
 .\vcpkg\vcpkg.exe integrate install


### PR DESCRIPTION
This PR builds VCPKG from source, and uses it in place of the pre-built VCPKG that is downloaded from https://github.com/microsoft/vcpkg-tool/releases.

The rationale is that we use a `vcpkg` baseline for our dependencies that is not necessarily the latest, so  the `bootstrap.ps1` file that is used to install `vcpkg.exe` in the buildimage, installs an older version of `vcpkg` too.
See : https://github.com/microsoft/vcpkg/blob/5568f110b509a9fd90711978a7cb76bae75bb092/scripts/bootstrap.ps1#L48

By building it ourselves we can always have the latest `vcpkg.exe` in our buildimage.