### PR TITLE
Remove rvm from `dd-agent-testing` image

### DIFF
--- a/dd-agent-testing/Dockerfile
+++ b/dd-agent-testing/Dockerfile
@@ -1,6 +1,5 @@
-FROM ubuntu:20.04
+FROM ruby:2.7.5-bullseye
 
-ENV RUBY_VERSION=2.7.5
 ENV BUNDLER_VERSION=1.17.3
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -20,20 +19,10 @@ COPY ./requirements.txt /requirements.txt
 RUN python3 -m pip install -r requirements.txt
 
 # Ruby
-COPY ./rvm/gpg-keys /gpg-keys
-RUN gpg --import --no-tty /gpg-keys/*
-RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
-    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version 1.29.12 \
-    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
-    && rm get-rvm.sh
-RUN /bin/bash -l -c "rvm install ${RUBY_VERSION}"
-RUN /bin/bash -l -c "rvm --default use ${RUBY_VERSION} && \
-    gem install bundler --version ${BUNDLER_VERSION}"
-RUN /bin/bash -l -c "rvm alias create default ${RUBY_VERSION}"
+RUN gem install bundler --version ${BUNDLER_VERSION}
 COPY dd-agent-testing/Gemfile dd-agent-testing/Gemfile.lock ./
-RUN bash -l -c "bundle install"
-RUN bash -l -c "bundle show"
+RUN bundle install
+RUN bundle show
 
 # create the agent build folder within $GOPATH
 RUN mkdir -p /go/src/github.com/DataDog/datadog-agent


### PR DESCRIPTION
RVM requires the use of a login shell, requiring all users to prefix their commands with `bash -l` (https://github.com/DataDog/datadog-agent/blob/5dbf29be553b5350515caea99ad3eb8d1c3228a0/.gitlab/kitchen_testing/suse.yml). This PR fixes this by using a ruby base image. 

This also removes the walls of logs at the beginning of the various kitchen tests (line 45 to 1172 in https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/227669653 for example)

Agent PR: https://github.com/DataDog/datadog-agent/pull/15534
Full pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/13286665