### PR TITLE
fix go bin path in system probe images

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -54,7 +54,7 @@ RUN echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin
 RUN chmod +x /bin/gimme
 RUN gimme $GIMME_GO_VERSION
 
-COPY ./gobin.sh /etc/profile.d/
+ENV PATH "${GOPATH}/bin:${PATH}"
 
 # create the agent build folder within $GOPATH
 RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -55,7 +55,7 @@ RUN echo "03b295636d4e22870b6f6e9bc06a71d65311ae90d3d48cbc7071f82dd5837fbc  /bin
 RUN chmod +x /bin/gimme
 RUN gimme $GIMME_GO_VERSION
 
-COPY ./gobin.sh /etc/profile.d/
+ENV PATH "${GOPATH}/bin:${PATH}"
 
 # create the agent build folder within $GOPATH
 RUN mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent


### PR DESCRIPTION
Contrary to the `entrypoint.sh` file, `entrypoint-sysprobe.sh` does not run with bash as a login shell. This means that files in `/etc/profile.d/` are not loaded, more importantly the `gobin.sh` is not run and thus the path is not filled with the gobin entry requiring noisy commands in scripts on the agent side like https://github.com/DataDog/datadog-agent/blob/c22ee9486d74d499471787dd5b731960d940de8a/.gitlab/source_test/ebpf.yml#L70

This PR fixes this