### PR TITLE
Fix 7.39.x branch builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,7 +148,7 @@ build_docker_x64:
 .test_agent6:
   extends: .test
   before_script:
-    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - git clone -b 7.39.x https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
     - VERSION="nightly"
     - source /root/.bashrc && conda activate ddpy3
     - inv -e deps
@@ -188,7 +188,7 @@ test_suse_x64:
 .test_system_probe:
   extends: .test
   before_script:
-    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - git clone -b 7.39.x https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
     - inv -e deps
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$ARCH-11.0.1.tar.xz /tmp/clang.tar.xz
     - mkdir -p $DATADOG_AGENT_EMBEDDED_PATH
@@ -274,7 +274,7 @@ build_windows_ltsc2022_x64:
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
-    - git clone https://github.com/DataDog/datadog-agent datadog-agent
+    - git clone -b 7.39.x https://github.com/DataDog/datadog-agent datadog-agent
     - cd datadog-agent
     - $VERSION="nightly"
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -17,9 +17,9 @@ case $DD_TARGET_ARCH in
     # FIXME: Pinning specific zlib version as the latest one doesn't work in our old builders:
     # version GLIBC_2.14 not found (required by /root/miniconda3/envs/ddpy2/lib/python2.7/lib-dynload/../../libz.so.1)
     PY2_VERSION="2 zlib=1.2.11=h7b6447c_3"
-    # FIXME: Pinning specific build since the last version doesn't seem to work with the glibc in the base image
+    # FIXME: Pinning specific build (zlib, xz) since the last version doesn't seem to work with the glibc in the base image
     # FIXME: Pinning OpenSSL to a version that's compatible with the Python build we pin (we get `SSL module is not available` errors with OpenSSL 1.1.1l)
-    PY3_VERSION="3.8.10=hdb3f193_7 certifi=2021.10.8=py38h06a4308_2 ld_impl_linux-64=2.38=h1181459_0 libgcc-ng=9.1.0=hdf63c60_0 libstdcxx-ng=9.1.0=hdf63c60_0 openssl=1.1.1k=h27cfd23_0 zlib=1.2.11=h7b6447c_3"
+    PY3_VERSION="3.8.10=hdb3f193_7 certifi=2021.10.8=py38h06a4308_2 ld_impl_linux-64=2.38=h1181459_0 libgcc-ng=9.1.0=hdf63c60_0 libstdcxx-ng=9.1.0=hdf63c60_0 openssl=1.1.1k=h27cfd23_0 xz=5.2.5=h7b6447c_0 zlib=1.2.11=h7b6447c_3"
     ;;
 "aarch64")
     DD_CONDA_VERSION=4.9.2-7


### PR DESCRIPTION
- Pin xz version (taken from `746a71dcf378fb633efb07ffcefb35d510b41d45`)
- Run tests on 7.39.x branch of datadog-agent