### PR TITLE
Revert "Bump awscli from 1.23.4 to 1.25.85"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ requests==2.27.1
 PyYAML==5.4.1
 toml==0.10.2
 packaging==21.3
-awscli==1.25.85
+awscli==1.23.4


### PR DESCRIPTION
Reverts DataDog/datadog-agent-buildimages#295

We are using an old version of Python elsewhere, so we can't bump this