### PR TITLE
Require pywin32 303 on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # python development requirements for the Datadog Agent
 invoke==1.6.0
 reno==3.5.0
+pywin32==303; sys_platform == 'win32'
 docker==5.0.3
 docker-squash==1.0.9
 requests==2.27.1


### PR DESCRIPTION
To be compatible with Python 3.10