### PR TITLE
Use Windows line endings for the powershell generator even on Linux

### DIFF
--- a/windows/dockerfile-to-powershell.py
+++ b/windows/dockerfile-to-powershell.py
@@ -2,6 +2,7 @@ from ast import Not
 import sys
 import getopt
 import re
+import io
 from datetime import datetime
 from dockerfile_parse import DockerfileParser
 
@@ -171,7 +172,7 @@ def parseDockerFile(dockerFilePath):
 # Open/Create Powershell file for writing
 def createPowershellFile(powershellFilePath):
    try:
-      return open(powershellFilePath, 'w')
+      return io.open(powershellFilePath, 'w', newline="\r\n")
    except Exception as inst:
       print('Failed to create "{}" Powershell file. Please validate that it is accessible'.format(powershellFile))
       sys.exit(1)


### PR DESCRIPTION
Without this PR, running the generator on Linux transforms all the newlines to just `\n` which makes the whole file appear as a git diff.