### PR TITLE
Pin dulwich to 0.20.35 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ invoke==1.7.0
 reno==3.5.0
 docker==5.0.3
 docker-squash==1.0.9
+dulwich==0.20.35
 requests==2.27.1
 PyYAML==5.4.1
 toml==0.10.2


### PR DESCRIPTION
The latest version of `dulwich`, `0.20.36` doesn't have pre-built wheels available in PyPI: https://github.com/jelmer/dulwich/issues/963, which is causing failures in some images, as well as `7.36.x` of `datadog-agent` (which uses the `requirements.txt` file from here), as some of the images don't have the tools needed to build `dulwich` from source.

While we wait for maintainers to upload these wheels, we should pin it to the previous release: `0.20.35`.