### PR TITLE
Create btf-gen image

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,7 @@
 /system-probe_x64/      @DataDog/ebpf-platform @DataDog/agent-platform
 /omnibus-nikos_arm64/   @DataDog/ebpf-platform @DataDog/agent-security @DataDog/agent-platform
 /omnibus-nikos_x64/     @DataDog/ebpf-platform @DataDog/agent-security @DataDog/agent-platform
+/btf-gen/               @DataDog/ebpf-platform @DataDog/agent-platform
 
 /windows/               @DataDog/windows-agent @DataDog/agent-platform
 /build-container.ps1    @DataDog/windows-agent @DataDog/agent-platform

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -143,6 +143,12 @@ build_docker_x64:
     DOCKERFILE: docker-x64/Dockerfile
     IMAGE: docker_x64
 
+build_btf_gen:
+  extends: [ .build, .x64 ]
+  variables:
+    DOCKERFILE: btf-gen/Dockerfile
+    IMAGE: btf-gen
+
 .test:
   stage: test
   except: [ tags, schedules ]

--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	curl \
 	git \
 	python3 \
-	python3-pip
+	python3-pip \
+	xz-utils
 
 RUN pip install awscli==${AWSCLI_VERSION} invoke==${INVOKE_VERSION}

--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:bookworm
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV AWSCLI_VERSION=1.25.55
+ENV INVOKE_VERSION=1.6.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	bpftool \
+	curl \
+	git \
+	python3 \
+	python3-pip
+
+RUN pip install awscli==${AWSCLI_VERSION} invoke==${INVOKE_VERSION}


### PR DESCRIPTION
Adds a build image to be used for generating minimized BTFs for our bpf programs in our CI.
This job needs its own image because it requires a new version of `bpftool` which isn't available on the distributions our other build images are running.