### PR TITLE
[python] Pin ddpy3 environment deps to prevent Python crashes in rpm image

### DIFF
--- a/setup_python.sh
+++ b/setup_python.sh
@@ -19,7 +19,7 @@ case $DD_TARGET_ARCH in
     PY2_VERSION="2 zlib=1.2.11=h7b6447c_3"
     # FIXME: Pinning specific build since the last version doesn't seem to work with the glibc in the base image
     # FIXME: Pinning OpenSSL to a version that's compatible with the Python build we pin (we get `SSL module is not available` errors with OpenSSL 1.1.1l)
-    PY3_VERSION="3.8.10=hdb3f193_7 certifi=2021.10.8=py38h06a4308_2 ld_impl_linux-64=2.38=h1181459_0 openssl=1.1.1k=h27cfd23_0 zlib=1.2.11=h7b6447c_3"
+    PY3_VERSION="3.8.10=hdb3f193_7 certifi=2021.10.8=py38h06a4308_2 ld_impl_linux-64=2.38=h1181459_0 libgcc-ng=9.1.0=hdf63c60_0 libstdcxx-ng=9.1.0=hdf63c60_0 openssl=1.1.1k=h27cfd23_0 zlib=1.2.11=h7b6447c_3"
     ;;
 "aarch64")
     DD_CONDA_VERSION=4.9.2-7

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -19,7 +19,7 @@ case $DD_TARGET_ARCH in
     PY2_VERSION="2 zlib=1.2.11=h7b6447c_3"
     # FIXME: Pinning specific build since the last version doesn't seem to work with the glibc in the base image
     # FIXME: Pinning OpenSSL to a version that's compatible with the Python build we pin (we get `SSL module is not available` errors with OpenSSL 1.1.1l)
-    PY3_VERSION="3.8.10=hdb3f193_7 openssl=1.1.1k=h27cfd23_0 zlib=1.2.11=h7b6447c_3"
+    PY3_VERSION="3.8.10=hdb3f193_7 ld_impl_linux-64=2.38=h1181459_0 openssl=1.1.1k=h27cfd23_0 zlib=1.2.11=h7b6447c_3"
     ;;
 "aarch64")
     DD_CONDA_VERSION=4.9.2-7

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -19,7 +19,7 @@ case $DD_TARGET_ARCH in
     PY2_VERSION="2 zlib=1.2.11=h7b6447c_3"
     # FIXME: Pinning specific build since the last version doesn't seem to work with the glibc in the base image
     # FIXME: Pinning OpenSSL to a version that's compatible with the Python build we pin (we get `SSL module is not available` errors with OpenSSL 1.1.1l)
-    PY3_VERSION="3.8.10=hdb3f193_7 ld_impl_linux-64=2.38=h1181459_0 openssl=1.1.1k=h27cfd23_0 zlib=1.2.11=h7b6447c_3"
+    PY3_VERSION="3.8.10=hdb3f193_7 certifi=2021.10.8=py38h06a4308_2 ld_impl_linux-64=2.38=h1181459_0 openssl=1.1.1k=h27cfd23_0 zlib=1.2.11=h7b6447c_3"
     ;;
 "aarch64")
     DD_CONDA_VERSION=4.9.2-7


### PR DESCRIPTION
### What does this PR do?

Pins a bunch of dependencies installed in the `ddpy3` environment to their last working version.

### Motivation

The `ddpy3` environment is currently broken in the `rpm_x64` image due to some dependencies being updated last week, causing all uses of Python to break with: `libgcc_s.so.1 must be installed for pthread_cancel to work`. This prevents any image currently built from being usable in the `datadog-agent` pipeline.