### PR TITLE
[suse-x64] Force umask to 0022 within container

### DIFF
--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -149,4 +149,7 @@ RUN chmod +x /entrypoint.sh
 # create the agent build folder within $GOPATH
 RUN mkdir -p /go/src/github.com/DataDog/datadog-agent
 
+# Force umask to 0022
+RUN echo "umask 0022" >> /root/.bashrc
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Repeat of https://github.com/DataDog/datadog-agent-buildimages/pull/11, this time for the SUSE builder:

> The latest rvm update (1.29.9) introduced a change in the shell script preparing the rvm environment at login.
As a result, the umask in the container has changed, which changes the permissions of all files created within the containers.
Because of this, the files included in the deb and rpm packages had their permissions changed, which can lead to installation issues.

