### PR TITLE
Create base `docker` image with python dependencies installed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -129,6 +129,18 @@ build_dd_agent_testing:
     DOCKERFILE: dd-agent-testing/Dockerfile
     IMAGE: dd-agent-testing
 
+build_docker_arm64:
+  extends: [ .build, .arm ]
+  variables:
+    DOCKERFILE: docker-arm64/Dockerfile
+    IMAGE: docker_arm64
+
+build_docker_x64:
+  extends: [ .build, .x64 ]
+  variables:
+    DOCKERFILE: docker-x64/Dockerfile
+    IMAGE: docker_x64
+
 .test:
   stage: test
   except: [ tags, schedules ]

--- a/datadog-ci-uploader/Dockerfile
+++ b/datadog-ci-uploader/Dockerfile
@@ -8,10 +8,11 @@ ENV N_SHA256="e0af3182861d91bbc65478bfad7b25e7cbbe200a4f7443baeeaf9c2b732da776"
 ENV NODE_VERSION=16.13.0
 ENV AWSCLI_VERSION=1.16.240
 ENV CODEOWNERS_VERSION=0.4.0
+ENV INVOKE_VERSION=1.6.0
 ENV DATADOG_CI_VERSION=0.17.8
 
 RUN apt update && apt install -y curl git python3 python3-pip
-RUN pip install awscli==${AWSCLI_VERSION} codeowners==${CODEOWNERS_VERSION}
+RUN pip install awscli==${AWSCLI_VERSION} codeowners==${CODEOWNERS_VERSION} invoke==${INVOKE_VERSION}
 
 RUN curl -L https://raw.githubusercontent.com/tj/n/v${N_VERSION}/bin/n -o n \
     && echo "${N_SHA256}  n" | sha256sum --check \

--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -1,0 +1,5 @@
+FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718787-3888eda-18.09.6-arm64-py3
+
+COPY ./requirements.txt .
+
+RUN python3 -m pip install -r requirements.txt

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -1,0 +1,5 @@
+FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718644-9ce6565-18.09.6-py3
+
+COPY ./requirements.txt .
+
+RUN python3 -m pip install -r requirements.txt


### PR DESCRIPTION
This prevents a `pip install` on every `datadog-agent` image build,
making builds a little bit faster and more reliable.