### PR TITLE
Pin Ubuntu version to workaround Docker issue with 22.04

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu as CURL_GETTER
+FROM ubuntu:21.10 as CURL_GETTER
 ENV WGET_VERSION=7.79.1
 ENV WGET_SHA256="0a89440848db3ba21d38b93b450d90fb84d4d0fa5562aa9c6933070b0eddc960"
 RUN apt-get update && apt-get install -y wget

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu as CURL_GETTER
+FROM ubuntu:21.10 as CURL_GETTER
 ENV WGET_VERSION=7.79.1
 ENV WGET_SHA256="0a89440848db3ba21d38b93b450d90fb84d4d0fa5562aa9c6933070b0eddc960"
 RUN apt-get update && apt-get install -y wget

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu as CERT_GETTER
+FROM ubuntu:21.10 as CERT_GETTER
 ENV CACERT_BUNDLE_VERSION=2022-03-29
 ENV CACERT_BUNDLE_SHA256="1979e7fe618c51ed1c9df43bba92f977a0d3fe7497ffa2a5e80dfc559a1e5a29"
 RUN apt-get update && apt-get install -y wget

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu as CURL_GETTER
+FROM ubuntu:21.10 as CURL_GETTER
 RUN apt-get update && apt-get install -y wget
 ENV WGET_VERSION=7.79.1
 ENV WGET_SHA256="0a89440848db3ba21d38b93b450d90fb84d4d0fa5562aa9c6933070b0eddc960"


### PR DESCRIPTION
We'll need the Ubuntu version pinned until Docker gets updated on our Gitlab builders. Just using "ubuntu" pulls in 22.04, which unfortunately doesn't work well with current Docker version on builders:

Root cause explained by Docker maintainer:
https://medium.com/nttlabs/ubuntu-21-10-and-fedora-35-do-not-work-on-docker-20-10-9-1cd439d9921
(Note: the glibc bump was reverted just before 21.10 release in the end)