### PR TITLE
Revert docker version bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # python development requirements for the Datadog Agent
 invoke==1.7.1
 reno==3.5.0
-docker==6.0.0
+docker==5.0.3
 docker-squash==1.0.9
 dulwich==0.20.45
 requests==2.27.1


### PR DESCRIPTION
I think this will fix datadog-agent CircleCI until https://github.com/DataDog/datadog-agent/pull/13424 is ready to go. We should probably figure out a way to not affect all branches until changes are tested and ready to go.