### PR TITLE
Verify sha256 checksums of all downloaded artifacts

### DIFF
--- a/build-clang.sh
+++ b/build-clang.sh
@@ -3,8 +3,10 @@
 CLANG_VERSION=8.0.0
 
 curl -LO http://releases.llvm.org/${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz
+echo "8872be1b12c61450cacc82b3d153eab02be2546ef34fa3580ed14137bb26224c  llvm-${CLANG_VERSION}.src.tar.xz" | sha256sum --check
 tar -xf llvm-${CLANG_VERSION}.src.tar.xz
 curl -LO http://releases.llvm.org/${CLANG_VERSION}/cfe-${CLANG_VERSION}.src.tar.xz
+echo "084c115aab0084e63b23eee8c233abb6739c399e29966eaeccfc6e088e0b736b  llvm-${CLANG_VERSION}.src.tar.xz" | sha256sum --check
 tar -xf cfe-${CLANG_VERSION}.src.tar.xz
 mv cfe-${CLANG_VERSION}.src/ clang
 cd llvm-${CLANG_VERSION}.src

--- a/build-clang.sh
+++ b/build-clang.sh
@@ -2,10 +2,10 @@
 
 CLANG_VERSION=8.0.0
 
-curl -LO http://releases.llvm.org/${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz
+curl -LO https://releases.llvm.org/${CLANG_VERSION}/llvm-${CLANG_VERSION}.src.tar.xz
 echo "8872be1b12c61450cacc82b3d153eab02be2546ef34fa3580ed14137bb26224c  llvm-${CLANG_VERSION}.src.tar.xz" | sha256sum --check
 tar -xf llvm-${CLANG_VERSION}.src.tar.xz
-curl -LO http://releases.llvm.org/${CLANG_VERSION}/cfe-${CLANG_VERSION}.src.tar.xz
+curl -LO https://releases.llvm.org/${CLANG_VERSION}/cfe-${CLANG_VERSION}.src.tar.xz
 echo "084c115aab0084e63b23eee8c233abb6739c399e29966eaeccfc6e088e0b736b  llvm-${CLANG_VERSION}.src.tar.xz" | sha256sum --check
 tar -xf cfe-${CLANG_VERSION}.src.tar.xz
 mv cfe-${CLANG_VERSION}.src/ clang

--- a/build-cmake.sh
+++ b/build-cmake.sh
@@ -3,6 +3,7 @@
 CMAKE_VERSION=3.14.4
 
 curl -sL -O https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz
+echo "00b4dc9b0066079d10f16eed32ec592963a44e7967371d2f5077fd1670ff36d9  cmake-${CMAKE_VERSION}.tar.gz" | sha256sum --check
 tar xf cmake-${CMAKE_VERSION}.tar.gz
 cd cmake-${CMAKE_VERSION}
 ./bootstrap --prefix=/opt/cmake

--- a/datadog-ci-uploader/Dockerfile
+++ b/datadog-ci-uploader/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 ENV N_VERSION=8.0.0
+ENV N_SHA256="e0af3182861d91bbc65478bfad7b25e7cbbe200a4f7443baeeaf9c2b732da776"
 ENV NODE_VERSION=16.13.0
 ENV AWSCLI_VERSION=1.16.240
 ENV CODEOWNERS_VERSION=0.4.0
@@ -12,6 +13,7 @@ ENV DATADOG_CI_VERSION=0.17.8
 RUN apt update && apt install -y curl git python3 python3-pip
 RUN pip install awscli==${AWSCLI_VERSION} codeowners==${CODEOWNERS_VERSION}
 
-RUN curl -L https://raw.githubusercontent.com/tj/n/v${N_VERSION}/bin/n -o n && \
-    bash n ${NODE_VERSION} && \
-    npm install -g @datadog/datadog-ci@${DATADOG_CI_VERSION}
+RUN curl -L https://raw.githubusercontent.com/tj/n/v${N_VERSION}/bin/n -o n \
+    && echo "${N_SHA256}  n" | sha256sum --check \
+    && bash n ${NODE_VERSION} \
+    && npm install -g @datadog/datadog-ci@${DATADOG_CI_VERSION}

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -1,9 +1,15 @@
 ARG BASE_IMAGE=arm64v8/ubuntu:16.04
 
 FROM ubuntu as CURL_GETTER
+ENV WGET_AARCH64_VERSION=7.79.1
+ENV WGET_AARCH64_SHA256="234cc67f7caae0a0e1222bd70b513c78f65e058397bc271191ede66d12ec0366"
+ENV WGET_ARMV7_VERSION=7.79.1
+ENV WGET_ARMV7_SHA256="db08ec3a16ce0a8db0ce512a55adb619f6fbc6005f151abb4a31333f26780cc3"
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-armv7
+RUN echo "${WGET_ARMV7_SHA256}  curl-armv7" | sha256sum --check
 RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-aarch64
+RUN echo "${WGET_AARCH64_SHA256}  curl-aarch64" | sha256sum --check
 
 ## Valid archs are
 # amd64, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -12,7 +18,9 @@ FROM ${BASE_IMAGE}
 # Build Args
 ARG GIMME_GO_VERSION=1.17.6
 ARG CMAKE_VERSION=3.14.4
+ARG CMAKE_SHA256="546b4526ea2844d530699cb1e0a267095e3cb095188700abab83af1d2f525334"
 ARG CLANG_VERSION=8.0.0
+ARG CLANG_SHA256="a77eb8fde0a475c25d46dccdeb851a83cbeeeb11779fa2218ae19db9cd0e51f9"
 ARG DD_TARGET_ARCH=aarch64
 
 
@@ -20,7 +28,9 @@ ARG DD_TARGET_ARCH=aarch64
 ENV GOPATH /go
 ENV GIMME_GO_VERSION $GIMME_GO_VERSION
 ENV CMAKE_VERSION $CMAKE_VERSION
+ENV CMAKE_SHA256 $CMAKE_SHA256
 ENV CLANG_VERSION $CLANG_VERSION
+ENV CLANG_SHA256 $CLANG_SHA256
 ENV CONDA_PATH /root/miniforge3
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 
@@ -55,6 +65,8 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
+# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
+# be done using the https://get.rvm.io URL.
 RUN curl -sSL https://get.rvm.io | bash -s stable
 RUN /bin/bash -l -c "rvm requirements"
 RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then \
@@ -65,7 +77,8 @@ RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then \
 RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Gimme
-RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme
+RUN echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin/gimme" | sha256sum --check
 RUN chmod +x /bin/gimme
 
 # GIMME_ARCH = GOARCH, so must be a valid entry from `goarchlist` here:
@@ -80,16 +93,18 @@ RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then \
 COPY ./gobin.sh /etc/profile.d/
 
 # CMake. Pre-built using the build-cmake.sh script, to speed-up docker build.
-RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then curl -sL -O https://dd-agent-omnibus.s3.amazonaws.com/cmake-${CMAKE_VERSION}-ubuntu-aarch64.tar.xz && \
-    tar xf cmake-${CMAKE_VERSION}-ubuntu-aarch64.tar.xz --no-same-owner -kC / && \
-    rm cmake-${CMAKE_VERSION}-ubuntu-aarch64.tar.xz ; fi
+RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then curl -sL -O https://dd-agent-omnibus.s3.amazonaws.com/cmake-${CMAKE_VERSION}-ubuntu-aarch64.tar.xz \
+    && echo "${CMAKE_SHA256}  cmake-${CMAKE_VERSION}-ubuntu-aarch64.tar.xz" | sha256sum --check \
+    && tar xf cmake-${CMAKE_VERSION}-ubuntu-aarch64.tar.xz --no-same-owner -kC / \
+    && rm cmake-${CMAKE_VERSION}-ubuntu-aarch64.tar.xz ; fi
 ENV PATH="/opt/cmake/bin:$PATH"
 
 # Install clang and llvm version 8. Pre-built because building takes ~4 hours.
 # This was built from sources on centos 7, using the build-clang.sh script
 RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then curl -sL -o clang_llvm.tar.xz https://dd-agent-omnibus.s3.amazonaws.com/clang%2Bllvm-${CLANG_VERSION}-aarch64-linux.tar.xz && \
-    tar xf clang_llvm.tar.xz --no-same-owner -kC / && \
-    rm clang_llvm.tar.xz ; fi
+    && echo "${CLANG_SHA256}  clang_llvm.tar.xz" | sha256sum --check \
+    && tar xf clang_llvm.tar.xz --no-same-owner -kC / \
+    && rm clang_llvm.tar.xz ; fi
 ENV PATH="/opt/clang/bin:$PATH"
 
 # Entrypoint

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -101,7 +101,7 @@ ENV PATH="/opt/cmake/bin:$PATH"
 
 # Install clang and llvm version 8. Pre-built because building takes ~4 hours.
 # This was built from sources on centos 7, using the build-clang.sh script
-RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then curl -sL -o clang_llvm.tar.xz https://dd-agent-omnibus.s3.amazonaws.com/clang%2Bllvm-${CLANG_VERSION}-aarch64-linux.tar.xz && \
+RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then curl -sL -o clang_llvm.tar.xz https://dd-agent-omnibus.s3.amazonaws.com/clang%2Bllvm-${CLANG_VERSION}-aarch64-linux.tar.xz \
     && echo "${CLANG_SHA256}  clang_llvm.tar.xz" | sha256sum --check \
     && tar xf clang_llvm.tar.xz --no-same-owner -kC / \
     && rm clang_llvm.tar.xz ; fi

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -67,7 +67,8 @@ RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
 RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
     && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version latest-1.29 \
+    && bash get-rvm.sh stable --version 1.29.12 \
+    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then \

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -65,9 +65,10 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
-# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
-# be done using the https://get.rvm.io URL.
-RUN curl -sSL https://get.rvm.io | bash -s stable
+RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
+    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
+    && bash get-rvm.sh stable --version latest-1.29 \
+    && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then \
         /bin/bash -l -c "rvm install --with-openssl-dir=${CONDA_PATH} 2.7 && rvm cleanup all" ; \

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -141,7 +141,7 @@ COPY ./gobin.sh /etc/profile.d/
 RUN curl -sSfL -o golangci-lint-install.sh https://raw.githubusercontent.com/golangci/golangci-lint/v1.44.2/install.sh \
     && echo "1c2edb726aad6bf7d260d95c370bd9ec0fb1a8651e6db6f77f250dd66067de0c  golangci-lint-install.sh" | sha256sum --check \
     && sh ./golangci-lint-install.sh -b $GOPATH/bin v1.21.0 \
-    && echo "799a7a017f8b04058f61ae163684f5ef9808280ddab5aee4241bc9fa7e84bbc2 $GOPATH/bin/golangci-lint" | sha256sum --check \
+    && echo "799a7a017f8b04058f61ae163684f5ef9808280ddab5aee4241bc9fa7e84bbc2  $GOPATH/bin/golangci-lint" | sha256sum --check \
     && rm golangci-lint-install.sh
 
 # Entrypoint

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -1,22 +1,35 @@
 FROM ubuntu as CURL_GETTER
+ENV WGET_VERSION=7.79.1
+ENV WGET_SHA256="0a89440848db3ba21d38b93b450d90fb84d4d0fa5562aa9c6933070b0eddc960"
 RUN apt-get update && apt-get install -y wget
-RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-amd64
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/v${WGET_VERSION}/curl-amd64
+RUN echo "${WGET_SHA256}  curl-amd64" | sha256sum --check
 
 FROM debian:wheezy-backports
 
 # Build Args
+ARG GIT_VERSION=2.10.1
+ARG GIT_SHA256="78553f786f1a66cb68983c170be482558028a3376056c0f2ed366f331b1e35f2"
 ARG GO_VERSION=1.17.6
 ARG IBM_MQ_VERSION=9.2.2.0
+ARG IBM_MQ_SHA256="aa619218371a3b27b94c7bbea4de57ed9651a4b8dd50a9525dabe8b9b3a64d61"
 ARG CMAKE_VERSION=3.14.4
+ARG CMAKE_SHA256="3337a648a3ac97b5e6a05f8a08ae97b71d37af48465dae4736932f8a3e85f368"
 ARG CLANG_VERSION=8.0.0
+ARG CLANG_SHA256="7e2846ff60c181d1f27d97c23c25a2295f5730b6d88612ddd53b4cbb8177c4b9"
 ARG DD_TARGET_ARCH=x64
 
 # Environment
 ENV GOPATH /go
+ENV GIT_VERSION $GIT_VERSION
+ENV GIT_SHA256 $GIT_SHA256
 ENV GO_VERSION $GO_VERSION
 ENV IBM_MQ_VERSION $IBM_MQ_VERSION
+ENV IBM_MQ_SHA256 $IBM_MQ_SHA256
 ENV CMAKE_VERSION $CMAKE_VERSION
+ENV CMAKE_SHA256 $CMAKE_SHA256
 ENV CLANG_VERSION $CLANG_VERSION
+ENV CLANG_SHA256 $CLANG_SHA256
 ENV CONDA_PATH /root/miniconda3
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 
@@ -44,12 +57,13 @@ COPY --from=CURL_GETTER /curl-amd64 /usr/local/bin/curl
 RUN chmod +x /usr/local/bin/curl
 
 # Git
-RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-2.10.1.tar.gz
+RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz
+RUN echo "${GIT_SHA256}  git-${GIT_VERSION}.tar.gz" | sha256sum --check
 # --no-same-owner: git tarball has a file with UID 110493 which makes pulling this image fail, because we use docker user namespacing and we can't have >65K UIDs.
-RUN tar xzf git-2.10.1.tar.gz --no-same-owner
-RUN cd git-2.10.1 && make prefix=/usr/local all
-RUN cd git-2.10.1 && make prefix=/usr/local install
-RUN rm -rf git-2.10.1 git-2.10.1.tar.gz
+RUN tar xzf git-${GIT_VERSION}.tar.gz --no-same-owner
+RUN cd git-${GIT_VERSION} && make prefix=/usr/local all
+RUN cd git-${GIT_VERSION} && make prefix=/usr/local install
+RUN rm -rf git-${GIT_VERSION} git-${GIT_VERSION}.tar.gz
 
 RUN git config --global user.email "package@datadoghq.com"
 RUN git config --global user.name "Bits"
@@ -57,6 +71,7 @@ RUN git config --global user.name "Bits"
 # IBM MQ
 RUN mkdir -p /opt/mqm \
     && curl "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/${IBM_MQ_VERSION}-IBM-MQC-Redist-LinuxX64.tar.gz" -o /tmp/mq_client.tar.gz \
+    && echo "${IBM_MQ_SHA256}  /tmp/mq_client.tar.gz" | sha256sum --check \
     && tar -C /opt/mqm -xf /tmp/mq_client.tar.gz \
     && rm -rf /tmp/mq_client.tar.gz
 
@@ -73,6 +88,8 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
+# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
+# be done using the https://get.rvm.io URL.
 RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
@@ -80,11 +97,15 @@ RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Docker
 # Pin docker to before they broke wheezy
-RUN curl -fsSL https://raw.githubusercontent.com/docker/docker-install/a34555fc0214be705330911071a8c3357f26e40b/install.sh | sed -e 's/ftp\.debian\.org/archive.debian.org/g' | sh
+RUN curl -fsSL https://raw.githubusercontent.com/docker/docker-install/a34555fc0214be705330911071a8c3357f26e40b/install.sh -o docker-install.sh
+RUN echo "68165ab5ce308d742b5e30f9e85f0a7e373fb6ba5990447143510dd92d384685  docker-install.sh" | sha256sum --check
+RUN cat docker-install.sh | sed -e 's/ftp\.debian\.org/archive.debian.org/g' | sh
+RUN rm -rf docker-install.sh
 
 # CMake
 RUN set -ex \
     && curl -sL -o cmake.sh https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh \
+    && echo "${CMAKE_SHA256}  cmake.sh" | sha256sum --check \
     && mkdir -p /opt/cmake/ \
     && sh cmake.sh --skip-license --prefix=/opt/cmake \
     && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake \
@@ -92,14 +113,16 @@ RUN set -ex \
 
 # Install clang and llvm version 8
 # Using build for sles11 because the versions built for other distros target glibcs that are too new to be used from this image
-RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
-    tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ && \
-    rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
+RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz \
+    && echo "${CLANG_SHA256}  clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz" | sha256sum --check \
+    && tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ \
+    && rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
 
 # To build the EBPF code we need kernel headers for Linux 4.9
-RUN curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-deb-x64.tgz && \
-    tar xf kernel-4.9-headers-deb-x64.tgz --no-same-owner --strip 1 -C /usr && \
-    rm kernel-4.9-headers-deb-x64.tgz
+RUN curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-deb-x64.tgz \
+    && echo "245f31a066460a51849365009557f61350e46579288e3f46cf9f44b3f5bee3ed  kernel-4.9-headers-deb-x64.tgz" | sha256sum --check \
+    && tar xf kernel-4.9-headers-deb-x64.tgz --no-same-owner --strip 1 -C /usr \
+    && rm kernel-4.9-headers-deb-x64.tgz
 
 # Go
 # Starting with go1.16, we need to build go from source, as the publicly distributed
@@ -113,6 +136,7 @@ RUN ./setup_go.sh
 COPY ./gobin.sh /etc/profile.d/
 
 # Download and install golangci-lint
+# TODO: To be able to check sums, we need to pin the golangci-lint install script
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOPATH/bin v1.21.0
 
 # Entrypoint

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -88,9 +88,10 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
-# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
-# be done using the https://get.rvm.io URL.
-RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
+RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
+    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
+    && bash get-rvm.sh stable --version latest-1.29 \
+    && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -141,7 +141,7 @@ COPY ./gobin.sh /etc/profile.d/
 RUN curl -sSfL -o golangci-lint-install.sh https://raw.githubusercontent.com/golangci/golangci-lint/v1.44.2/install.sh \
     && echo "1c2edb726aad6bf7d260d95c370bd9ec0fb1a8651e6db6f77f250dd66067de0c  golangci-lint-install.sh" | sha256sum --check \
     && sh ./golangci-lint-install.sh -b $GOPATH/bin v1.21.0 \
-    && echo "799a7a017f8b04058f61ae163684f5ef9808280ddab5aee4241bc9fa7e84bbc2  $GOPATH/bin/golangci-lint" | sha256sum --check \
+    && echo "942efc00799b83aebaf6628c34e1151467b7fa21f0cfd78554279dc73f8c8ef3  $GOPATH/bin/golangci-lint" | sha256sum --check \
     && rm golangci-lint-install.sh
 
 # Entrypoint

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -90,7 +90,8 @@ RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
 RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
     && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version latest-1.29 \
+    && bash get-rvm.sh stable --version 1.29.12 \
+    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
@@ -137,8 +138,11 @@ RUN ./setup_go.sh
 COPY ./gobin.sh /etc/profile.d/
 
 # Download and install golangci-lint
-# TODO: To be able to check sums, we need to pin the golangci-lint install script
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOPATH/bin v1.21.0
+RUN curl -sSfL -o golangci-lint-install.sh https://raw.githubusercontent.com/golangci/golangci-lint/v1.44.2/install.sh \
+    && echo "1c2edb726aad6bf7d260d95c370bd9ec0fb1a8651e6db6f77f250dd66067de0c  golangci-lint-install.sh" | sha256sum --check \
+    && sh ./golangci-lint-install.sh -b $GOPATH/bin v1.21.0 \
+    && echo "799a7a017f8b04058f61ae163684f5ef9808280ddab5aee4241bc9fa7e84bbc2 $GOPATH/bin/golangci-lint" | sha256sum --check \
+    && rm golangci-lint-install.sh
 
 # Entrypoint
 COPY ./entrypoint.sh /

--- a/omnibus-nikos_arm64/Dockerfile
+++ b/omnibus-nikos_arm64/Dockerfile
@@ -1,17 +1,26 @@
 FROM ubuntu as CURL_GETTER
+ENV WGET_AARCH64_VERSION=7.79.1
+ENV WGET_AARCH64_SHA256="234cc67f7caae0a0e1222bd70b513c78f65e058397bc271191ede66d12ec0366"
+ENV WGET_ARMV7_VERSION=7.79.1
+ENV WGET_ARMV7_SHA256="db08ec3a16ce0a8db0ce512a55adb619f6fbc6005f151abb4a31333f26780cc3"
 RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-armv7
+RUN echo "${WGET_ARMV7_SHA256}  curl-armv7" | sha256sum --check
 RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-aarch64
+RUN echo "${WGET_AARCH64_SHA256}  curl-aarch64" | sha256sum --check
 
 FROM arm64v8/ubuntu:16.04
 
 # Build Args
 ARG GIMME_GO_VERSION=1.17.6
 ARG CLANG_VERSION=8.0.0
+ARG CLANG_SHA256="a77eb8fde0a475c25d46dccdeb851a83cbeeeb11779fa2218ae19db9cd0e51f9"
 
 # Environment
 ENV GOPATH /go
 ENV GIMME_GO_VERSION $GIMME_GO_VERSION
 ENV CLANG_VERSION $CLANG_VERSION
+ENV CLANG_SHA256 $CLANG_SHA256
 
 RUN apt-get update && apt-get install -y fakeroot cmake curl bzip2 g++ gcc git \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libz-dev \
@@ -25,14 +34,17 @@ RUN chmod +x /usr/local/bin/curl
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
+# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
+# be done using the https://get.rvm.io URL.
 RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.6.6 && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Install python 3.8
-RUN curl -O -k https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tar.xz && \
-        tar -xf Python-3.8.0.tar.xz -C /tmp/
+RUN curl -O -k https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tar.xz \
+    && echo "b356244e13fb5491da890b35b13b2118c3122977c2cd825e3eb6e7d462030d84  Python-3.8.0.tar.xz" | sha256sum --check \
+    && tar -xf Python-3.8.0.tar.xz -C /tmp/
 RUN cd /tmp/Python-3.8.0 && ./configure
 RUN cd /tmp/Python-3.8.0 && make -j 8 && make install
 
@@ -42,19 +54,22 @@ COPY ./requirements.txt /requirements.txt
 RUN python3.8 -m pip install -r requirements.txt
 
 # Install clang and llvm version 8
-RUN curl -sL -o clang_llvm.tar.xz https://dd-agent-omnibus.s3.amazonaws.com/clang%2Bllvm-${CLANG_VERSION}-aarch64-linux.tar.xz && \
-    tar xf clang_llvm.tar.xz --no-same-owner -kC / && \
-    rm clang_llvm.tar.xz
+RUN curl -sL -o clang_llvm.tar.xz https://dd-agent-omnibus.s3.amazonaws.com/clang%2Bllvm-${CLANG_VERSION}-aarch64-linux.tar.xz \
+    && echo "${CLANG_SHA256}  clang_llvm.tar.xz" | sha256sum --check \
+    && tar xf clang_llvm.tar.xz --no-same-owner -kC / \
+    && rm clang_llvm.tar.xz
 ENV PATH="/opt/clang/bin:$PATH"
 
 # Gimme
-RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme
+RUN echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin/gimme" | sha256sum --check
 RUN chmod +x /bin/gimme
 RUN gimme $GIMME_GO_VERSION
 COPY ./gobin.sh /etc/profile.d/
 
 # Automake
 RUN curl -OL https://ftp.gnu.org/gnu/automake/automake-1.16.tar.gz
+RUN echo "80da43bb5665596ee389e6d8b64b4f122ea4b92a685b1dbd813cd1f0e0c2d83f  automake-1.16.tar.gz"  | sha256sum --check
 RUN tar xzf automake-1.16.tar.gz
 COPY ./omnibus-nikos_x64/automake.patch automake-1.16/automake.patch
 RUN cd automake-1.16 && patch -p1 < automake.patch

--- a/omnibus-nikos_arm64/Dockerfile
+++ b/omnibus-nikos_arm64/Dockerfile
@@ -36,7 +36,8 @@ RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
 RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
     && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version latest-1.29 \
+    && bash get-rvm.sh stable --version 1.29.12 \
+    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.6.6 && rvm cleanup all"

--- a/omnibus-nikos_arm64/Dockerfile
+++ b/omnibus-nikos_arm64/Dockerfile
@@ -34,9 +34,10 @@ RUN chmod +x /usr/local/bin/curl
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
-# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
-# be done using the https://get.rvm.io URL.
-RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
+RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
+    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
+    && bash get-rvm.sh stable --version latest-1.29 \
+    && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.6.6 && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -71,7 +71,8 @@ RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
 RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
     && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version latest-1.29 \
+    && bash get-rvm.sh stable --version 1.29.12 \
+    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.6.6 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -111,7 +111,7 @@ RUN curl -LO https://ftp.gnu.org/gnu/glibc/glibc-2.16.0.tar.gz \
   && tar zxvf glibc-2.16.0.tar.gz \
   && cd glibc-2.16.0 \
   && mkdir build \
-  && cd build && \
+  && cd build \
   && ../configure --prefix=/opt/glibc-2.16 \
   && make -j 8 \
   && make install

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -69,9 +69,10 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
-# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
-# be done using the https://get.rvm.io URL.
-RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
+RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
+    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
+    && bash get-rvm.sh stable --version latest-1.29 \
+    && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.6.6 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -1,22 +1,31 @@
 FROM ubuntu as CURL_GETTER
+ENV WGET_VERSION=7.79.1
+ENV WGET_SHA256="0a89440848db3ba21d38b93b450d90fb84d4d0fa5562aa9c6933070b0eddc960"
 RUN apt-get update && apt-get install -y wget
-RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-amd64
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/v${WGET_VERSION}/curl-amd64
+RUN echo "${WGET_SHA256}  curl-amd64" | sha256sum --check
 
 FROM debian:wheezy-backports
 
 # Build Args
 ARG GIMME_GO_VERSION=1.17.6
 ARG CMAKE_VERSION=3.14.4
+ARG CMAKE_SHA256="3337a648a3ac97b5e6a05f8a08ae97b71d37af48465dae4736932f8a3e85f368"
 ARG CLANG_VERSION=8.0.0
+ARG CLANG_SHA256="7e2846ff60c181d1f27d97c23c25a2295f5730b6d88612ddd53b4cbb8177c4b9"
 ARG CONDA_VERSION=4.9.2
+ARG CONDA_SHA256="536817d1b14cb1ada88900f5be51ce0a5e042bae178b5550e62f61e223deae7c"
 
 # Environment
 ENV GOPATH /go
 ENV CONDA_PATH /root/miniconda3
 ENV GIMME_GO_VERSION $GIMME_GO_VERSION
 ENV CMAKE_VERSION $CMAKE_VERSION
+ENV CMAKE_SHA256 $CMAKE_SHA256
 ENV CLANG_VERSION $CLANG_VERSION
+ENV CLANG_SHA256 $CLANG_SHA256
 ENV CONDA_VERSION $CONDA_VERSION
+ENV CONDA_SHA256 $CONDA_SHA256
 
 # Mitigation for CVE-2019-3462
 RUN echo 'Acquire::http::AllowRedirect"false";' >> /etc/apt/apt.conf.d/20datadog
@@ -41,15 +50,17 @@ RUN chmod +x /usr/local/bin/curl
 # CMake
 RUN set -ex \
     && curl -sL -o cmake.sh https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh \
+    && echo "${CMAKE_SHA256}  cmake.sh" | sha256sum --check \
     && mkdir -p /opt/cmake/ \
     && sh cmake.sh --skip-license --prefix=/opt/cmake \
     && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake \
     && rm cmake.sh
 
 # CONDA
-RUN curl -fsL -o ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py39_${CONDA_VERSION}-Linux-x86_64.sh
-RUN bash ~/miniconda.sh -b -p $CONDA_PATH
-RUN rm ~/miniconda.sh
+RUN curl -fsL -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py39_${CONDA_VERSION}-Linux-x86_64.sh
+RUN echo "${CONDA_SHA256}  miniconda.sh" | sha256sum --check
+RUN bash miniconda.sh -b -p $CONDA_PATH
+RUN rm miniconda.sh
 COPY ./conda.sh /etc/profile.d/conda.sh
 ENV PATH "${CONDA_PATH}/bin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
@@ -58,6 +69,8 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
+# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
+# be done using the https://get.rvm.io URL.
 RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.6.6 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
@@ -69,12 +82,14 @@ RUN conda install -c psi4 gcc-5
 
 # Install ssl in a custom location
 RUN curl -L -O http://www.openssl.org/source/openssl-1.1.1k.tar.gz
+RUN echo "892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5  openssl-1.1.1k.tar.gz" | sha256sum --check
 RUN tar -xzf openssl-1.1.1k.tar.gz
 RUN cd openssl-1.1.1k && ./config --prefix=/home/openssl --openssldir=/home/openssl
 RUN cd openssl-1.1.1k && make -j 8 && make install
 
 # Install python3.8 with custom openssl
 RUN curl -O -k https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tar.xz
+RUN echo "b356244e13fb5491da890b35b13b2118c3122977c2cd825e3eb6e7d462030d84  Python-3.8.0.tar.xz" | sha256sum --check
 RUN tar -xf Python-3.8.0.tar.xz -C /tmp/
 RUN cd /tmp/Python-3.8.0 && LDFLAGS="${LDFLAGS} -Wl,-rpath=/home/openssl/lib" ./configure --with-openssl=/home/openssl
 RUN cd /tmp/Python-3.8.0 && make -j 8 && make install
@@ -85,28 +100,32 @@ RUN python3.8 -m pip install -r requirements.txt
 
 # Install clang and llvm version 8
 # Using build for sles11 because the versions built for other distros target glibcs that are too new to be used from this image
-RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
-    tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ && \
-    rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
+RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz \
+    && echo "${CLANG_SHA256}  clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz" | sha256sum --check \
+    && tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ \
+    && rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
 
 # Install glibc 2.16
-RUN curl -LO https://ftp.gnu.org/gnu/glibc/glibc-2.16.0.tar.gz && \
-  tar zxvf glibc-2.16.0.tar.gz && \
-  cd glibc-2.16.0 && \
-  mkdir build && \
-  cd build && \
-  ../configure --prefix=/opt/glibc-2.16 && \
-  make -j 8 && \
-  make install
+RUN curl -LO https://ftp.gnu.org/gnu/glibc/glibc-2.16.0.tar.gz \
+  && echo "a75be51658cc1cfb6324ec6dbdbed416526c44c14814823129f0fcc74c279f6e  glibc-2.16.0.tar.gz" | sha256sum --check \
+  && tar zxvf glibc-2.16.0.tar.gz \
+  && cd glibc-2.16.0 \
+  && mkdir build \
+  && cd build && \
+  && ../configure --prefix=/opt/glibc-2.16 \
+  && make -j 8 \
+  && make install
 
 # Gimme
-RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme
+RUN echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin/gimme" | sha256sum --check
 RUN chmod +x /bin/gimme
 RUN gimme $GIMME_GO_VERSION
 COPY ./gobin.sh /etc/profile.d/
 
 # Automake
 RUN curl -OL https://ftp.gnu.org/gnu/automake/automake-1.16.tar.gz
+RUN echo "80da43bb5665596ee389e6d8b64b4f122ea4b92a685b1dbd813cd1f0e0c2d83f  automake-1.16.tar.gz"  | sha256sum --check
 RUN tar xzf automake-1.16.tar.gz
 # Patch automake to resolve a build error from building with a version of perl which is too old (see patch for more details)
 COPY ./omnibus-nikos_x64/automake.patch automake-1.16/automake.patch

--- a/rpm-arm/Dockerfile
+++ b/rpm-arm/Dockerfile
@@ -73,7 +73,8 @@ RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
 RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
     && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version latest-1.29 \
+    && bash get-rvm.sh stable --version 1.29.12 \
+    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install --with-arch='armv7-a' -C '--build' -C 'arm-linux-gnueabihf' 2.7 && rvm cleanup all"

--- a/rpm-arm/Dockerfile
+++ b/rpm-arm/Dockerfile
@@ -2,22 +2,20 @@ ARG BASE_IMAGE=arm32v7/centos:7
 
 FROM ubuntu as CERT_GETTER
 ENV CACERT_BUNDLE_VERSION=2022-02-01
+ENV CACERT_BUNDLE_SHA256="1d9195b76d2ea25c2b5ae9bee52d05075244d78fcd9c58ee0b6fac47d395a5eb"
 RUN apt-get update && apt-get install -y wget
 RUN wget https://curl.se/ca/cacert-${CACERT_BUNDLE_VERSION}.pem -O /cacert.pem
+RUN echo "${CACERT_BUNDLE_SHA256}  /cacert.pem" | sha256sum --check
 
 FROM ${BASE_IMAGE}
 
 # Build Args
 ARG GIMME_GO_VERSION=1.17.6
-ARG CMAKE_VERSION=3.14.4
-ARG CLANG_VERSION=8.0.0
 ARG DD_TARGET_ARCH=armhf
 
 # Environment
 ENV GOPATH /go
 ENV GIMME_GO_VERSION $GIMME_GO_VERSION
-ENV CMAKE_VERSION $CMAKE_VERSION
-ENV CLANG_VERSION $CLANG_VERSION
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 
 # configure yum and rpm for running on non-armv7l architectures
@@ -43,6 +41,7 @@ COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
 # Build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp
 RUN curl -sL -o /tmp/rpm-4.15.1.tar.bz2 http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2 \
+    && echo "ddef45f9601cd12042edfc9b6e37efcca32814e1e0f4bb8682d08144a3e2d230  /tmp/rpm-4.15.1.tar.bz2" | sha256sum --check \
     && cd /tmp \
     && tar -xjf /tmp/rpm-4.15.1.tar.bz2 \
     && cd rpm-4.15.1 \
@@ -72,6 +71,8 @@ RUN git clone --depth 1 https://github.com/DataDog/fakearmv7l ; \
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
+# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
+# be done using the https://get.rvm.io URL.
 RUN curl -sSL https://get.rvm.io | bash -s stable
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install --with-arch='armv7-a' -C '--build' -C 'arm-linux-gnueabihf' 2.7 && rvm cleanup all"
@@ -84,7 +85,8 @@ COPY ./requirements.txt /requirements.txt
 RUN ./setup_python.sh
 
 # Gimme
-RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme
+RUN echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin/gimme" | sha256sum --check
 RUN chmod +x /bin/gimme
 
 # GIMME_ARCH = GOARCH, so must be a valid entry from `goarchlist` here:

--- a/rpm-arm/Dockerfile
+++ b/rpm-arm/Dockerfile
@@ -71,9 +71,10 @@ RUN git clone --depth 1 https://github.com/DataDog/fakearmv7l ; \
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
-# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
-# be done using the https://get.rvm.io URL.
-RUN curl -sSL https://get.rvm.io | bash -s stable
+RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
+    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
+    && bash get-rvm.sh stable --version latest-1.29 \
+    && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install --with-arch='armv7-a' -C '--build' -C 'arm-linux-gnueabihf' 2.7 && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"

--- a/rpm-arm/Dockerfile
+++ b/rpm-arm/Dockerfile
@@ -40,6 +40,7 @@ COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
 
 # Build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp
+# Cannot use HTTPS here: cert name is invalid
 RUN curl -sL -o /tmp/rpm-4.15.1.tar.bz2 http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2 \
     && echo "ddef45f9601cd12042edfc9b6e37efcca32814e1e0f4bb8682d08144a3e2d230  /tmp/rpm-4.15.1.tar.bz2" | sha256sum --check \
     && cd /tmp \

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -39,6 +39,7 @@ COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
 
 # Build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp
+# Cannot use HTTPS here: cert name is invalid
 RUN curl -sL -o /tmp/rpm-4.15.1.tar.bz2 http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2 \
     && echo "ddef45f9601cd12042edfc9b6e37efcca32814e1e0f4bb8682d08144a3e2d230  /tmp/rpm-4.15.1.tar.bz2" | sha256sum --check \
     && cd /tmp \

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -69,9 +69,10 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
-# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
-# be done using the https://get.rvm.io URL.
-RUN curl -sSL https://get.rvm.io | bash -s stable
+RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
+    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
+    && bash get-rvm.sh stable --version latest-1.29 \
+    && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -71,7 +71,8 @@ RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
 RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
     && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version latest-1.29 \
+    && bash get-rvm.sh stable --version 1.29.12 \
+    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -2,15 +2,19 @@ ARG BASE_IMAGE=amazonlinux:2.0.20181114
 
 FROM ubuntu as CERT_GETTER
 ENV CACERT_BUNDLE_VERSION=2022-02-01
+ENV CACERT_BUNDLE_SHA256="1d9195b76d2ea25c2b5ae9bee52d05075244d78fcd9c58ee0b6fac47d395a5eb"
 RUN apt-get update && apt-get install -y wget
 RUN wget https://curl.se/ca/cacert-${CACERT_BUNDLE_VERSION}.pem -O /cacert.pem
+RUN echo "${CACERT_BUNDLE_SHA256}  /cacert.pem" | sha256sum --check
 
 FROM ${BASE_IMAGE}
 
 # Build Args
 ARG GIMME_GO_VERSION=1.17.6
 ARG CMAKE_VERSION=3.14.4
+ARG CMAKE_SHA256="3f692c33483d27a9722211eb0bcd8fe1dc6cb8753f5a9d4a66dc08ce6eda33e5"
 ARG CLANG_VERSION=8.0.0
+ARG CLANG_SHA256="a77eb8fde0a475c25d46dccdeb851a83cbeeeb11779fa2218ae19db9cd0e51f9"
 ARG DD_TARGET_ARCH=aarch64
 
 
@@ -18,7 +22,9 @@ ARG DD_TARGET_ARCH=aarch64
 ENV GOPATH /go
 ENV GIMME_GO_VERSION $GIMME_GO_VERSION
 ENV CMAKE_VERSION $CMAKE_VERSION
+ENV CMAKE_SHA256 $CMAKE_SHA256
 ENV CLANG_VERSION $CLANG_VERSION
+ENV CLANG_SHA256 $CLANG_SHA256
 ENV CONDA_PATH /root/miniforge3
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 
@@ -34,6 +40,7 @@ COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
 # Build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp
 RUN curl -sL -o /tmp/rpm-4.15.1.tar.bz2 http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2 \
+    && echo "ddef45f9601cd12042edfc9b6e37efcca32814e1e0f4bb8682d08144a3e2d230  /tmp/rpm-4.15.1.tar.bz2" | sha256sum --check \
     && cd /tmp \
     && tar -xjf /tmp/rpm-4.15.1.tar.bz2 \
     && cd rpm-4.15.1 \
@@ -62,28 +69,33 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
+# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
+# be done using the https://get.rvm.io URL.
 RUN curl -sSL https://get.rvm.io | bash -s stable
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Gimme
-RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme
+RUN echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin/gimme" | sha256sum --check
 RUN chmod +x /bin/gimme
 RUN gimme $GIMME_GO_VERSION
 COPY ./gobin.sh /etc/profile.d/
 
 # CMake. Pre-built using the build-cmake.sh script, to speed-up docker build.
-RUN curl -sL -O https://dd-agent-omnibus.s3.amazonaws.com/cmake-${CMAKE_VERSION}-amzn-aarch64.tar.xz && \
-    tar xf cmake-${CMAKE_VERSION}-amzn-aarch64.tar.xz --no-same-owner -kC / && \
-    rm cmake-${CMAKE_VERSION}-amzn-aarch64.tar.xz
+RUN curl -sL -O https://dd-agent-omnibus.s3.amazonaws.com/cmake-${CMAKE_VERSION}-amzn-aarch64.tar.xz \
+    && echo "${CMAKE_SHA256}  cmake-${CMAKE_VERSION}-amzn-aarch64.tar.xz" | sha256sum --check \
+    && tar xf cmake-${CMAKE_VERSION}-amzn-aarch64.tar.xz --no-same-owner -kC / \
+    && rm cmake-${CMAKE_VERSION}-amzn-aarch64.tar.xz
 ENV PATH="/opt/cmake/bin:$PATH"
 
 # Install clang and llvm version 8. Pre-built because building takes ~4 hours.
 # This was built from sources on centos 7, using the build-clang.sh script
-RUN curl -sL -o clang_llvm.tar.xz https://dd-agent-omnibus.s3.amazonaws.com/clang%2Bllvm-${CLANG_VERSION}-aarch64-linux.tar.xz && \
-    tar xf clang_llvm.tar.xz --no-same-owner -kC / && \
-    rm clang_llvm.tar.xz
+RUN curl -sL -o clang_llvm.tar.xz https://dd-agent-omnibus.s3.amazonaws.com/clang%2Bllvm-${CLANG_VERSION}-aarch64-linux.tar.xz \
+    && echo "${CLANG_SHA256}  clang_llvm.tar.xz" | sha256sum --check \
+    && tar xf clang_llvm.tar.xz --no-same-owner -kC / \
+    && rm clang_llvm.tar.xz
 ENV PATH="/opt/clang/bin:$PATH"
 
 # Entrypoint

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -118,7 +118,8 @@ RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
 RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
     && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version latest-1.29 \
+    && bash get-rvm.sh stable --version 1.29.12 \
+    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.6 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
@@ -179,8 +180,11 @@ ENV CPP=/opt/rh/devtoolset-1.1/root/usr/bin/cpp
 ENV CXX=/opt/rh/devtoolset-1.1/root/usr/bin/c++
 
 # Download and install golangci-lint
-# TODO: To be able to check sums, we need to pin the golangci-lint install script
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOPATH/bin v1.21.0
+RUN curl -sSfL -o golangci-lint-install.sh https://raw.githubusercontent.com/golangci/golangci-lint/v1.44.2/install.sh \
+    && echo "1c2edb726aad6bf7d260d95c370bd9ec0fb1a8651e6db6f77f250dd66067de0c  golangci-lint-install.sh" | sha256sum --check \
+    && sh ./golangci-lint-install.sh -b $GOPATH/bin v1.21.0 \
+    && echo "799a7a017f8b04058f61ae163684f5ef9808280ddab5aee4241bc9fa7e84bbc2 $GOPATH/bin/golangci-lint" | sha256sum --check \
+    && rm golangci-lint-install.sh
 
 # Entrypoint
 COPY ./entrypoint.sh /

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -183,7 +183,7 @@ ENV CXX=/opt/rh/devtoolset-1.1/root/usr/bin/c++
 RUN curl -sSfL -o golangci-lint-install.sh https://raw.githubusercontent.com/golangci/golangci-lint/v1.44.2/install.sh \
     && echo "1c2edb726aad6bf7d260d95c370bd9ec0fb1a8651e6db6f77f250dd66067de0c  golangci-lint-install.sh" | sha256sum --check \
     && sh ./golangci-lint-install.sh -b $GOPATH/bin v1.21.0 \
-    && echo "799a7a017f8b04058f61ae163684f5ef9808280ddab5aee4241bc9fa7e84bbc2 $GOPATH/bin/golangci-lint" | sha256sum --check \
+    && echo "799a7a017f8b04058f61ae163684f5ef9808280ddab5aee4241bc9fa7e84bbc2  $GOPATH/bin/golangci-lint" | sha256sum --check \
     && rm golangci-lint-install.sh
 
 # Entrypoint

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -74,6 +74,7 @@ RUN curl -sL -o /tmp/libarchive-3.1.2-12.el7.src.rpm https://vault.centos.org/7.
 
 # Actually build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp
+# Cannot use HTTPS here: cert name is invalid
 RUN curl -sL -o /tmp/rpm-4.15.1.tar.bz2 http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2 \
     && echo "ddef45f9601cd12042edfc9b6e37efcca32814e1e0f4bb8682d08144a3e2d230  /tmp/rpm-4.15.1.tar.bz2" | sha256sum --check \
     && cd /tmp \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -183,7 +183,7 @@ ENV CXX=/opt/rh/devtoolset-1.1/root/usr/bin/c++
 RUN curl -sSfL -o golangci-lint-install.sh https://raw.githubusercontent.com/golangci/golangci-lint/v1.44.2/install.sh \
     && echo "1c2edb726aad6bf7d260d95c370bd9ec0fb1a8651e6db6f77f250dd66067de0c  golangci-lint-install.sh" | sha256sum --check \
     && sh ./golangci-lint-install.sh -b $GOPATH/bin v1.21.0 \
-    && echo "799a7a017f8b04058f61ae163684f5ef9808280ddab5aee4241bc9fa7e84bbc2  $GOPATH/bin/golangci-lint" | sha256sum --check \
+    && echo "942efc00799b83aebaf6628c34e1151467b7fa21f0cfd78554279dc73f8c8ef3  $GOPATH/bin/golangci-lint" | sha256sum --check \
     && rm golangci-lint-install.sh
 
 # Entrypoint

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -116,9 +116,10 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
-# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
-# be done using the https://get.rvm.io URL.
-RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
+RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
+    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
+    && bash get-rvm.sh stable --version latest-1.29 \
+    && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.6 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -1,23 +1,35 @@
 FROM ubuntu as CERT_GETTER
-RUN apt-get update && apt-get install -y wget
 ENV CACERT_BUNDLE_VERSION=2022-02-01
+ENV CACERT_BUNDLE_SHA256="1d9195b76d2ea25c2b5ae9bee52d05075244d78fcd9c58ee0b6fac47d395a5eb"
+RUN apt-get update && apt-get install -y wget
 RUN wget https://curl.se/ca/cacert-${CACERT_BUNDLE_VERSION}.pem -O /cacert.pem
+RUN echo "${CACERT_BUNDLE_SHA256}  /cacert.pem" | sha256sum --check
 
 FROM centos:6
 
 # Build Args
+ARG GIT_VERSION=2.10.1
+ARG GIT_SHA256="78553f786f1a66cb68983c170be482558028a3376056c0f2ed366f331b1e35f2"
 ARG GIMME_GO_VERSION=1.17.6
 ARG IBM_MQ_VERSION=9.2.2.0
+ARG IBM_MQ_SHA256="aa619218371a3b27b94c7bbea4de57ed9651a4b8dd50a9525dabe8b9b3a64d61"
 ARG CMAKE_VERSION=3.14.4
+ARG CMAKE_SHA256="3337a648a3ac97b5e6a05f8a08ae97b71d37af48465dae4736932f8a3e85f368"
 ARG CLANG_VERSION=8.0.0
+ARG CLANG_SHA256="7e2846ff60c181d1f27d97c23c25a2295f5730b6d88612ddd53b4cbb8177c4b9"
 ARG DD_TARGET_ARCH=x64
 
 # Environment
 ENV GOPATH /go
+ENV GIT_VERSION $GIT_VERSION
+ENV GIT_SHA256 $GIT_SHA256
 ENV GIMME_GO_VERSION $GIMME_GO_VERSION
 ENV IBM_MQ_VERSION $IBM_MQ_VERSION
+ENV IBM_MQ_SHA256 $IBM_MQ_SHA256
 ENV CMAKE_VERSION $CMAKE_VERSION
+ENV CMAKE_SHA256 $CMAKE_SHA256
 ENV CLANG_VERSION $CLANG_VERSION
+ENV CLANG_SHA256 $CLANG_SHA256
 ENV CONDA_PATH /root/miniconda3
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 
@@ -44,6 +56,7 @@ RUN yum remove -y ruby
 # Autoconf
 # We need a newer version of autoconf to compile procps-ng and also new rpm version (installing 2.69 over 2.63).
 RUN curl -sL -o /tmp/autoconf-2.69.tar.gz https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz \
+    && echo "954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969  /tmp/autoconf-2.69.tar.gz" | sha256sum --check \
     && cd /tmp \
     && tar -xvf /tmp/autoconf-2.69.tar.gz --no-same-owner \
     && cd autoconf-2.69 \
@@ -54,6 +67,7 @@ RUN curl -sL -o /tmp/autoconf-2.69.tar.gz https://ftp.gnu.org/gnu/autoconf/autoc
 
 # New libarchive is required for the new rpm version
 RUN curl -sL -o /tmp/libarchive-3.1.2-12.el7.src.rpm https://vault.centos.org/7.7.1908/os/Source/SPackages/libarchive-3.1.2-12.el7.src.rpm \
+    && echo "9584008f5afe3fc18351c40c2cb627193f1d7c92480dea0161f11f6b63e575d2  /tmp/libarchive-3.1.2-12.el7.src.rpm" | sha256sum --check \
     && rpmbuild --rebuild /tmp/libarchive-3.1.2-12.el7.src.rpm \
     && rpm -Uvh --nodeps /root/rpmbuild/RPMS/x86_64/* \
     && rm -rf /tmp/libarchive-3.1.2-12.el7.src.rpm /root/rpmbuild
@@ -61,6 +75,7 @@ RUN curl -sL -o /tmp/libarchive-3.1.2-12.el7.src.rpm https://vault.centos.org/7.
 # Actually build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp
 RUN curl -sL -o /tmp/rpm-4.15.1.tar.bz2 http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2 \
+    && echo "ddef45f9601cd12042edfc9b6e37efcca32814e1e0f4bb8682d08144a3e2d230  /tmp/rpm-4.15.1.tar.bz2" | sha256sum --check \
     && cd /tmp \
     && tar -xjf /tmp/rpm-4.15.1.tar.bz2 \
     && cd rpm-4.15.1 \
@@ -77,12 +92,13 @@ RUN mkdir -p /usr/local/var/lib/rpm \
     && /usr/local/bin/rpm --rebuilddb
 
 # Git
-RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-2.10.1.tar.gz
+RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz
+RUN echo "${GIT_SHA256}  git-${GIT_VERSION}.tar.gz" | sha256sum --check
 # --no-same-owner: git tarball has a file with UID 110493 which makes pulling this image fail, because we use docker user namespacing and we can't have >65K UIDs.
-RUN tar xzf git-2.10.1.tar.gz --no-same-owner
-RUN cd git-2.10.1 && make prefix=/usr/local all
-RUN cd git-2.10.1 && make prefix=/usr/local install
-RUN rm -rf git-2.10.1 git-2.10.1.tar.gz
+RUN tar xzf git-${GIT_VERSION}.tar.gz --no-same-owner
+RUN cd git-${GIT_VERSION} && make prefix=/usr/local all
+RUN cd git-${GIT_VERSION} && make prefix=/usr/local install
+RUN rm -rf git-${GIT_VERSION} git-${GIT_VERSION}.tar.gz
 
 RUN git config --global user.email "package@datadoghq.com"
 RUN git config --global user.name "Bits"
@@ -100,13 +116,16 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
+# TODO: To be able to check sums, we need to pin the rvm install script, which cannot
+# be done using the https://get.rvm.io URL.
 RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.6 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Gimme
-RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme
+RUN echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin/gimme" | sha256sum --check
 RUN chmod +x /bin/gimme
 RUN gimme $GIMME_GO_VERSION
 COPY ./gobin.sh /etc/profile.d/
@@ -115,6 +134,7 @@ COPY ./gobin.sh /etc/profile.d/
 # IBM MQ
 RUN mkdir -p /opt/mqm \
     && curl "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/${IBM_MQ_VERSION}-IBM-MQC-Redist-LinuxX64.tar.gz" -o /tmp/mq_client.tar.gz \
+    && echo "${IBM_MQ_SHA256}  /tmp/mq_client.tar.gz" | sha256sum --check \
     && tar -C /opt/mqm -xf /tmp/mq_client.tar.gz \
     && rm -rf /tmp/mq_client.tar.gz
 
@@ -124,6 +144,7 @@ COPY ./rpm-headers/systemd /usr/include/systemd
 # CMake
 RUN set -ex \
     && curl -sL -o cmake.sh https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh \
+    && echo "${CMAKE_SHA256}  cmake.sh" | sha256sum --check \
     && mkdir -p /opt/cmake/ \
     && sh cmake.sh --skip-license --prefix=/opt/cmake \
     && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake \
@@ -131,15 +152,17 @@ RUN set -ex \
 
 # Install clang and llvm version 8
 # Using build for sles11 because the versions built for other distros target glibcs that are too new to be used from this image
-RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
-    tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ && \
-    rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
+RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz \
+    && echo "${CLANG_SHA256}  clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz" | sha256sum --check \
+    && tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ \
+    && rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
 
 # To build the EBPF code we need kernel headers for Linux 4.9
-RUN rm -r /usr/src/kernels/* && \
-    curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-rpm-x64.tgz && \
-    tar xf kernel-4.9-headers-rpm-x64.tgz --no-same-owner --strip 1 -C /usr && \
-    rm kernel-4.9-headers-rpm-x64.tgz
+RUN rm -r /usr/src/kernels/* \
+    && curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-rpm-x64.tgz \
+    && echo "1657ffa995654bc96405d4dbce0b17a55cd1eabd19479bc1611b0cb4f3c01fcc  kernel-4.9-headers-rpm-x64.tgz" | sha256sum --check \
+    && tar xf kernel-4.9-headers-rpm-x64.tgz --no-same-owner --strip 1 -C /usr \
+    && rm kernel-4.9-headers-rpm-x64.tgz
 
 # Update GCC: CentOS6 gcc-4.4 is a little too far behind what we use with the debian builder
 # Copy (and import through the repo file) the CERN signing key:
@@ -147,6 +170,7 @@ RUN rm -r /usr/src/kernels/* && \
 # uid                  CERN Linux Support (RPM signing key for CERN Linux Support) <linux.support@cern.ch>
 COPY rpm-x64/RPM-GPG-KEY-cern /etc/pki/rpm-gpg/RPM-GPG-KEY-cern
 RUN curl -o /etc/yum.repos.d/slc6-devtoolset.repo https://linuxsoft.cern.ch/cern/devtoolset/slc6-devtoolset.repo
+RUN echo "17a8cb10265d7c9ff285aa563c526ae0acc1871f54fcecd198ca9d3441322dfd  /etc/yum.repos.d/slc6-devtoolset.repo" | sha256sum --check
 RUN yum --enablerepo=slc6-devtoolset -y install devtoolset-1.1-gcc devtoolset-1.1-gcc-c++
 
 ENV CC=/opt/rh/devtoolset-1.1/root/usr/bin/gcc
@@ -154,6 +178,7 @@ ENV CPP=/opt/rh/devtoolset-1.1/root/usr/bin/cpp
 ENV CXX=/opt/rh/devtoolset-1.1/root/usr/bin/c++
 
 # Download and install golangci-lint
+# TODO: To be able to check sums, we need to pin the golangci-lint install script
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOPATH/bin v1.21.0
 
 # Entrypoint

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -12,6 +12,7 @@ function detect_distro(){
 case $DD_TARGET_ARCH in
 "x64")
     DD_CONDA_VERSION=4.9.2
+    DD_CONDA_SHA256="536817d1b14cb1ada88900f5be51ce0a5e042bae178b5550e62f61e223deae7c"
     CONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py39_${DD_CONDA_VERSION}-Linux-x86_64.sh
     # FIXME: Pinning specific zlib version as the latest one doesn't work in our old builders:
     # version GLIBC_2.14 not found (required by /root/miniconda3/envs/ddpy2/lib/python2.7/lib-dynload/../../libz.so.1)
@@ -22,6 +23,7 @@ case $DD_TARGET_ARCH in
     ;;
 "aarch64")
     DD_CONDA_VERSION=4.9.2-7
+    DD_CONDA_SHA256="ea7d631e558f687e0574857def38d2c8855776a92b0cf56cf5285bede54715d9"
     CONDA_URL=https://github.com/conda-forge/miniforge/releases/download/${DD_CONDA_VERSION}/Miniforge3-Linux-aarch64.sh
     PY2_VERSION=2
     PY3_VERSION=3.8.10
@@ -36,6 +38,7 @@ case $DD_TARGET_ARCH in
         libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev \
         libc6-dev libbz2-dev libffi-dev zlib1g-dev
         wget https://www.python.org/ftp/python/3.9.9/Python-3.9.9.tgz
+        echo "2cc7b67c1f3f66c571acc42479cdf691d8ed6b47bee12c9b68430413a17a44ea  Python-3.9.9.tgz" | sha256sum --check
         tar xzf Python-3.9.9.tgz
         pushd /Python-3.9.9
            ./configure
@@ -61,9 +64,10 @@ case $DD_TARGET_ARCH in
     exit -1
 esac
 
-curl -fsL -o ~/miniconda.sh $CONDA_URL
-bash ~/miniconda.sh -b
-rm ~/miniconda.sh
+curl -fsL -o miniconda.sh $CONDA_URL
+echo "${DD_CONDA_SHA256}  miniconda.sh" | sha256sum --check
+bash miniconda.sh -b
+rm miniconda.sh
 
 PATH="${CONDA_PATH}/bin:${PATH}"
 conda init bash

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -100,7 +100,8 @@ RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
 RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
     && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version latest-1.29 \
+    && bash get-rvm.sh stable --version 1.29.12 \
+    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
 RUN bash -l -c "rvm autolibs disable" # do not try to fetch requirements from system repos
 RUN bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -1,8 +1,14 @@
 FROM ubuntu as CURL_GETTER
 RUN apt-get update && apt-get install -y wget
-RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-amd64
+ENV WGET_VERSION=7.79.1
+ENV WGET_SHA256="0a89440848db3ba21d38b93b450d90fb84d4d0fa5562aa9c6933070b0eddc960"
 ENV CACERT_BUNDLE_VERSION=2022-02-01
+ENV CACERT_BUNDLE_SHA256="1d9195b76d2ea25c2b5ae9bee52d05075244d78fcd9c58ee0b6fac47d395a5eb"
+RUN apt-get update && apt-get install -y wget
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/v${WGET_VERSION}/curl-amd64
+RUN echo "${WGET_SHA256}  curl-amd64" | sha256sum --check
 RUN wget https://curl.se/ca/cacert-${CACERT_BUNDLE_VERSION}.pem -O /cacert.pem
+RUN echo "${CACERT_BUNDLE_SHA256}  /cacert.pem" | sha256sum --check
 
 # We use OpenSUSE 42.1, which is based on SLES 12.1
 FROM opensuse/archive:42.1
@@ -10,16 +16,22 @@ FROM opensuse/archive:42.1
 # Build Args
 ARG GIMME_GO_VERSION=1.17.6
 ARG IBM_MQ_VERSION=9.2.2.0
+ARG IBM_MQ_SHA256="aa619218371a3b27b94c7bbea4de57ed9651a4b8dd50a9525dabe8b9b3a64d61"
 ARG CMAKE_VERSION=3.14.4
+ARG CMAKE_SHA256="3337a648a3ac97b5e6a05f8a08ae97b71d37af48465dae4736932f8a3e85f368"
 ARG CLANG_VERSION=8.0.0
+ARG CLANG_SHA256="7e2846ff60c181d1f27d97c23c25a2295f5730b6d88612ddd53b4cbb8177c4b9"
 ARG DD_TARGET_ARCH=x64
 
 # Environment
 ENV GOPATH /go
 ENV GIMME_GO_VERSION $GIMME_GO_VERSION
 ENV IBM_MQ_VERSION $IBM_MQ_VERSION
+ENV IBM_MQ_SHA256 $IBM_MQ_SHA256
 ENV CMAKE_VERSION $CMAKE_VERSION
+ENV CMAKE_SHA256 $CMAKE_SHA256
 ENV CLANG_VERSION $CLANG_VERSION
+ENV CLANG_SHA256 $CLANG_SHA256
 ENV CONDA_PATH /root/miniconda3
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 ENV PATH="/opt/datadog/bin:${PATH}"
@@ -57,7 +69,8 @@ COPY --from=CURL_GETTER /curl-amd64 /opt/datadog/bin/curl
 RUN chmod +x /opt/datadog/bin/curl
 
 # Gimme
-RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme
+RUN echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin/gimme" | sha256sum --check
 RUN chmod +x /bin/gimme
 RUN gimme $GIMME_GO_VERSION
 COPY ./gobin.sh /etc/profile.d/
@@ -68,6 +81,7 @@ COPY ./rpm-headers/systemd /usr/include/systemd
 # IBM MQ
 RUN mkdir -p /opt/mqm \
     && curl "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/${IBM_MQ_VERSION}-IBM-MQC-Redist-LinuxX64.tar.gz" -o /tmp/mq_client.tar.gz \
+    && echo "${IBM_MQ_SHA256}  /tmp/mq_client.tar.gz" | sha256sum --check \
     && tar -C /opt/mqm -xf /tmp/mq_client.tar.gz \
     && rm -rf /tmp/mq_client.tar.gz
 
@@ -95,6 +109,7 @@ RUN bash -l -c "gem install bundler --no-document"
 # CMake
 RUN set -ex \
     && curl -sL -o cmake.sh https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh \
+    && echo "${CMAKE_SHA256}  cmake.sh" | sha256sum --check \
     && mkdir -p /opt/cmake/ \
     && sh cmake.sh --skip-license --prefix=/opt/cmake \
     && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake \
@@ -102,17 +117,22 @@ RUN set -ex \
 
 # Install clang and llvm version 8
 # Using build for sles11 because the versions built for other distros target glibcs that are too new to be used from this image
-RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
-    tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ && \
-    rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
+RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz \
+    && echo "${CLANG_SHA256}  clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz" | sha256sum --check \
+    && tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ \
+    && rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
 
 # To build the EBPF code we need kernel headers for Linux 4.9
-RUN curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-rpm-x64.tgz && \
-    tar xf kernel-4.9-headers-rpm-x64.tgz --no-same-owner --strip 1 -C /usr && \
-    rm kernel-4.9-headers-rpm-x64.tgz
+RUN curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-rpm-x64.tgz \
+    && echo "1657ffa995654bc96405d4dbce0b17a55cd1eabd19479bc1611b0cb4f3c01fcc  kernel-4.9-headers-rpm-x64.tgz" | sha256sum --check \
+    && rm kernel-4.9-headers-rpm-x64.tgz
 
 # Rust is needed to compile the cryptography python lib
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.41.0
+RUN curl -sSL -O https://static.rust-lang.org/rustup/archive/1.24.3/x86_64-unknown-linux-gnu/rustup-init \
+    && echo "3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338  rustup-init" | sha256sum --check \
+    && chmod +x rustup-init \
+    && ./rustup-init -y --default-toolchain 1.41.0 \
+    && rm rustup-init
 ENV PATH "~/.cargo/bin:${PATH}"
 
 # Entrypoint

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -84,7 +84,10 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*
 RUN rm -rf /gpg-keys
-RUN curl -sSL https://get.rvm.io | bash -s stable
+RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
+    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
+    && bash get-rvm.sh stable --version latest-1.29 \
+    && rm get-rvm.sh
 RUN bash -l -c "rvm autolibs disable" # do not try to fetch requirements from system repos
 RUN bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN bash -l -c "gem install bundler --no-document"

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         wget \
         xz-utils
 
-RUN wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme
 RUN echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin/gimme" | sha256sum --check
 RUN chmod +x /bin/gimme
 RUN gimme $GIMME_GO_VERSION
@@ -52,7 +52,7 @@ RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 
 # install clang from the website since the package manager can change at any time
 RUN wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.1/clang+llvm-11.0.1-aarch64-linux-gnu.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
-RUN echo "39b3d3e3b534e327d90c77045058e5fc924b1a81d349eac2be6fb80f4a0e40d4  clang+llvm-11.0.1-aarch64-linux-gnu.tar.xz" | sha256sum --check
+RUN echo "39b3d3e3b534e327d90c77045058e5fc924b1a81d349eac2be6fb80f4a0e40d4  /tmp/clang.tar.xz" | sha256sum --check
 RUN mkdir -p /opt/clang
 RUN tar xf /tmp/clang.tar.xz --no-same-owner -C /opt/clang --strip-components=1
 ENV PATH "/opt/clang/bin:${PATH}"

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         wget \
         xz-utils
 
-RUN wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme
+RUN wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+RUN echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin/gimme" | sha256sum --check
 RUN chmod +x /bin/gimme
 RUN gimme $GIMME_GO_VERSION
 
@@ -51,6 +52,7 @@ RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 
 # install clang from the website since the package manager can change at any time
 RUN wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.1/clang+llvm-11.0.1-aarch64-linux-gnu.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
+RUN echo "39b3d3e3b534e327d90c77045058e5fc924b1a81d349eac2be6fb80f4a0e40d4  clang+llvm-11.0.1-aarch64-linux-gnu.tar.xz" | sha256sum --check
 RUN mkdir -p /opt/clang
 RUN tar xf /tmp/clang.tar.xz --no-same-owner -C /opt/clang --strip-components=1
 ENV PATH "/opt/clang/bin:${PATH}"

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -41,7 +41,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         wget \
         xz-utils
 
-RUN wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme
+RUN wget -O /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme
+RUN echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin/gimme" | sha256sum --check
 RUN chmod +x /bin/gimme
 RUN gimme $GIMME_GO_VERSION
 
@@ -52,6 +53,7 @@ RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 
 # install clang from the website since the package manager can change at any time
 RUN wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.1/clang+llvm-11.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
+RUN echo "67f18660231d7dd09dc93502f712613247b7b4395e6f48c11226629b250b53c5  clang+llvm-11.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz" | sha256sum --check
 RUN mkdir -p /opt/clang
 RUN tar xf /tmp/clang.tar.xz --no-same-owner -C /opt/clang --strip-components=1
 ENV PATH "/opt/clang/bin:${PATH}"

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -53,7 +53,7 @@ RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
 
 # install clang from the website since the package manager can change at any time
 RUN wget "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.1/clang+llvm-11.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz" -O /tmp/clang.tar.xz  -o /dev/null
-RUN echo "67f18660231d7dd09dc93502f712613247b7b4395e6f48c11226629b250b53c5  clang+llvm-11.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz" | sha256sum --check
+RUN echo "67f18660231d7dd09dc93502f712613247b7b4395e6f48c11226629b250b53c5  /tmp/clang.tar.xz" | sha256sum --check
 RUN mkdir -p /opt/clang
 RUN tar xf /tmp/clang.tar.xz --no-same-owner -C /opt/clang --strip-components=1
 ENV PATH "/opt/clang/bin:${PATH}"

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -24,21 +24,33 @@ ARG DD_TARGET_ARCH
 ENV TARGET_ARCH=${DD_TARGET_ARCH:-x64}
 
 ENV GIT_VERSION "2.26.2"
-ENV SEVENZIP_VERSION "19.0.0" # now needs all 3 digits
+ENV GIT_SHA256 "2dfbb1c46547c70179442a92b8593d592292b8bce2fd02ac4e0051a8072dde8f"
+ENV SEVENZIP_VERSION "19.0.0"
+ENV SEVENZIP_SHA256 "0f5d4dbbe5e55b7aa31b91e5925ed901fdf46a367491d81381846f05ad54c45e"
 ENV VS2017BUILDTOOLS_VERSION "16.8.3.0"
+ENV VS2017BUILDTOOLS_SHA256 "ccfb9355f4f753315455542f966025f96de734292d3908c8c3717e9685b709f0"
 #ENV VS2017BUILDTOOLS_DOWNLOAD_URL "https://download.visualstudio.microsoft.com/download/pr/d0eac510-174b-4241-b73b-93dc7cc1fbf7/9822b4c851e14d9658babd1533f66f518c6169196e985fe5713b2774128832ae/vs_BuildTools.exe"
 ENV VS2017BUILDTOOLS_DOWNLOAD_URL "https://download.visualstudio.microsoft.com/download/pr/9b3476ff-6d0a-4ff8-956d-270147f21cd4/ccfb9355f4f753315455542f966025f96de734292d3908c8c3717e9685b709f0/vs_BuildTools.exe"
-ENV VCPYTHON27_VERSION "9.0.0.30729"
 ENV GO_VERSION "1.17.6"
+ENV GO_SHA256 "5bf8f87aec7edfc08e6bc845f1c30dba6de32b863f89ae46553ff4bbcc1d4954"
 ENV RUBY_VERSION "2.6.6-1"
+ENV RUBY_SHA256 "fbdf77a3e1fa36e25cf0af1303ac76f67dec7a6f739a829784a299702cad1492"
 ENV IBM_MQ_VERSION "9.2.2.0"
+ENV IBM_MQ_SHA256 "1cf718a4efc5d591452f1ebab5d880d9e52ef6447c5c8b098ccec2486bd74745"
 ENV PYTHON_VERSION "3.8.2"
+ENV PYTHON_SHA256 "8e400e3f32cdcb746e62e0db4d3ae4cba1f927141ebc4d0d5a4006b0daee8921"
 ENV WIX_VERSION "3.11.2"
+ENV WIX_SHA256 "32bb76c478fcb356671d4aaf006ad81ca93eea32c22a9401b168fc7471feccd2"
 ENV CMAKE_VERSION "3.17.2"
+ENV CMAKE_SHA256 "06e999be9e50f9d33945aeae698b9b83678c3f98cedb3139a84e19636d2f6433"
 ENV MSYS_VERSION "20210725"
+ENV MSYS_SHA256 "4013a9d5e51b448343efc24fc6a324cc999bb96b4c01b13a6bd3c661bb5c8a82"
 ENV NUGET_VERSION "5.8.0"
+ENV NUGET_SHA256 "5c5b9c96165d3283b2cb9e5b65825d343e0e7139b9e70a250b4bb24c2285f3ba"
 ENV EMBEDDED_PYTHON_2_VERSION "2.7.17"
+ENV EMBEDDED_PYTHON_2_SHA256 "557ea6690c5927360656c003d3114b73adbd755b712a2911975dde813d6d7afb"
 ENV EMBEDDED_PYTHON_3_VERSION "3.8.1"
+ENV EMBEDDED_PYTHON_3_SHA256 "58563ca60891025923572107e02b8f07439928eb5222dd10466cc92089072c2a"
 ENV EMBEDDED_PIP_VERSION "20.3.4"
 
 ENV CACERTS_HASH "1d9195b76d2ea25c2b5ae9bee52d05075244d78fcd9c58ee0b6fac47d395a5eb"
@@ -50,7 +62,6 @@ LABEL windows_version=${WINDOWS_VERSION}
 LABEL git_version=${GIT_VERSION}
 LABEL sevenzip_version=${SEVENZIP_VERSION}
 LABEL vs2017buildtools_version=${VS2017BUILDTOOLS_VERSION}
-LABEL vcpython27_version=${VCPYTHON27_VERSION}
 LABEL go_version=${GO_VERSION}
 LABEL ruby_version=${RUBY_VERSION}
 LABEL wix_version=${WIX_VERSION}
@@ -64,7 +75,7 @@ LABEL nuget_version=${NUGET_VERSION}
 # We need to trust the DigiCert High Assurance EV Root CA certificate, which signs python.org,
 # to be able to download some Python components during the Agent build.
 RUN (New-Object System.Net.WebClient).DownloadFile(\"https://curl.haxx.se/ca/cacert-${ENV:CACERTS_VERSION}.pem\", \"cacert.pem\")
-RUN if ((Get-FileHash .\cacert.pem).Hash -ne \"$ENV:CACERTS_HASH\") { Write-Host \"Wrong hashsum for cacert.pem: got '$((Get-FileHash .\cacert.pem).Hash)', expected '$ENV:CACERTS_HASH'.\"; exit 1 }
+RUN if ((Get-FileHash -Algorithm SHA256 .\cacert.pem).Hash -ne \"$ENV:CACERTS_HASH\") { Write-Host \"Wrong hashsum for cacert.pem: got '$((Get-FileHash -Algorithm SHA256 .\cacert.pem).Hash)', expected '$ENV:CACERTS_HASH'.\"; exit 1 }
 RUN setx SSL_CERT_FILE \"C:\cacert.pem\"
 
 ### Preliminary step: we need both the .NET 3.5 runtime and
@@ -86,11 +97,11 @@ RUN Powershell -C .\install_net35.ps1
 
 # Install 7-zip
 Copy ./windows/install_7zip.ps1 install_7zip.ps1
-RUN powershell -Command .\install_7zip.ps1 -Version $ENV:SEVENZIP_VERSION
+RUN powershell -Command .\install_7zip.ps1 -Version $ENV:SEVENZIP_VERSION -Sha256 $ENV:SEVENZIP_SHA256
 
 # Install git
 COPY ./windows/install_mingit.ps1 install_mingit.ps1
-RUN powershell -Command .\install_mingit.ps1 -Version $ENV:GIT_VERSION
+RUN powershell -Command .\install_mingit.ps1 -Version $ENV:GIT_VERSION -Sha256 $ENV:GIT_SHA256
 
 ### HACK: we disable symbolic links when cloning repositories
 ### to work around a symlink-related failure in the agent-binaries omnibus project
@@ -99,7 +110,7 @@ RUN git config --system core.symlinks false
 
 # Install VS2017
 COPY ./windows/install_vstudio.ps1 install_vstudio.ps1
-RUN powershell -Command .\install_vstudio.ps1 -Version $ENV:VS2017BUILDTOOLS_VERSION $ENV:VS2017BUILDTOOLS_DOWNLOAD_URL
+RUN powershell -Command .\install_vstudio.ps1 -Version $ENV:VS2017BUILDTOOLS_VERSION -Sha256 $ENV:VS2017BUILDTOOLS_SHA256 $ENV:VS2017BUILDTOOLS_DOWNLOAD_URL
 
 # If x64, install the WDK for driver development
 COPY ./windows/install_wdk.ps1 install_wdk.ps1
@@ -107,7 +118,7 @@ RUN if ($Env:TARGET_ARCH -eq 'x64') { powershell -Command .\install_wdk.ps1 }
 
 # Install Wix and update PATH to include it
 COPY ./windows/install_wix.ps1 install_wix.ps1
-RUN powershell -Command .\install_wix.ps1 -Version $ENV:WIX_VERSION
+RUN powershell -Command .\install_wix.ps1 -Version $ENV:WIX_VERSION -Sha256 $ENV:WIX_SHA256
 
 # Install dotnet core
 COPY ./windows/install_dotnetcore.ps1 install_dotnetcore.ps1
@@ -115,7 +126,7 @@ RUN powershell -Command .\install_dotnetcore.ps1
 
 # install nuget
 COPY ./windows/install_nuget.ps1 install_nuget.ps1
-RUN powershell -Command .\install_nuget.ps1 $ENV:NUGET_VERSION
+RUN powershell -Command .\install_nuget.ps1 -Version $ENV:NUGET_VERSION -Sha256 $ENV:NUGET_SHA256
 
 # Install VC compiler for Python 2.7
 COPY ./windows/install_vcpython.ps1 install_vcpython.ps1
@@ -123,12 +134,12 @@ RUN powershell -Command .\install_vcpython.ps1
 
 # Install IBM MQ
 COPY ./windows/install_ibm_mq.ps1 install_ibm_mq.ps1
-RUN Powershell -C .\install_ibm_mq.ps1 $ENV:IBM_MQ_VERSION
+RUN Powershell -C .\install_ibm_mq.ps1 -Version $ENV:IBM_MQ_VERSION -Sha256 $ENV:IBM_MQ_SHA256
 RUN setx MQ_FILE_PATH c:\ibm_mq
 
 # Install Cmake and update PATH to include it
 COPY ./windows/install_cmake.ps1 install_cmake.ps1
-RUN powershell -Command .\install_cmake.ps1 -Version $ENV:CMAKE_VERSION -Arch $ENV:TARGET_ARCH
+RUN powershell -Command .\install_cmake.ps1 -Version $ENV:CMAKE_VERSION -Sha256 $ENV:CMAKE_SHA256
 
 # Install golang and set GOPATH to the dev path used in builds & tests
 # RUN cinst -y --no-progress golang $ENV:CHOCO_ARCH_FLAG --version $ENV:GO_VERSION
@@ -143,15 +154,15 @@ RUN setx GOPATH C:\dev\go
 # We always install the 64 bit version because vcredist140 won't work otherwise
 COPY ./windows/install_python.ps1 install_python.ps1
 COPY ./requirements.txt /requirements.txt
-RUN powershell -C .\install_python.ps1 -Version $ENV:PYTHON_VERSION
+RUN powershell -C .\install_python.ps1 -Version $ENV:PYTHON_VERSION -Sha256 $ENV:PYTHON_SHA256
 
 # Install 64-bit ruby and bundler (for omnibus builds)
 COPY ./windows/install_ruby.ps1 install_ruby.ps1
-RUN powershell -C .\install_ruby.ps1 -Version $ENV:RUBY_VERSION
+RUN powershell -C .\install_ruby.ps1 -Version $ENV:RUBY_VERSION -Sha256 $ENV:RUBY_SHA256
 
 # Install msys2 system & install 64-bit C/C++ compilation toolchain
 copy ./windows/install_msys.ps1 install_msys.ps1
-RUN powershell -C .\install_msys.ps1 -Version $ENV:MSYS_VERSION
+RUN powershell -C .\install_msys.ps1 -Version $ENV:MSYS_VERSION -Sha256 $ENV:MSYS_SHA256
 
 RUN ridk install 3
 

--- a/windows/install_7zip.ps1
+++ b/windows/install_7zip.ps1
@@ -1,5 +1,6 @@
 param (
-    [Parameter(Mandatory=$true)][string]$Version
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Sha256
 )
 
 # Enabled TLS12
@@ -15,6 +16,8 @@ $sevenzip="https://www.7-zip.org/a/7z$($shortenedver)-x64.exe"
 Write-Host -ForegroundColor Green "Installing 7zip $sevenzip"
 $out = "$($PSScriptRoot)\7zip.exe"
 (New-Object System.Net.WebClient).DownloadFile($sevenzip, $out)
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$Sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$Sha256'.\"; exit 1 }
+
 Start-Process 7zip.exe -ArgumentList '/S' -Wait
 Remove-Item $out
 setx PATH "$Env:Path;c:\program files\7-zip"

--- a/windows/install_awscli.ps1
+++ b/windows/install_awscli.ps1
@@ -7,8 +7,11 @@ $awscli = 'https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi'
 ## installs awscli inside container
 Write-Host -ForegroundColor Green Installing awscli
 $out = 'awscli.msi'
+$sha256 = "e930336fb14872f6bd8fd2a6856d5a3052ad457fd8cd0279c97c629487a05b26"
 (New-Object System.Net.WebClient).DownloadFile($awscli, $out)
 Start-Process msiexec -ArgumentList '/q /i awscli.msi' -Wait
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$sha256'.\"; exit 1 }
+
 Remove-Item $out
 setx PATH "$Env:Path;c:\program files\amazon\awscli\bin"
 $Env:Path="$Env:Path;c:\program files\amazon\awscli\bin"

--- a/windows/install_awscli.ps1
+++ b/windows/install_awscli.ps1
@@ -7,10 +7,10 @@ $awscli = 'https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi'
 ## installs awscli inside container
 Write-Host -ForegroundColor Green Installing awscli
 $out = 'awscli.msi'
-$sha256 = "e930336fb14872f6bd8fd2a6856d5a3052ad457fd8cd0279c97c629487a05b26"
+$sha256 = "c647a7d738fb4745c08d8b5c9687fc2d4824868d2f350613ed250a2996ead3ed"
 (New-Object System.Net.WebClient).DownloadFile($awscli, $out)
-Start-Process msiexec -ArgumentList '/q /i awscli.msi' -Wait
 if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$sha256'.\"; exit 1 }
+Start-Process msiexec -ArgumentList '/q /i awscli.msi' -Wait
 
 Remove-Item $out
 setx PATH "$Env:Path;c:\program files\amazon\awscli\bin"

--- a/windows/install_cmake.ps1
+++ b/windows/install_cmake.ps1
@@ -1,6 +1,6 @@
 param (
     [Parameter(Mandatory=$true)][string]$Version,
-    [Parameter(Mandatory=$true)][string]$Arch
+    [Parameter(Mandatory=$true)][string]$Sha256
 )
 
 # Enabled TLS12
@@ -15,19 +15,12 @@ $splitver = $Version.split(".")
 $majmin = "$($splitver[0])$($splitver[1])" 
 
 # https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-win64-x64.msi
-# https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-win32-x86.msi
-$cmakeurl = ""
-if($Arch -eq 'x64' ) {
-    $cmakeurl = "https://github.com/Kitware/CMake/releases/download/v$($Version)/cmake-$($Version)-win64-x64.msi"
-} else {
-    $cmakeurl = "https://github.com/Kitware/CMake/releases/download/v$($Version)/cmake-$($Version)-win32-x86.msi"
-}
-
+$cmakeurl = "https://github.com/Kitware/CMake/releases/download/v$($Version)/cmake-$($Version)-win64-x64.msi"
 
 Write-Host  -ForegroundColor Green starting with CMake
 $out = "$($PSScriptRoot)\cmake.msi"
 (New-Object System.Net.WebClient).DownloadFile($cmakeurl, $out)
-
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$Sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$Sha256'.\"; exit 1 }
 
 Start-Process msiexec -ArgumentList "/q /i $($out) ADD_CMAKE_TO_PATH=System" -Wait
 

--- a/windows/install_docker.ps1
+++ b/windows/install_docker.ps1
@@ -5,15 +5,24 @@ mkdir C:\Docker
 
 # Docker CLI builds maintained by a Docker engineer
 $dockerVersion = "19.03.3"
-Invoke-WebRequest -Uri "https://github.com/StefanScherer/docker-cli-builder/releases/download/$dockerVersion/docker.exe" -OutFile "C:\Docker\docker.exe"
+$out = "C:\Docker\docker.exe"
+$sha256 = "2d6ff967c717a38dd41f5ad418396bdeb84642fe04985b30925e38f593d386da"
+Invoke-WebRequest -Uri "https://github.com/StefanScherer/docker-cli-builder/releases/download/$dockerVersion/docker.exe" -OutFile $out
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$sha256'.\"; exit 1 }
 
 # Install manifest-tool
 $manifestVersion = "v1.0.1"
-Invoke-WebRequest -Uri "https://github.com/estesp/manifest-tool/releases/download/$manifestVersion/manifest-tool-windows-amd64.exe" -OutFile "C:\Docker\manifest-tool.exe"
+$out = "C:\Docker\manifest-tool.exe"
+$sha256 = "41c08bc1052534f07282eae1f2998e542734b53e79e8d84e4f989ac1c27b2861"
+Invoke-WebRequest -Uri "https://github.com/estesp/manifest-tool/releases/download/$manifestVersion/manifest-tool-windows-amd64.exe" -OutFile $out
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$sha256'.\"; exit 1 }
 
 # Install notary
 $notaryVersion = "v0.6.1"
-Invoke-WebRequest -Uri "https://github.com/theupdateframework/notary/releases/download/$notaryVersion/notary-Windows-amd64.exe" -OutFile "C:\Docker\notary.exe"
+$out = "C:\Docker\notary.exe"
+$sha256 = "9d736f9b569b6a6a3de30cbfa3c60a764acdd445cf4ced760efa9d370bcad64f"
+Invoke-WebRequest -Uri "https://github.com/theupdateframework/notary/releases/download/$notaryVersion/notary-Windows-amd64.exe" -OutFile $out
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$sha256'.\"; exit 1 }
 
 # Add Docker to path
 setx PATH "$Env:Path;C:\Docker"

--- a/windows/install_dotnetcore.ps1
+++ b/windows/install_dotnetcore.ps1
@@ -10,9 +10,11 @@ $url = "https://download.visualstudio.microsoft.com/download/pr/0f71eaf1-ce85-48
 Write-Host -ForegroundColor Green "Installing dotnetcore from $($Url)"
 
 $out = "$($PSScriptRoot)\dotnetcoresdk.exe"
+$sha256 = "1fcf6b9efd37d25e75b426cd8430eb3c006092bee07d748967f1dbfc3f9a0190"
 
 Write-Host -ForegroundColor Green Downloading $Url to $out
 (New-Object System.Net.WebClient).DownloadFile($Url, $out)
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$sha256'.\"; exit 1 }
 
 # Skip extraction of XML docs - generally not useful within an image/container - helps performance
 setx NUGET_XMLDOC_MODE skip

--- a/windows/install_embedded_pythons.ps1
+++ b/windows/install_embedded_pythons.ps1
@@ -49,17 +49,14 @@ function DownloadAndExpandTo{
 $py2 = "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-${Env:EMBEDDED_PYTHON_2_VERSION}-amd64.zip"
 $py3 = "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-${Env:EMBEDDED_PYTHON_3_VERSION}-amd64.zip"
 
-if ( $Env:TARGET_ARCH -eq "x86") {
-    $py2 = "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-${Env:EMBEDDED_PYTHON_2_VERSION}-x86.zip"
-    $py3 = "https://s3.amazonaws.com/dd-agent-omnibus/python-windows-${Env:EMBEDDED_PYTHON_3_VERSION}-x86.zip"
-} 
-
-
 $py2Target = "c:\embeddedpy\py${Env:EMBEDDED_PYTHON_2_VERSION}"
 $py3Target = "c:\embeddedpy\py${Env:EMBEDDED_PYTHON_3_VERSION}"
 
 DownloadAndExpandTo -TargetDir $py2Target -SourceURL $py2
+if ((Get-FileHash -Algorithm SHA256 $py2Target).Hash -ne "$Env:EMBEDDED_PYTHON_2_SHA256") { Write-Host \"Wrong hashsum for $py2Target: got '$((Get-FileHash -Algorithm SHA256 $py2Target).Hash)', expected '$Env:EMBEDDED_PYTHON_2_SHA256'.\"; exit 1 }
+
 DownloadAndExpandTo -TargetDir $py3Target -SourceURL $py3
+if ((Get-FileHash -Algorithm SHA256 $py3Target).Hash -ne "$Env:EMBEDDED_PYTHON_3_SHA256") { Write-Host \"Wrong hashsum for $py3Target: got '$((Get-FileHash -Algorithm SHA256 $py3Target).Hash)', expected '$Env:EMBEDDED_PYTHON_3_SHA256'.\"; exit 1 }
 
 setx TEST_EMBEDDED_PY2 $py2Target
 setx TEST_EMBEDDED_PY3 $py3Target

--- a/windows/install_gcloud_sdk.ps1
+++ b/windows/install_gcloud_sdk.ps1
@@ -6,9 +6,12 @@ Write-Host -ForegroundColor Green Installing Google Cloud SDK
 $version = "315.0.0"
 $gsdk = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$version-windows-x86_64.zip"
 $out = 'gsdk.zip'
+$sha256 = "c9b283c9db4ed472111ccf32e6689fd467daf18ce3a77b8e601f9c646a83d86b"
 
 Write-Host -ForegroundColor Green Downloading $gsdk to $out
 (New-Object System.Net.WebClient).DownloadFile($gsdk, $out)
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$sha256'.\"; exit 1 }
+
 Get-ChildItem $out
 
 # write file size to make sure it worked

--- a/windows/install_go.ps1
+++ b/windows/install_go.ps1
@@ -4,15 +4,13 @@ $ProgressPreference = 'SilentlyContinue'
 Write-Host -ForegroundColor Green "Installing go $ENV:GO_VERSION"
 
 $gozip = "https://dl.google.com/go/go$ENV:GO_VERSION.windows-amd64.zip"
-if ($Env:TARGET_ARCH -eq "x86") {
-    $gozip = "https://dl.google.com/go/go$ENV:GO_VERSION.windows-386.zip"
-}
 
 $out = 'go.zip'
 
 Write-Host -ForegroundColor Green "Downloading $gozip to $out"
 
 (New-Object System.Net.WebClient).DownloadFile($gozip, $out)
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$ENV:GO_SHA256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$ENV:GO_SHA256'.\"; exit 1 }
 
 Write-Host -ForegroundColor Green "Extracting $out to c:\"
 

--- a/windows/install_ibm_mq.ps1
+++ b/windows/install_ibm_mq.ps1
@@ -1,5 +1,6 @@
 param (
-    [Parameter(Mandatory=$true)][string]$Version
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Sha256
 )
 
 $ErrorActionPreference = 'Stop'
@@ -39,3 +40,4 @@ $source = "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messag
 $target = "c:\ibm_mq"
 
 DownloadAndExpandTo -TargetDir $target -SourceURL $source
+if ((Get-FileHash -Algorithm SHA256 $target).Hash -ne "$Sha256") { Write-Host \"Wrong hashsum for ${target}: got '$((Get-FileHash -Algorithm SHA256 $target).Hash)', expected '$Sha256'.\"; exit 1 }

--- a/windows/install_mingit.ps1
+++ b/windows/install_mingit.ps1
@@ -1,5 +1,6 @@
 param (
-    [Parameter(Mandatory=$true)][string]$Version
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Sha256
 )
 
 # Enabled TLS12
@@ -14,6 +15,8 @@ $mingit = "https://github.com/git-for-windows/git/releases/download/v$($Version)
 Write-Host -ForegroundColor Green Installing MinGit
 $out = "$($PSScriptRoot)\mingit.zip"
 (New-Object System.Net.WebClient).DownloadFile($mingit, $out)
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$Sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$Sha256'.\"; exit 1 }
+
 md c:\devtools\git
 & '7z' x -oc:\devtools\git $out
 

--- a/windows/install_msys.ps1
+++ b/windows/install_msys.ps1
@@ -1,5 +1,6 @@
 param (
-    [Parameter(Mandatory=$true)][string]$Version
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Sha256
 )
 $InstallPath = "c:\tools"
 <#
@@ -31,11 +32,12 @@ $ErrorActionPreference = 'Stop'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 # http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200629.tar.xz
-$msyszip = "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-$($Version).tar.xz"
+$msyszip = "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-$($Version).tar.xz"
 
 Write-Host  -ForegroundColor Green starting with MSYS
 $out = "$($PSScriptRoot)\msys.tar.xz"
 (New-Object System.Net.WebClient).DownloadFile($msyszip, $out)
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$Sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$Sha256'.\"; exit 1 }
 
 # uncompress the tar-xz into a tar
 $msystar = "msys.tar"

--- a/windows/install_msys.ps1
+++ b/windows/install_msys.ps1
@@ -31,7 +31,7 @@ $ErrorActionPreference = 'Stop'
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-# http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200629.tar.xz
+# https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200629.tar.xz
 $msyszip = "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-$($Version).tar.xz"
 
 Write-Host  -ForegroundColor Green starting with MSYS

--- a/windows/install_net35.ps1
+++ b/windows/install_net35.ps1
@@ -9,7 +9,11 @@ $UpgradeTable = @{
         ## https://github.com/microsoft/dotnet-framework-docker/blob/26597e42d157cc1e09d1e0dc8f23c32e6c3d1467/3.5/runtime/windowsservercore-ltsc2019/Dockerfile
 
         netfxzip = "https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1809.zip";
+        netfxsha256 = "439f0b98438d9d302a21765cdfe2f28af784aa6a63dfff11c4e1a8a20e9fdf93"
+        # Trying to get the patch with HTTPS yields:
+        # 2022-02-24T15:53:44.6586746+00:00: curl: (60) schannel: SNI or certificate check failed: SEC_E_WRONG_PRINCIPAL (0x80090322) - The target principal name is incorrect.
         patch = "http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/01/windows10.0-kb4534119-x64_a2dce2c83c58ea57145e9069f403d4a5d4f98713.msu";
+        patchsha256 = "0287ba4106ba5462ba542e0124c4211f50bbce1123167375f125ea27b8f48632"
         expandedpatch = "windows10.0-kb4534119-x64.cab"
     };
     1909 = @{ 
@@ -17,28 +21,44 @@ $UpgradeTable = @{
         ## https://github.com/microsoft/dotnet-framework-docker/blob/abc2ca65b28058f7c71ec8cd8763a8fbf2a9c03f/3.5/runtime/windowsservercore-1909/Dockerfile
 
         netfxzip = "https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1909.zip";
+        netfxsha256 = "e451de8d0de5b6e8c6275e7f5baeec0fe755238964a42b89602f5e7a57542de2"
+        # Trying to get the patch with HTTPS yields:
+        # 2022-02-24T15:53:44.6586746+00:00: curl: (60) schannel: SNI or certificate check failed: SEC_E_WRONG_PRINCIPAL (0x80090322) - The target principal name is incorrect.
         patch = "http://download.windowsupdate.com/d/msdownload/update/software/updt/2020/01/windows10.0-kb4534132-x64-ndp48_21067bd5f9c305ee6a6cee79db6ca38587cb6ad8.msu";
+        patchsha256 = "6f8acc2f1d9d83230ec400a04c5de07899dbf1ab3c8b299b0cea973c18abe009"
         expandedpatch = "windows10.0-kb4534132-x64-ndp48.cab"
     };
     2004 = @{
         # Taken from the mcr.microsoft.com/dotnet/framework/runtime:3.5 Dockerfile:
         # https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/3.5/windowsservercore-2004/Dockerfile
         netfxzip = "https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-2004.zip";
+        netfxsha256 = "06ce7df5864490c76da45bd5d83662810afdbd44c719b710166e9eaf8ddc73e2"
+        # Trying to get the patch with HTTPS yields:
+        # 2022-02-24T15:53:44.6586746+00:00: curl: (60) schannel: SNI or certificate check failed: SEC_E_WRONG_PRINCIPAL (0x80090322) - The target principal name is incorrect.
         patch = "http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580419-x64-ndp48_197efbd77177abe76a587359cea77bda5398c594.msu";
+        patchsha256 = "5890767a66b8f979378128c70b1caa1a20e61c31176f8cbf598d7ef424f7b2d2"
         expandedpatch = "Windows10.0-KB4580419-x64-NDP48.cab"
     }
     2009 = @{ ## 20H2 reports itself as 2009 from the registry
         # Taken from the mcr.microsoft.com/dotnet/framework/runtime:3.5 Dockerfile:
         # https://github.com/microsoft/dotnet-framework-docker/blob/e0b59f4aeb47bd6bf13e4c7ec6676a1935306df9/src/runtime/3.5/windowsservercore-20H2/Dockerfile
         netfxzip = "https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-2009.zip";
+        netfxsha256 = "396ad6808a3d6013ff86e0e0163a8602da3fc7ddf36b82b2b18792f6497b88f3"
+        # Trying to get the patch with HTTPS yields:
+        # 2022-02-24T15:53:44.6586746+00:00: curl: (60) schannel: SNI or certificate check failed: SEC_E_WRONG_PRINCIPAL (0x80090322) - The target principal name is incorrect.
         patch = "http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580419-x64-ndp48_197efbd77177abe76a587359cea77bda5398c594.msu";
+        patchsha256 = "5890767a66b8f979378128c70b1caa1a20e61c31176f8cbf598d7ef424f7b2d2"
         expandedpatch = "Windows10.0-KB4580419-x64-NDP48.cab"
     }
     2022 = @{
         # Taken from the mcr.microsoft.com/dotnet/framework/runtime:3.5 Dockerfile:
         # https://github.com/microsoft/dotnet-framework-docker/blob/ee63b25718f434065cd9d1010580ba2a7ab2119f/src/runtime/3.5/windowsservercore-ltsc2022/Dockerfile
         netfxzip = "https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-ltsc2022.zip";
+        netfxsha256 = "e7bb9d923dd9e9d11629fab173ad78ecd622c3ab669344e421db62dfac93d16b"
+        # Trying to get the patch with HTTPS yields:
+        # 2022-02-24T15:53:44.6586746+00:00: curl: (60) schannel: SNI or certificate check failed: SEC_E_WRONG_PRINCIPAL (0x80090322) - The target principal name is incorrect.
         patch = "http://download.windowsupdate.com/c/msdownload/update/software/updt/2021/08/windows10.0-kb5005538-x64-ndp48_451a4214d51de628ef2c3c8a69c87826b2ab43c8.msu";
+        patchsha256 = "d752801b38de2cd6e442385d0a2c9983a5bbe7ed87225bbb3190cdbdc1c0f067"
         expandedpatch = "windows10.0-kb5005538-x64-ndp48.cab"
     }
 }
@@ -53,16 +73,25 @@ if ($build -ge 20348) {
 
 $Env:DOTNET_RUNNING_IN_CONTAINER="true"
 
-Write-Host curl -fSLo microsoft-windows-netfx3.zip $UpgradeTable[$kernelver]["netfxzip"]
-curl.exe -fSLo microsoft-windows-netfx3.zip $UpgradeTable[$kernelver]["netfxzip"]
-tar -zxf microsoft-windows-netfx3.zip
-remove-item -force microsoft-windows-netfx3.zip
+$out = "microsoft-windows-netfx3.zip"
+$sha256 = $UpgradeTable[$kernelver]["netfxsha256"]
+Write-Host curl -fSLo $out $UpgradeTable[$kernelver]["netfxzip"]
+curl.exe -fSLo $out $UpgradeTable[$kernelver]["netfxzip"]
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$sha256'.\"; exit 1 }
+
+tar -zxf $out
+remove-item -force $out
 DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab
 remove-item microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab
 Remove-Item -Force -Recurse ${Env:TEMP}\*
 
-Write-Host curl.exe -fSLo patch.msu $UpgradeTable[$kernelver]["patch"]
-curl.exe -fSLo patch.msu $UpgradeTable[$kernelver]["patch"]
+
+$out = "patch.msu"
+$sha256 = $UpgradeTable[$kernelver]["patchsha256"]
+Write-Host curl.exe -fSLo $out $UpgradeTable[$kernelver]["patch"]
+curl.exe -fSLo $out $UpgradeTable[$kernelver]["patch"]
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$sha256'.\"; exit 1 }
+
 mkdir patch
 expand patch.msu patch -F:*
 remove-item -force patch.msu

--- a/windows/install_nuget.ps1
+++ b/windows/install_nuget.ps1
@@ -1,5 +1,6 @@
 param (
-    [Parameter(Mandatory=$true)][string]$Version
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Sha256
 )
 
 # Enabled TLS12
@@ -16,6 +17,7 @@ $nugetexe="https://dist.nuget.org/win-x86-commandline/v$($Version)/nuget.exe"
 Write-Host -ForegroundColor Green "Downloading nuget"
 $out = "$($PSScriptRoot)\nuget.exe"
 (New-Object System.Net.WebClient).DownloadFile($nugetexe, $out)
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$Sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$Sha256'.\"; exit 1 }
 
 # just put it in it's own directory
 mkdir \nuget

--- a/windows/install_python.ps1
+++ b/windows/install_python.ps1
@@ -1,5 +1,6 @@
 param (
-    [Parameter(Mandatory=$true)][string]$Version
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Sha256
 )
 
 # Enabled TLS12
@@ -16,6 +17,7 @@ $pyexe = "https://www.python.org/ftp/python/$($Version)/python-$($Version)-amd64
 Write-Host  -ForegroundColor Green starting with Python
 $out = "$($PSScriptRoot)\python.exe"
 (New-Object System.Net.WebClient).DownloadFile($pyexe, $out)
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$Sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$Sha256'.\"; exit 1 }
 
 Write-Host -ForegroundColor Green Done downloading wix, installing
 

--- a/windows/install_ruby.ps1
+++ b/windows/install_ruby.ps1
@@ -1,5 +1,6 @@
 param (
-    [Parameter(Mandatory=$true)][string]$Version
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Sha256
 )
 
 # Enabled TLS12
@@ -16,6 +17,7 @@ $rubyexe = "https://github.com/oneclick/rubyinstaller2/releases/download/RubyIns
 Write-Host  -ForegroundColor Green starting with Ruby
 $out = "$($PSScriptRoot)\rubyinstaller.exe"
 (New-Object System.Net.WebClient).DownloadFile($rubyexe, $out)
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$Sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$Sha256'.\"; exit 1 }
 
 Write-Host -ForegroundColor Green Done downloading Ruby, installing
 Start-Process $out -ArgumentList '/verysilent /dir="c:\tools\ruby" /tasks="assocfiles,noridkinstall,modpath"' -Wait

--- a/windows/install_vcpython.ps1
+++ b/windows/install_vcpython.ps1
@@ -10,13 +10,10 @@ $vcpmsi = 'https://s3.amazonaws.com/dd-agent-omnibus/VCForPython27.msi'
 
 Write-host -ForegroundColor Green Downloading VC++ for Python
 $out = "$($PSScriptRoot)\vcp.msi"
+$sha256 = "070474db76a2e625513a5835df4595df9324d820f9cc97eab2a596dcbc2f5cbf"
 
 (New-Object System.Net.WebClient).DownloadFile($vcpmsi, $out)
-
-if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "070474DB76A2E625513A5835DF4595DF9324D820F9CC97EAB2A596DCBC2F5CBF")
-{
-    Write-Error "VCForPython27.msi hash doesn't match"
-}
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$sha256'.\"; exit 1 }
 
 Write-host -ForegroundColor Green VC++ for Python downloaded, installing...
 Start-Process msiexec -ArgumentList '/q /i vcp.msi' -Wait

--- a/windows/install_vstudio.ps1
+++ b/windows/install_vstudio.ps1
@@ -1,5 +1,6 @@
 param (
     [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Sha256,
     [Parameter(Mandatory=$true)][string]$Url,
     [Parameter(Mandatory=$false)][string]$InstallRoot="c:\devtools\vstudio",
     [Parameter(Mandatory=$false)][switch]$NoQuiet
@@ -18,6 +19,8 @@ $out = "$($PSScriptRoot)\vs_buildtools.exe"
 
 Write-Host -ForegroundColor Green Downloading $Url to $out
 (New-Object System.Net.WebClient).DownloadFile($Url, $out)
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$Sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$Sha256'.\"; exit 1 }
+
 # write file size to make sure it worked
 Write-Host -ForegroundColor Green "File size is $((get-item $out).length)"
 

--- a/windows/install_wdk.ps1
+++ b/windows/install_wdk.ps1
@@ -8,8 +8,11 @@ $wdk = 'https://go.microsoft.com/fwlink/?linkid=2085767' ## 1903 WDK link
 
 Write-Host -ForegroundColor Green Installing WDK
 $out = 'wdksetup.exe'
+$sha256 = "c35057cb294096c63bbea093e5024a5fb4120103b20c13fa755c92f227b644e5"
 Write-Host -ForegroundColor Green Downloading $wdk to $out
 (New-Object System.Net.WebClient).DownloadFile($wdk, $out)
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$sha256'.\"; exit 1 }
+
 Get-ChildItem $out
 # write file size to make sure it worked
 Write-Host -ForegroundColor Green "File size is $((get-item $out).length)"

--- a/windows/install_wix.ps1
+++ b/windows/install_wix.ps1
@@ -1,5 +1,6 @@
 param (
-    [Parameter(Mandatory=$true)][string]$Version
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Sha256
 )
 
 # Enabled TLS12
@@ -19,6 +20,7 @@ $wixzip = "https://github.com/wixtoolset/wix3/releases/download/wix$($shortenedv
 Write-Host  -ForegroundColor Green starting with WiX
 $out = "$($PSScriptRoot)\wix.exe"
 (New-Object System.Net.WebClient).DownloadFile($wixzip, $out)
+if ((Get-FileHash -Algorithm SHA256 $out).Hash -ne "$Sha256") { Write-Host \"Wrong hashsum for ${out}: got '$((Get-FileHash -Algorithm SHA256 $out).Hash)', expected '$Sha256'.\"; exit 1 }
 
 Write-Host -ForegroundColor Green Done downloading wix, installing
 #Start-Process wix.exe -ArgumentList '/quiet' -Wait


### PR DESCRIPTION
### What does this PR do?

Adds sha256 checksum verifications for all artifacts we download, and use HTTPS whenever possible.
Pins all artifacts that weren't previously pinned.
Checksums have been first computed locally then verified in the CI.

### Motivation

Check that the components we're using haven't been tampered with. More reproducible builds.

### Additional notes

Future improvements:
- on Linux, we download artifacts through various ways (`wget`, `curl` with different option sets). We should check whether or not we can harmonize this and have a single (or a few) utility functions to download & check the sums of artifacts.
- on Windows, some install scripts define utility functions (`DownloadFile` and `DownloadAndExpandTo`) that could likely be reused in other install scripts, and which could include the checksum verification.