### PR TITLE
Update deb_x64 builder to Debian Jessie

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu as CURL_GETTER
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-amd64
 
-FROM debian:wheezy-backports
+FROM debian:jessie-backports
 
 # Build Args
 ARG GO_VERSION=1.17.6
@@ -28,16 +28,19 @@ RUN echo 'Acquire::http::AllowRedirect"false";' >> /etc/apt/apt.conf.d/20datadog
 # expired making the following option necessary for apt to work.
 RUN echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf.d/20datadog
 
-RUN echo "deb http://archive.debian.org/debian wheezy main contrib non-free" > /etc/apt/sources.list && \
- echo "deb http://archive.debian.org/debian wheezy-backports main contrib non-free" > /etc/apt/sources.list.d/backports.list && \
- echo "deb http://archive.debian.org/debian-security wheezy/updates main contrib non-free" > /etc/apt/sources.list.d/security.list
+# NOTE: for some reason, ATM jessie-backports is only available at
+# archive.debian.org, while "debian-security jessie/updates" is only available
+# at deb.debian.org. I guess at some point it will move as well.
+RUN echo "deb http://deb.debian.org/debian jessie main contrib non-free" > /etc/apt/sources.list && \
+ echo "deb http://archive.debian.org/debian jessie-backports main contrib non-free" > /etc/apt/sources.list.d/backports.list && \
+ echo "deb http://deb.debian.org/debian-security jessie/updates main contrib non-free" > /etc/apt/sources.list.d/security.list
 
 RUN apt-get update && apt-get install -y fakeroot procps bzip2 \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libpq-dev libz-dev \
   rpm tar gettext libtool autopoint autoconf pkg-config flex \
   selinux-basics
 
-RUN apt-get install -y libsystemd-journal-dev/wheezy-backports
+# TODO: RUN apt-get install -y libsystemd-journal-dev/wheezy-backports
 
 # Update curl with a statically linked binary
 COPY --from=CURL_GETTER /curl-amd64 /usr/local/bin/curl
@@ -80,7 +83,7 @@ RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Docker
 # Pin docker to before they broke wheezy
-RUN curl -fsSL https://raw.githubusercontent.com/docker/docker-install/a34555fc0214be705330911071a8c3357f26e40b/install.sh | sed -e 's/ftp\.debian\.org/archive.debian.org/g' | sh
+# TODO: RUN curl -fsSL https://raw.githubusercontent.com/docker/docker-install/a34555fc0214be705330911071a8c3357f26e40b/install.sh | sed -e 's/ftp\.debian\.org/archive.debian.org/g' | sh
 
 # CMake
 RUN set -ex \
@@ -91,10 +94,9 @@ RUN set -ex \
     && rm cmake.sh
 
 # Install clang and llvm version 8
-# Using build for sles11 because the versions built for other distros target glibcs that are too new to be used from this image
-RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
-    tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --no-same-owner --strip 1 -kC /usr/ && \
-    rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
+RUN curl -LO https://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-gnu-ubuntu-14.04.tar.xz && \
+    tar -xf clang+llvm-${CLANG_VERSION}-x86_64-linux-gnu-ubuntu-14.04.tar.xz --no-same-owner --strip 1 -kC /usr/ && \
+    rm clang+llvm-${CLANG_VERSION}-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 
 # To build the EBPF code we need kernel headers for Linux 4.9
 RUN curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-deb-x64.tgz && \

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -37,10 +37,8 @@ RUN echo "deb http://deb.debian.org/debian jessie main contrib non-free" > /etc/
 
 RUN apt-get update && apt-get install -y fakeroot procps bzip2 \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libpq-dev libz-dev \
-  rpm tar gettext libtool autopoint autoconf pkg-config flex \
+  libsystemd-journal-dev rpm tar gettext libtool autopoint autoconf pkg-config flex \
   selinux-basics
-
-# TODO: RUN apt-get install -y libsystemd-journal-dev/wheezy-backports
 
 # Update curl with a statically linked binary
 COPY --from=CURL_GETTER /curl-amd64 /usr/local/bin/curl

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -23,14 +23,15 @@ ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 # Mitigation for CVE-2019-3462
 RUN echo 'Acquire::http::AllowRedirect"false";' >> /etc/apt/apt.conf.d/20datadog
 # Ignore expired repos signature
-# Wheezy is EOL, security updates repo will not get any newer updates, or will do so
+# Jessie is EOL, security updates repo will not get any newer updates, or will do so
 # in arbitrary, unscheduled timeframes. At the time of this writing the repo has
 # expired making the following option necessary for apt to work.
 RUN echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf.d/20datadog
 
 # NOTE: for some reason, ATM jessie-backports is only available at
 # archive.debian.org, while "debian-security jessie/updates" is only available
-# at deb.debian.org. I guess at some point it will move as well.
+# at deb.debian.org. I guess at some point it will move as well. For now,
+# we have to use combination of archive.debian.org and deb.debian.org.
 RUN echo "deb http://deb.debian.org/debian jessie main contrib non-free" > /etc/apt/sources.list && \
  echo "deb http://archive.debian.org/debian jessie-backports main contrib non-free" > /etc/apt/sources.list.d/backports.list && \
  echo "deb http://deb.debian.org/debian-security jessie/updates main contrib non-free" > /etc/apt/sources.list.d/security.list
@@ -78,10 +79,6 @@ RUN curl -sSL https://get.rvm.io | bash -s stable --version latest-1.29
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
-
-# Docker
-# Pin docker to before they broke wheezy
-# TODO: RUN curl -fsSL https://raw.githubusercontent.com/docker/docker-install/a34555fc0214be705330911071a8c3357f26e40b/install.sh | sed -e 's/ftp\.debian\.org/archive.debian.org/g' | sh
 
 # CMake
 RUN set -ex \

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -38,7 +38,7 @@ RUN echo "deb http://deb.debian.org/debian jessie main contrib non-free" > /etc/
 RUN apt-get update && apt-get install -y fakeroot procps bzip2 \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libpq-dev libz-dev \
   libsystemd-journal-dev rpm tar gettext libtool autopoint autoconf pkg-config flex \
-  selinux-basics
+  selinux-basics libtool-bin
 
 # Update curl with a statically linked binary
 COPY --from=CURL_GETTER /curl-amd64 /usr/local/bin/curl

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu as CURL_GETTER
 RUN apt-get update && apt-get install -y wget
 RUN wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-amd64
 
+# NOTE: we can't upgrade to Debian Jessie, because that has glibc 2.19 and
+# we still need to support CentOS 7.6+ with nikos, which has glibc 2.17.
+# We can upgrade the base image once we drop support for CentOS 7.
 FROM debian:wheezy-backports
 
 # Build Args

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -14,25 +14,9 @@ echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin/gim
 chmod +x /bin/gimme
 eval "$(gimme 1.15.11)"
 
-# Install gcc 4.9 (needed to compile go, as it introduces -fdiagnostics-color which is required
-# in the post-compilation steps of go).
-# Note: this doesn't replace the existing gcc (4.7.2), gcc 4.9 is installed in
-# /usr/lib/gcc-4.9-backport/bin.
-apt-get update && apt-get install -y gcc-4.9-backport
-
 git clone --branch "go$GO_VERSION" --depth 1 https://go.googlesource.com/go goroot && cd goroot/src
 
-# Use gcc 4.9 + go1.15.11 to build the target go version
-# HACK: cgo tries to look for gcc in the same place that CC
-# pointed to when go was compiled. By default, CC=gcc.
-# We don't want to keep gcc 4.9 after building go, so we temporarily
-# change the PATH so that "gcc" is the gcc 4.9 we installed.
-# Then, when cgo is used, it will use "gcc" which will be gcc 4.7.
-export PATH="/usr/lib/gcc-4.9-backport/bin:$PATH"
 ./all.bash
-
-# Remove gcc 4.9 after building go
-apt-get remove -y gcc-4.9-backport
 
 # Update PATH to include the built go binaries
 echo 'export PATH="/goroot/bin:$PATH"' >> /root/.bashrc


### PR DESCRIPTION
As noted in the omnibus-nikos Dockerfile, we can't update that one, as that would break compatibility with CentOS 7.