### PR TITLE
Add awscli to requirements.txt

### DIFF
--- a/omnibus-nikos_arm64/Dockerfile
+++ b/omnibus-nikos_arm64/Dockerfile
@@ -37,7 +37,7 @@ RUN cd /tmp/Python-3.8.0 && ./configure
 RUN cd /tmp/Python-3.8.0 && make -j 8 && make install
 
 RUN python3.8 -m pip install --upgrade pip --user
-RUN python3.8 -m pip install awscli meson ninja
+RUN python3.8 -m pip install meson ninja
 COPY ./requirements.txt /requirements.txt
 RUN python3.8 -m pip install -r requirements.txt
 

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -79,7 +79,7 @@ RUN tar -xf Python-3.8.0.tar.xz -C /tmp/
 RUN cd /tmp/Python-3.8.0 && LDFLAGS="${LDFLAGS} -Wl,-rpath=/home/openssl/lib" ./configure --with-openssl=/home/openssl
 RUN cd /tmp/Python-3.8.0 && make -j 8 && make install
 
-RUN python3.8 -m pip install awscli meson ninja
+RUN python3.8 -m pip install meson ninja
 COPY ./requirements.txt /requirements.txt
 RUN python3.8 -m pip install -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ reno==3.5.0
 docker==5.0.3
 docker-squash==1.0.9
 requests==2.27.1
-PyYAML==6.0
+PyYAML==5.4.1
 toml==0.10.2
 packaging==21.3
 awscli==1.22.57

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ requests==2.27.1
 PyYAML==6.0
 toml==0.10.2
 packaging==21.3
-awscli==1.11.152
+awscli==1.22.57

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests==2.27.1
 PyYAML==6.0
 toml==0.10.2
 packaging==21.3
+awscli==1.11.152

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -52,7 +52,7 @@ case $DD_TARGET_ARCH in
     fi
 
     curl "${DD_PIP_GET_URL}" | python3 - pip==${DD_PIP_VERSION_PY3} setuptools==${DD_SETUPTOOLS_VERSION_PY3}
-    python3 -m pip install distro==1.4.0 awscli==1.16.240
+    python3 -m pip install distro==1.4.0
     python3 -m pip install -r requirements.txt
     exit 0
     ;;
@@ -77,13 +77,13 @@ conda create -n ddpy3 python python=$PY3_VERSION
 conda activate ddpy2
 pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION}
 pip install setuptools==${DD_SETUPTOOLS_VERSION}
-pip install distro==1.4.0 awscli==1.16.240
+pip install distro==1.4.0
 
 # Update pip, setuptools and misc deps
 conda activate ddpy3
 pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION_PY3}
 pip install setuptools==${DD_SETUPTOOLS_VERSION_PY3}
-pip install distro==1.4.0 awscli==1.16.240
+pip install distro==1.4.0
 pip install -r requirements.txt
 
 

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -7,7 +7,6 @@ ENV GIMME_GO_VERSION $GIMME_GO_VERSION
 ENV GOPATH=/go
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
-        awscli \
         bison \
         cmake \
         curl \

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -7,7 +7,6 @@ ENV GIMME_GO_VERSION $GIMME_GO_VERSION
 ENV GOPATH=/go
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
-        awscli \
         bison \
         cmake \
         curl \


### PR DESCRIPTION
Adds and pins the python dependency `awscli` to `requirements.txt`. 

We previously were installing it manually, in several different ways, instead of using `requirements.txt`.

`awscli` is used in the `datadog-agent` repo by some invoke tasks and Gitlab jobs.

This also downgrades the pinned PyYAML version, since `awscli` isn't officially compatible with  6.0. Before, we were installing awscli + PyYAML 6.0 regardless of this potential incompatibility.