### PR TITLE
[deb-x64, omnibus-nikos_x64] Ignore key expiration date when verifying packages

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -39,6 +39,11 @@ ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 ENV RUST_VERSION $RUST_VERSION
 ENV RUSTC_SHA256 $RUSTC_SHA256
 
+# The Debian Jessie GPG key expired on Sat Nov 19 2022 21:01:13 GMT+0000.
+# Use gpgv wrapper that ignores key expiration date but checks package signatures.
+COPY gpgvnoexpkeysig /usr/local/sbin
+RUN echo 'Dir::Bin::gpg "/usr/local/sbin/gpgvnoexpkeysig";' >> /etc/apt/apt.conf.d/20datadog
+
 # Mitigation for CVE-2019-3462
 RUN echo 'Acquire::http::AllowRedirect"false";' >> /etc/apt/apt.conf.d/20datadog
 # Ignore expired repos signature

--- a/gpgvnoexpkeysig
+++ b/gpgvnoexpkeysig
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# This script is in the public domain
+#
+# Author: Johannes Schauer Marin Rodrigues <josch@mister-muffin.de>
+#
+# This is a wrapper around gpgv as invoked by apt. It turns EXPKEYSIG results
+# from gpgv into GOODSIG results. This is necessary for apt to access very old
+# timestamps from snapshot.debian.org for which the GPG key is already expired:
+#
+#     Get:1 http://snapshot.debian.org/archive/debian/20150106T000000Z unstable InRelease [242 kB]
+#     Err:1 http://snapshot.debian.org/archive/debian/20150106T000000Z unstable InRelease
+#       The following signatures were invalid: EXPKEYSIG 8B48AD6246925553 Debian Archive Automatic Signing Key (7.0/wheezy) <ftpmaster@debian.org>
+#     Reading package lists...
+#     W: GPG error: http://snapshot.debian.org/archive/debian/20150106T000000Z unstable InRelease: The following signatures were invalid: EXPKEYSIG 8B48AD6246925553 Debian Archive Automatic Signing Key (7.0/wheezy) <ftpmaster@debian.org>
+#     E: The repository 'http://snapshot.debian.org/archive/debian/20150106T000000Z unstable InRelease' is not signed.
+#
+# To use this script, call apt with
+#
+#    -o Apt::Key::gpgvcommand=/usr/libexec/mmdebstrap/gpgvnoexpkeysig
+#
+# Scripts doing similar things can be found here:
+#
+#  * debuerreotype as /usr/share/debuerreotype/scripts/.gpgv-ignore-expiration.sh
+#  * derivative census: salsa.d.o/deriv-team/census/-/blob/master/bin/fakegpgv
+
+set -eu
+
+find_gpgv_status_fd() {
+	while [ "$#" -gt 0 ]; do
+		if [ "$1" = '--status-fd' ]; then
+			echo "$2"
+			return 0
+		fi
+		shift
+	done
+	# default fd is stdout
+	echo 1
+}
+GPGSTATUSFD="$(find_gpgv_status_fd "$@")"
+
+case $GPGSTATUSFD in
+	''|*[!0-9]*)
+		echo "invalid --status-fd argument" >&2
+		exit 1
+		;;
+esac
+
+# we need eval because we cannot redirect a variable fd
+eval 'exec gpgv "$@" '"$GPGSTATUSFD"'>&1 | sed "s/^\[GNUPG:\] EXPKEYSIG /[GNUPG:] GOODSIG /" >&'"$GPGSTATUSFD"

--- a/gpgvnoexpkeysig
+++ b/gpgvnoexpkeysig
@@ -15,9 +15,13 @@
 #     W: GPG error: http://snapshot.debian.org/archive/debian/20150106T000000Z unstable InRelease: The following signatures were invalid: EXPKEYSIG 8B48AD6246925553 Debian Archive Automatic Signing Key (7.0/wheezy) <ftpmaster@debian.org>
 #     E: The repository 'http://snapshot.debian.org/archive/debian/20150106T000000Z unstable InRelease' is not signed.
 #
-# To use this script, call apt with
+# How to use this script depends on the APT version, in particular of whether your version has this patch https://salsa.debian.org/apt-team/apt/-/commit/12841e8320aa499554ac50b102b222900bb1b879:
 #
+# 1. On apt 1.0 or lower, call apt with
 #    -o Apt::Key::gpgvcommand=/usr/libexec/mmdebstrap/gpgvnoexpkeysig
+#
+# 2. On apt 1.1 or higher, call apt with
+#    -o Dir::Bin::gpg=/usr/libexec/mmdebstrap/gpgvnoexpkeysig
 #
 # Scripts doing similar things can be found here:
 #

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -30,6 +30,11 @@ ENV CLANG_SHA256 $CLANG_SHA256
 ENV CONDA_VERSION $CONDA_VERSION
 ENV CONDA_SHA256 $CONDA_SHA256
 
+# The Debian Wheezy GPG key expired on Sat Nov 19 2022 21:01:13 GMT+0000.
+# Use gpgv wrapper that ignores key expiration date but checks package signatures.
+COPY gpgvnoexpkeysig /usr/local/sbin
+RUN echo 'Dir::Bin::gpg "/usr/local/sbin/gpgvnoexpkeysig";' >> /etc/apt/apt.conf.d/20datadog
+
 # Mitigation for CVE-2019-3462
 RUN echo 'Acquire::http::AllowRedirect"false";' >> /etc/apt/apt.conf.d/20datadog
 # Ignore expired repos signature


### PR DESCRIPTION
### What does this PR do?

Fixes deb-x64 image build by ignoring key expiration date when verifying packages signatures.
We still check the signature on packages to avoid tampering.

To do this we override the gpg command with a gpgv wrapper that ignores KEYEXPIRED errors.

Inspired by https://hg.mozilla.org/integration/autoland/rev/3ced9d12bbe9
