### PR TITLE
fix windows release image tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ variables:
   # Thus, to release buildimages, we do the same thing as what we do in the Agent: we run the Docker publish script in
   # the buildimage for the highest Windows version supported.
   # This image must use the same Windows version as the Windows version of the Gitlab runner used in .winrelease
-  WINDOWS_RELEASE_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_ltsc2022_x64:v6165899-6f80cc5
+  WINDOWS_RELEASE_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_ltsc2022_x64:v10180886-a9a8910
   S3_CP_CMD: aws s3 cp $S3_CP_OPTIONS
   S3_PERMANENT_ARTIFACTS_URI: s3://dd-ci-persistent-artefacts-build-stable/datadog-agent
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -427,7 +427,7 @@ release_datadog-ci-uploader:
 
 release_windows_1809_x64:
   extends: .winrelease
-  needs: [ "test_windows_1809_x64" ]
+  needs: [ "build_windows_ltsc2022_x64", "test_windows_1809_x64" ]
   variables:
     IMAGE: windows_1809_x64
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64
@@ -435,7 +435,7 @@ release_windows_1809_x64:
 
 release_windows_1909_x64:
   extends: .winrelease
-  needs: [ "test_windows_1909_x64" ]
+  needs: [ "build_windows_ltsc2022_x64", "test_windows_1909_x64" ]
   variables:
     IMAGE: windows_1909_x64
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64
@@ -443,7 +443,7 @@ release_windows_1909_x64:
 
 release_windows_2004_x64:
   extends: .winrelease
-  needs: [ "test_windows_2004_x64" ]
+  needs: [ "build_windows_ltsc2022_x64", "test_windows_2004_x64" ]
   variables:
     IMAGE: windows_2004_x64
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64
@@ -451,7 +451,7 @@ release_windows_2004_x64:
 
 release_windows_20h2_x64:
   extends: .winrelease
-  needs: [ "test_windows_20h2_x64" ]
+  needs: [ "build_windows_ltsc2022_x64", "test_windows_20h2_x64" ]
   variables:
     IMAGE: windows_20h2_x64
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64
@@ -459,7 +459,7 @@ release_windows_20h2_x64:
 
 release_windows_ltsc2022_x64:
   extends: .winrelease
-  needs: [ "test_windows_ltsc2022_x64" ]
+  needs: [ "build_windows_ltsc2022_x64", "test_windows_ltsc2022_x64" ]
   variables:
     IMAGE: windows_ltsc2022_x64
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ variables:
   # Thus, to release buildimages, we do the same thing as what we do in the Agent: we run the Docker publish script in
   # the buildimage for the highest Windows version supported.
   # This image must use the same Windows version as the Windows version of the Gitlab runner used in .winrelease
-  WINDOWS_RELEASE_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_ltsc2022_x64:v10180886-a9a8910
+  WINDOWS_RELEASE_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_ltsc2022_x64
   S3_CP_CMD: aws s3 cp $S3_CP_OPTIONS
   S3_PERMANENT_ARTIFACTS_URI: s3://dd-ci-persistent-artefacts-build-stable/datadog-agent
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded
@@ -346,7 +346,7 @@ test_windows_ltsc2022_x64:
 .winrelease:
   stage: release
   except: [ tags, schedules ]
-  only: [ master, main ]
+  # only: [ master, main ]
   ## this always needs to be the newest available builder version
   tags: [ "runner:windows-docker", "windowsversion:2022" ]
   script:
@@ -381,7 +381,7 @@ test_windows_ltsc2022_x64:
       }
       "@ | out-file ci-scripts/docker-publish.ps1
     - cat ci-scripts/docker-publish.ps1
-    - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine $WINDOWS_RELEASE_IMAGE powershell -C C:\mnt\ci-scripts\docker-publish.ps1
+    - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine $WINDOWS_RELEASE_IMAGE:$SRC_TAG powershell -C C:\mnt\ci-scripts\docker-publish.ps1
   after_script:
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -190,6 +190,7 @@ test_suse_x64:
 .test_system_probe:
   extends: .test
   before_script:
+    - rm -r /go/src/github.com/DataDog/datadog-agent || true
     - git clone https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
     - cd /go/src/github.com/DataDog/datadog-agent
     - inv -e deps

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -381,7 +381,7 @@ test_windows_ltsc2022_x64:
       }
       "@ | out-file ci-scripts/docker-publish.ps1
     - cat ci-scripts/docker-publish.ps1
-    - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine $WINDOWS_RELEASE_IMAGE:$SRC_TAG powershell -C C:\mnt\ci-scripts\docker-publish.ps1
+    - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine ${WINDOWS_RELEASE_IMAGE}:${SRC_TAG} powershell -C C:\mnt\ci-scripts\docker-publish.ps1
   after_script:
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -346,7 +346,7 @@ test_windows_ltsc2022_x64:
 .winrelease:
   stage: release
   except: [ tags, schedules ]
-  # only: [ master, main ]
+  only: [ master, main ]
   ## this always needs to be the newest available builder version
   tags: [ "runner:windows-docker", "windowsversion:2022" ]
   script:


### PR DESCRIPTION
This PR fixes the windows release image tag, by using the currently being built one

This PR also fixes an issue where the datadog-agent was already cloned (for yet unknown reasons) when running system-probe tests