### PR TITLE
[dependabot] Ignore pyyaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,7 @@ updates:
       - python
     schedule:
       interval: monthly
+    ignore:
+      # pyyaml 6 is incompatible with awscli
+      # see https://github.com/DataDog/datadog-agent-buildimages/pull/207
+      - dependency-name: pyyaml


### PR DESCRIPTION
Ignore `pyyaml` dependency to avoid getting Dependabot PRs (see #207 for rationale)