### PR TITLE
docker image size reduction

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ variables:
     - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
     # For size debug purposes
     - docker images 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
-    - docker history 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    - docker history --no-trunc 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
     # For testing purposes
     - docker tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7} 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID
     - if [ "$CI_PIPELINE_SOURCE" != "schedule" ]; then docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID; fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,8 @@ variables:
     # Build
     - docker build --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg DD_TARGET_ARCH=$DD_TARGET_ARCH --tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7} --file $DOCKERFILE .
     - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    # For size debug purposes
+    - docker images 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
     # For testing purposes
     - docker tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7} 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID
     - if [ "$CI_PIPELINE_SOURCE" != "schedule" ]; then docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID; fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,7 @@ variables:
     - docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
     # For size debug purposes
     - docker images 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    - docker history 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
     # For testing purposes
     - docker tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7} 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID
     - if [ "$CI_PIPELINE_SOURCE" != "schedule" ]; then docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE:v$CI_PIPELINE_ID; fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,9 @@ build_docker_x64:
 .test_agent6:
   extends: .test
   before_script:
-    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - rm -r /go/src/github.com/DataDog/datadog-agent || true
+    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
+    - cd /go/src/github.com/DataDog/datadog-agent
     - VERSION="nightly"
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -165,6 +165,6 @@ RUN mkdir -p /go/src/github.com/DataDog/datadog-agent
 RUN echo "umask 0022" >> /root/.bashrc
 
 RUN du -cks * | sort -rn | head
-RUN du -cks /usr | sort -rn | head
+RUN du -cks /usr/* | sort -rn | head
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -164,7 +164,4 @@ RUN mkdir -p /go/src/github.com/DataDog/datadog-agent
 # Force umask to 0022
 RUN echo "umask 0022" >> /root/.bashrc
 
-RUN du -cks * | sort -rn | head
-RUN du -cks /usr/* | sort -rn | head
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -150,7 +150,8 @@ RUN curl -sSL -o rustup-init https://static.rust-lang.org/rustup/archive/${RUSTU
     && echo "${RUSTUP_SHA256}  rustup-init" | sha256sum --check \
     && chmod +x ./rustup-init \
     && ./rustup-init -y --default-toolchain ${RUST_VERSION} \
-    && echo "${RUSTC_SHA256}  $HOME/.cargo/bin/rustc" | sha256sum --check
+    && echo "${RUSTC_SHA256}  $HOME/.cargo/bin/rustc" | sha256sum --check \
+    && rm ./rustup-init
 ENV PATH "~/.cargo/bin:${PATH}"
 
 # Entrypoint

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -65,13 +65,13 @@ COPY --from=CURL_GETTER /curl-amd64 /usr/local/bin/curl
 RUN chmod +x /usr/local/bin/curl
 
 # Git
-RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz
-RUN echo "${GIT_SHA256}  git-${GIT_VERSION}.tar.gz" | sha256sum --check
-# --no-same-owner: git tarball has a file with UID 110493 which makes pulling this image fail, because we use docker user namespacing and we can't have >65K UIDs.
-RUN tar xzf git-${GIT_VERSION}.tar.gz --no-same-owner
-RUN cd git-${GIT_VERSION} && make prefix=/usr/local all
-RUN cd git-${GIT_VERSION} && make prefix=/usr/local install
-RUN rm -rf git-${GIT_VERSION} git-${GIT_VERSION}.tar.gz
+RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz \
+    && echo "${GIT_SHA256}  git-${GIT_VERSION}.tar.gz" | sha256sum --check
+    # --no-same-owner: git tarball has a file with UID 110493 which makes pulling this image fail, because we use docker user namespacing and we can't have >65K UIDs. \
+    && RUN tar xzf git-${GIT_VERSION}.tar.gz --no-same-owner \
+    && cd git-${GIT_VERSION} && make prefix=/usr/local all \
+    && cd git-${GIT_VERSION} && make prefix=/usr/local install \
+    && rm -rf git-${GIT_VERSION} git-${GIT_VERSION}.tar.gz
 
 RUN git config --global user.email "package@datadoghq.com"
 RUN git config --global user.name "Bits"

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -68,9 +68,11 @@ RUN chmod +x /usr/local/bin/curl
 RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz \
     && echo "${GIT_SHA256}  git-${GIT_VERSION}.tar.gz" | sha256sum --check
     # --no-same-owner: git tarball has a file with UID 110493 which makes pulling this image fail, because we use docker user namespacing and we can't have >65K UIDs. \
-    && RUN tar xzf git-${GIT_VERSION}.tar.gz --no-same-owner \
-    && cd git-${GIT_VERSION} && make prefix=/usr/local all \
-    && cd git-${GIT_VERSION} && make prefix=/usr/local install \
+    && tar xzf git-${GIT_VERSION}.tar.gz --no-same-owner \
+    && cd git-${GIT_VERSION} \
+    && make prefix=/usr/local all \
+    && make prefix=/usr/local install \
+    && cd .. \
     && rm -rf git-${GIT_VERSION} git-${GIT_VERSION}.tar.gz
 
 RUN git config --global user.email "package@datadoghq.com"

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -165,5 +165,6 @@ RUN mkdir -p /go/src/github.com/DataDog/datadog-agent
 RUN echo "umask 0022" >> /root/.bashrc
 
 RUN du -cks * | sort -rn | head
+RUN du -cks /usr | sort -rn | head
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -149,7 +149,7 @@ RUN curl -sSfL -o golangci-lint-install.sh https://raw.githubusercontent.com/gol
 RUN curl -sSL -o rustup-init https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init \
     && echo "${RUSTUP_SHA256}  rustup-init" | sha256sum --check \
     && chmod +x ./rustup-init \
-    && ./rustup-init -y --default-toolchain ${RUST_VERSION} \
+    && ./rustup-init -y --profile minimal --default-toolchain ${RUST_VERSION} \
     && echo "${RUSTC_SHA256}  $HOME/.cargo/bin/rustc" | sha256sum --check \
     && rm ./rustup-init
 ENV PATH "~/.cargo/bin:${PATH}"

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -163,4 +163,6 @@ RUN mkdir -p /go/src/github.com/DataDog/datadog-agent
 # Force umask to 0022
 RUN echo "umask 0022" >> /root/.bashrc
 
+RUN du -cks * | sort -rn | head
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -66,7 +66,7 @@ RUN chmod +x /usr/local/bin/curl
 
 # Git
 RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz \
-    && echo "${GIT_SHA256}  git-${GIT_VERSION}.tar.gz" | sha256sum --check
+    && echo "${GIT_SHA256}  git-${GIT_VERSION}.tar.gz" | sha256sum --check \
     # --no-same-owner: git tarball has a file with UID 110493 which makes pulling this image fail, because we use docker user namespacing and we can't have >65K UIDs. \
     && tar xzf git-${GIT_VERSION}.tar.gz --no-same-owner \
     && cd git-${GIT_VERSION} \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -106,13 +106,15 @@ RUN mkdir -p /usr/local/var/lib/rpm \
     && /usr/local/bin/rpm --rebuilddb
 
 # Git
-RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz
-RUN echo "${GIT_SHA256}  git-${GIT_VERSION}.tar.gz" | sha256sum --check
-# --no-same-owner: git tarball has a file with UID 110493 which makes pulling this image fail, because we use docker user namespacing and we can't have >65K UIDs.
-RUN tar xzf git-${GIT_VERSION}.tar.gz --no-same-owner
-RUN cd git-${GIT_VERSION} && make prefix=/usr/local all
-RUN cd git-${GIT_VERSION} && make prefix=/usr/local install
-RUN rm -rf git-${GIT_VERSION} git-${GIT_VERSION}.tar.gz
+RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz \
+    && echo "${GIT_SHA256}  git-${GIT_VERSION}.tar.gz" | sha256sum --check \
+    # --no-same-owner: git tarball has a file with UID 110493 which makes pulling this image fail, because we use docker user namespacing and we can't have >65K UIDs. \
+    && tar xzf git-${GIT_VERSION}.tar.gz --no-same-owner \
+    && cd git-${GIT_VERSION} \
+    && make prefix=/usr/local all \
+    && make prefix=/usr/local install \
+    && cd .. \
+    && rm -rf git-${GIT_VERSION} git-${GIT_VERSION}.tar.gz
 
 RUN git config --global user.email "package@datadoghq.com"
 RUN git config --global user.name "Bits"

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -216,8 +216,9 @@ RUN curl -sSfL -o golangci-lint-install.sh https://raw.githubusercontent.com/gol
 RUN curl -sSL -o rustup-init https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init \
     && echo "${RUSTUP_SHA256}  rustup-init" | sha256sum --check \
     && chmod +x ./rustup-init \
-    && ./rustup-init -y --default-toolchain ${RUST_VERSION} \
-    && echo "${RUSTC_SHA256}  $HOME/.cargo/bin/rustc" | sha256sum --check
+    && ./rustup-init -y --profile minimal --default-toolchain ${RUST_VERSION} \
+    && echo "${RUSTC_SHA256}  $HOME/.cargo/bin/rustc" | sha256sum --check \
+    && rm ./rustup-init
 ENV PATH "~/.cargo/bin:${PATH}"
 
 # Perl >= 5.14 is needed to compile the libxcrypt project

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -20,3 +20,7 @@ git clone --branch "go$GO_VERSION" --depth 1 https://go.googlesource.com/go goro
 
 # Update PATH to include the built go binaries
 echo 'export PATH="/goroot/bin:$PATH"' >> /root/.bashrc
+
+# Remove gimme
+rm -rf $HOME/.gimme
+rm /bin/gimme

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -138,8 +138,9 @@ RUN curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-rpm
 RUN curl -sSL -o rustup-init https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init \
     && echo "${RUSTUP_SHA256}  rustup-init" | sha256sum --check \
     && chmod +x ./rustup-init \
-    && ./rustup-init -y --default-toolchain ${RUST_VERSION} \
-    && echo "${RUSTC_SHA256}  $HOME/.cargo/bin/rustc" | sha256sum --check
+    && ./rustup-init -y --profile minimal --default-toolchain ${RUST_VERSION} \
+    && echo "${RUSTC_SHA256}  $HOME/.cargo/bin/rustc" | sha256sum --check \
+    && rm ./rustup-init
 ENV PATH "~/.cargo/bin:${PATH}"
 
 # Entrypoint


### PR DESCRIPTION
The current `deb-x64` docker image is around ~7.5GB. Even though it is cached in most cases, when it's not it can take up to 1min30secondes to setup the docker executor in the agent CI because of pull time.

This PR reduces the image size by:
- doing the git installation in one layer (before the installation was split into multiple layers with one containing the downloaded archive)
- installing rust with minimal profile (dropping `rust-docs` and `rustfmt` that are not needed for a CI installation)
- ~cleaning up the apt lists after installation~
- removing the gimme go versions after usage (currently we use gimme to download an old go version, in order to build the final go version from sources, this PR removes the old go version after use)

to arrive at ~6.22GB for the `deb-x64` image

Agent-side pipeline to show that it still passes as before: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/9192158

This PR also adds steps in the build script in order to display the image size, but also the size of each layer to enable more introspection in the future.

**For the future**: the current worst offender in the `deb-x64` case is the installation of clang+llvm (the layer takes ~2GB). This installation is also way too big for what we use (it includes lldb for example but also support for a lot of architectures and programming languages that we don't use).