### PR TITLE
[windows] Pin bundler version to 2.3.22

### DIFF
--- a/windows/install_ruby.ps1
+++ b/windows/install_ruby.ps1
@@ -23,7 +23,7 @@ Write-Host -ForegroundColor Green Done downloading Ruby, installing
 Start-Process $out -ArgumentList '/verysilent /dir="c:\tools\ruby" /tasks="assocfiles,noridkinstall,modpath"' -Wait
 $Env:PATH="$Env:PATH;c:\tools\ruby\bin"
 setx RIDK ((Get-Command ridk).Path)
-Start-Process gem -ArgumentList  'install bundler' -Wait
+Start-Process gem -ArgumentList  'install bundler -v 2.3.22' -Wait
 
 
 Remove-Item $out


### PR DESCRIPTION
### What does this PR do

`bundler` 2.3.23 [was released yesterday](https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#2323-october-5-2022). It breaks the Windows build: if given the same `Gemfile` in `datadog-agent` as bundler 2.3.22, it doesn't install the `win32-process` gem, which breaks the Agent build.

To fix this, this PR pins `bundler` to 2.3.22 in the Windows images.

Long-term, we should consider systematically pinning `bundler` in all places where it's used. It's the second time a patch update of bundler breaks things.