### PR TITLE
Fix docker dependency for Python 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # python development requirements for the Datadog Agent
 invoke==1.7.1
 reno==3.5.0
-docker==6.0.0
+docker==6.0.0; python_version >= '3.7'
+docker==5.0.3; python_version < '3.7'
 docker-squash==1.0.9
 dulwich==0.20.45
 requests==2.27.1


### PR DESCRIPTION
### What does this PR do?

FIxes the `docker` dependency declared in `requirements.txt` to work with Python 3.6.

### Motivation

Some images that use the `requirements.txt` file from here (namely `gitlab-agent-deploy`) use Python 3.6.

The long-term fix would be to fix these images so they have a newer Python version.