### PR TITLE
[omnibus-nikos] Pin gmp dependency

### DIFF
--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -82,7 +82,9 @@ RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Use conda to install gcc5
 # Must be done after installing ruby with RVM, otherwise conda's gcc is used to build ruby and it doesn't work
-RUN conda install -c psi4 gcc-5 isl=0.12.2
+# Pin gmp to gmp=6.2.1=h2531618_2, to avoid the following issue while installing gcc-5:
+# /root/miniconda3/gcc/libexec/gcc/x86_64-unknown-linux-gnu/5.2.0/cc1: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.14' not found
+RUN conda install -c psi4 gcc-5 gmp=6.2.1=h2531618_2 isl=0.12.2
 
 # Install ssl in a custom location
 RUN curl -L -O http://www.openssl.org/source/openssl-1.1.1k.tar.gz


### PR DESCRIPTION
### What does this PR do?

Pins `gmp` to `gmp=6.2.1=h2531618_2` to avoid the following issue when installing `gcc-5`:

```
The following packages will be downloaded:
    package                    |            build
    ---------------------------|-----------------
    ca-certificates-2022.4.26  |       h06a4308_0         124 KB
    certifi-2022.5.18.1        |   py39h06a4308_0         147 KB
    cloog-0.18.0               |                0         565 KB
    conda-4.13.0               |   py39h06a4308_0         895 KB
    gcc-5-5.2.0                |                1        78.0 MB  psi4
    gmp-6.2.1                  |       h295c915_3         544 KB
    isl-0.12.2                 |                0         917 KB
    mpc-1.1.0                  |       h10f8cd9_1          90 KB
    mpfr-4.0.2                 |       hb69a4c5_1         487 KB
    openssl-1.1.1o             |       h7f8727e_0         2.5 MB
    ------------------------------------------------------------
                                           Total:        84.2 MB
The following NEW packages will be INSTALLED:
  cloog              pkgs/main/linux-64::cloog-0.18.0-0
  gcc-5              psi4/linux-64::gcc-5-5.2.0-1
  gmp                pkgs/main/linux-64::gmp-6.2.1-h295c915_3
  isl                pkgs/main/linux-64::isl-0.12.2-0
  mpc                pkgs/main/linux-64::mpc-1.1.0-h10f8cd9_1
  mpfr               pkgs/main/linux-64::mpfr-4.0.2-hb69a4c5_1
The following packages will be UPDATED:
  ca-certificates                      2020.12.8-h06a4308_0 --> 2022.4.26-h06a4308_0
  certifi                          2020.12.5-py39h06a4308_0 --> 2022.5.18.1-py39h06a4308_0
  conda                                4.9.2-py39h06a4308_0 --> 4.13.0-py39h06a4308_0
  openssl                                 1.1.1i-h27cfd23_0 --> 1.1.1o-h7f8727e_0
Proceed ([y]/n)? 
Downloading and Extracting Packages
mpfr-4.0.2           | 487 KB    | ########## | 100% 
conda-4.13.0         | 895 KB    | ########## | 100% 
certifi-2022.5.18.1  | 147 KB    | ########## | 100% 
ca-certificates-2022 | 124 KB    | ########## | 100% 
mpc-1.1.0            | 90 KB     | ########## | 100% 
isl-0.12.2           | 917 KB    | ########## | 100% 
cloog-0.18.0         | 565 KB    | ########## | 100% 
gmp-6.2.1            | 544 KB    | ########## | 100% 
gcc-5-5.2.0          | 78.0 MB   | ########## | 100% 
openssl-1.1.1o       | 2.5 MB    | ########## | 100% 
Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
ERROR conda.core.link:_execute(698): An error occurred while installing package 'psi4::gcc-5-5.2.0-1'.
Rolling back transaction: ...working... done
LinkError: post-link script failed for package psi4::gcc-5-5.2.0-1
location of failed script: /root/miniconda3/bin/.gcc-5-post-link.sh
==> script messages <==
<None>
==> script output <==
stdout: Installation failed: gcc is not able to compile a simple 'Hello, World' program.
stderr: /root/miniconda3/gcc/libexec/gcc/x86_64-unknown-linux-gnu/5.2.0/cc1: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.14' not found (required by /root/miniconda3/gcc/libexec/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../../lib/libgmp.so.10)
```

that started happening when the installed `gmp` version changed from `gmp=6.2.1=h2531618_2` to `gmp=6.2.1=h295c915_3`.