### PR TITLE
Pin azure-cli to 2.40.0

### DIFF
--- a/dd-agent-testing/Dockerfile
+++ b/dd-agent-testing/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ focal main" | \
       tee /etc/apt/sources.list.d/azure-cli.list && \
       curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-  && apt-get update && apt-get install -y azure-cli \
+  && apt-get update && apt-get install -y azure-cli=2.40.0-1~focal \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Python


### PR DESCRIPTION
This should fix the issue preventing azure cleanup from happening, due to https://github.com/Azure/azure-cli/issues/24295