### PR TITLE
system probe: fixes and simplifications

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -190,7 +190,8 @@ test_suse_x64:
 .test_system_probe:
   extends: .test
   before_script:
-    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
+    - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
+    - cd /go/src/github.com/DataDog/datadog-agent
     - inv -e deps
   script:
     - inv -e system-probe.build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,9 +192,6 @@ test_suse_x64:
   before_script:
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent && cd /go/src/github.com/DataDog/datadog-agent
     - inv -e deps
-    - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$ARCH-11.0.1.tar.xz /tmp/clang.tar.xz
-    - mkdir -p $DATADOG_AGENT_EMBEDDED_PATH
-    - tar -xvf /tmp/clang.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
   script:
     - inv -e system-probe.build
 

--- a/entrypoint-sysprobe.sh
+++ b/entrypoint-sysprobe.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-source /root/.bashrc
-
 eval "$(gimme)"
 
 exec "$@"

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         $(apt-cache search --names-only linux-headers-5.* | \
           cut -d " " -f 1 | \
           grep "\-common$" | \
-          sed -rn 's/(.*bpo\.)([0-9]+)-common/\2 \0 \1\2-arm64/p' | \
+          sed -rn 's/(.*deb10\.)([0-9]+)-common/\2 \0 \1\2-arm64/p' | \
           sort -gr | \
           head -n 1 | \
           cut -f 2-3 -d " ") \

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -76,7 +76,7 @@ RUN ln -s /usr/bin/llc-14 /opt/clang/bin/llc
 RUN ln -s /usr/bin/llvm-strip-14 /opt/clang/bin/llvm-strip
 ENV PATH "/opt/clang/bin:${PATH}"
 
-COPY ./requirements.txt ./requirements-py2.txt /
+COPY ./requirements.txt /
 RUN python3 -m pip install wheel
 RUN python3 -m pip install -r requirements.txt
 

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -77,7 +77,7 @@ RUN ln -s /usr/bin/llc-14 /opt/clang/bin/llc
 RUN ln -s /usr/bin/llvm-strip-14 /opt/clang/bin/llvm-strip
 ENV PATH "/opt/clang/bin:${PATH}"
 
-COPY ./requirements.txt ./requirements-py2.txt /
+COPY ./requirements.txt /
 RUN python3 -m pip install wheel
 RUN python3 -m pip install -r requirements.txt
 

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         $(apt-cache search --names-only linux-headers-5.* | \
           cut -d " " -f 1 | \
           grep "\-common$" | \
-          sed -rn 's/(.*bpo\.)([0-9]+)-common/\2 \0 \1\2-amd64/p' | \
+          sed -rn 's/(.*deb10\.)([0-9]+)-common/\2 \0 \1\2-amd64/p' | \
           sort -gr | \
           head -n 1 | \
           cut -f 2-3 -d " ") \


### PR DESCRIPTION
Fix and simplification for the system probe images:
- fix linux headers version
- remove python 2 requirements
- remove `/root/.bashrc` since it's not needed
- remove clang 11 installation in tests