### PR TITLE
[all] Install requirements.txt on datadog-agent-buildimages

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -45,6 +45,7 @@ RUN chmod +x /usr/local/bin/curl
 # CONDA
 COPY ./python-packages-versions.txt /python-packages-versions.txt
 COPY ./setup_python.sh /setup_python.sh
+COPY ./requirements.txt /requirements.txt
 RUN ./setup_python.sh
 COPY ./conda.sh /etc/profile.d/conda.sh
 ENV PATH "${CONDA_PATH}/bin:${PATH}"

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -63,6 +63,7 @@ RUN mkdir -p /opt/mqm \
 # CONDA
 COPY ./python-packages-versions.txt /python-packages-versions.txt
 COPY ./setup_python.sh /setup_python.sh
+COPY ./requirements.txt /requirements.txt
 RUN ./setup_python.sh
 COPY ./conda.sh /etc/profile.d/conda.sh
 ENV PATH "${CONDA_PATH}/bin:${PATH}"

--- a/omnibus-nikos_arm64/Dockerfile
+++ b/omnibus-nikos_arm64/Dockerfile
@@ -38,6 +38,8 @@ RUN cd /tmp/Python-3.8.0 && make -j 8 && make install
 
 RUN python3.8 -m pip install --upgrade pip --user
 RUN python3.8 -m pip install awscli meson ninja
+COPY ./requirements.txt /requirements.txt
+RUN python3.8 -m pip install -r requirements.txt
 
 # Install clang and llvm version 8
 RUN curl -sL -o clang_llvm.tar.xz https://dd-agent-omnibus.s3.amazonaws.com/clang%2Bllvm-${CLANG_VERSION}-aarch64-linux.tar.xz && \

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -80,6 +80,8 @@ RUN cd /tmp/Python-3.8.0 && LDFLAGS="${LDFLAGS} -Wl,-rpath=/home/openssl/lib" ./
 RUN cd /tmp/Python-3.8.0 && make -j 8 && make install
 
 RUN python3.8 -m pip install awscli meson ninja
+COPY ./requirements.txt /requirements.txt
+RUN python3.8 -m pip install -r requirements.txt
 
 # Install clang and llvm version 8
 # Using build for sles11 because the versions built for other distros target glibcs that are too new to be used from this image

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# python development requirements for the Datadog Agent
+invoke==1.6.0
+reno==3.5.0
+docker==5.0.3
+docker-squash==1.0.9
+requests==2.27.1
+PyYAML==6.0
+toml==0.10.2

--- a/rpm-arm/Dockerfile
+++ b/rpm-arm/Dockerfile
@@ -80,6 +80,7 @@ RUN /bin/bash -l -c "gem install bundler --no-document"
 # Pip & Invoke
 COPY ./python-packages-versions.txt /python-packages-versions.txt
 COPY ./setup_python.sh /setup_python.sh
+COPY ./requirements.txt /requirements.txt
 RUN ./setup_python.sh
 
 # Gimme

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -52,6 +52,7 @@ RUN mkdir -p /usr/local/var/lib/rpm \
 # CONDA
 COPY ./python-packages-versions.txt /python-packages-versions.txt
 COPY ./setup_python.sh /setup_python.sh
+COPY ./requirements.txt /requirements.txt
 RUN ./setup_python.sh
 COPY ./conda.sh /etc/profile.d/conda.sh
 ENV PATH "${CONDA_PATH}/bin:${PATH}"

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -90,6 +90,7 @@ RUN git config --global user.name "Bits"
 # CONDA
 COPY ./python-packages-versions.txt /python-packages-versions.txt
 COPY ./setup_python.sh /setup_python.sh
+COPY ./requirements.txt /requirements.txt
 RUN ./setup_python.sh
 COPY ./conda.sh /etc/profile.d/conda.sh
 ENV PATH "${CONDA_PATH}/bin:${PATH}"

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -77,7 +77,7 @@ conda create -n ddpy3 python python=$PY3_VERSION
 conda activate ddpy2
 pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION}
 pip install setuptools==${DD_SETUPTOOLS_VERSION}
-pip install invoke==1.4.1 distro==1.4.0 awscli==1.16.240
+pip install distro==1.4.0 awscli==1.16.240
 
 # Update pip, setuptools and misc deps
 conda activate ddpy3

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -52,7 +52,8 @@ case $DD_TARGET_ARCH in
     fi
 
     curl "${DD_PIP_GET_URL}" | python3 - pip==${DD_PIP_VERSION_PY3} setuptools==${DD_SETUPTOOLS_VERSION_PY3}
-    python3 -m pip install invoke==1.4.1 distro==1.4.0 awscli==1.16.240
+    python3 -m pip install distro==1.4.0 awscli==1.16.240
+    python3 -m pip install -r requirements.txt
     exit 0
     ;;
 *)
@@ -76,13 +77,15 @@ conda create -n ddpy3 python python=$PY3_VERSION
 conda activate ddpy2
 pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION}
 pip install setuptools==${DD_SETUPTOOLS_VERSION}
-pip install distro==1.4.0 awscli==1.16.240
+pip install invoke==1.4.1 distro==1.4.0 awscli==1.16.240
 
 # Update pip, setuptools and misc deps
 conda activate ddpy3
 pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION_PY3}
 pip install setuptools==${DD_SETUPTOOLS_VERSION_PY3}
-pip install invoke==1.4.1 distro==1.4.0 awscli==1.16.240
+pip install distro==1.4.0 awscli==1.16.240
+pip install -r requirements.txt
+
 
 if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then
     # Conda creates "lib" but on Amazon Linux, the embedded Python2 we use in unit tests will look in "lib64" instead

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -74,6 +74,7 @@ RUN mkdir -p /opt/mqm \
 # CONDA
 COPY ./python-packages-versions.txt /python-packages-versions.txt
 COPY ./setup_python.sh /setup_python.sh
+COPY ./requirements.txt /requirements.txt
 RUN ./setup_python.sh
 COPY ./conda.sh /etc/profile.d/conda.sh
 ENV PATH "${CONDA_PATH}/bin:${PATH}"

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -55,7 +55,8 @@ RUN mkdir -p /opt/clang
 RUN tar xf /tmp/clang.tar.xz --no-same-owner -C /opt/clang --strip-components=1
 ENV PATH "/opt/clang/bin:${PATH}"
 
-RUN python3 -m pip install invoke==1.4.1
+COPY ./requirements.txt /requirements.txt
+RUN python3 -m pip install -r requirements.txt
 
 COPY ./entrypoint-sysprobe.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         python3-setuptools \
         python3-pip \
         python3-pyroute2 \
+        python3-dev \
         wget \
         xz-utils
 
@@ -56,6 +57,7 @@ RUN tar xf /tmp/clang.tar.xz --no-same-owner -C /opt/clang --strip-components=1
 ENV PATH "/opt/clang/bin:${PATH}"
 
 COPY ./requirements.txt /requirements.txt
+RUN python3 -m pip install wheel
 RUN python3 -m pip install -r requirements.txt
 
 COPY ./entrypoint-sysprobe.sh /entrypoint.sh

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         python3-setuptools \
         python3-pip \
         python3-pyroute2 \
+        python3-dev \
         wget \
         xz-utils
 
@@ -57,6 +58,7 @@ RUN tar xf /tmp/clang.tar.xz --no-same-owner -C /opt/clang --strip-components=1
 ENV PATH "/opt/clang/bin:${PATH}"
 
 COPY ./requirements.txt /requirements.txt
+RUN python3 -m pip install wheel
 RUN python3 -m pip install -r requirements.txt
 
 COPY ./entrypoint-sysprobe.sh /entrypoint.sh

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -56,7 +56,8 @@ RUN mkdir -p /opt/clang
 RUN tar xf /tmp/clang.tar.xz --no-same-owner -C /opt/clang --strip-components=1
 ENV PATH "/opt/clang/bin:${PATH}"
 
-RUN python3 -m pip install invoke==1.4.1
+COPY ./requirements.txt /requirements.txt
+RUN python3 -m pip install -r requirements.txt
 
 COPY ./entrypoint-sysprobe.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -174,6 +174,7 @@ RUN powershell -C .\install_gcloud_sdk.ps1
 
 # Install embedded pythons (for unit testing)
 COPY ./python-packages-versions.txt python-packages-versions.txt
+COPY ./requirements.txt /requirements.txt
 COPY ./windows/install_embedded_pythons.ps1 install_embedded_pythons.ps1
 RUN powershell -C .\install_embedded_pythons.ps1
 

--- a/windows/install_embedded_pythons.ps1
+++ b/windows/install_embedded_pythons.ps1
@@ -78,6 +78,7 @@ curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
 cd $py3Target
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 .\python get-pip.py pip==${Env:DD_PIP_VERSION_PY3}
+.\python -m pip install -r requirements.txt
 
 if ( $Env:TARGET_ARCH -eq "x86") {
     $crt = "https://s3.amazonaws.com/dd-agent-omnibus/msvc_ucrt_runtime_x86.zip"


### PR DESCRIPTION
Install `requirements.txt` needed to build the Datadog Agent at image build time. After this we need to:
- Do the same thing on datadog-agent-builders
- Point the datadog-agent `requirements.txt` file to the `requirements.txt` file here
- (possibly) Remove the `pip install requirements.txt` lines from the Gitlab CI
- Move Dependabot here