### PR TITLE
Add liblz4to the deb-arm and rpm-arm64 Dockerfiles

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -40,7 +40,7 @@ RUN grep -v return /root/.bashrc >> /root/newbashrc && cp /root/newbashrc /root/
 RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
     build-essential pkg-config tar libsystemd-dev libkrb5-dev \
     gettext libtool autopoint autoconf libtool-bin \
-    selinux-basics
+    selinux-basics libunwind-dev liblz4-dev
 
 # Update curl with a statically linked binary
 COPY --from=CURL_GETTER /curl-aarch64 /usr/local/bin/curl-aarch64

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -31,7 +31,7 @@ ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 # The last two lines contain dependencies for build of newer rpm
 RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-libs git procps \
     curl-devel expat-devel gettext-devel openssl-devel systemd-devel zlib-devel bzip2 glibc-static python-devel tar pkgconfig  \
-    libtool autoconf policycoreutils-python \
+    libtool autoconf policycoreutils-python libunwind-devel lz4-devel \
     bzip2-devel e2fsprogs-devel file-devel libacl-devel libarchive-devel libattr-devel \
     libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel \
     && yum clean all


### PR DESCRIPTION
Context: 

We are facing memory leaks in some integrations. Lately it has been the case for the ibm_mq integration for instance. Those leaks are difficult to pinpoint and we would like to give [memray](https://github.com/bloomberg/memray) a shot. We are already using it in our unit tests to track memory and would like to be able to enable it on a running integration so the customer could enable it when needed and send us the generated report to find where the leak comes from.

This means we are adding a new dependency to the agent. Unfortunately, they do not provide wheels for arm64 architectures and we need to build it. This is currently failing, example [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/197418526#L2246). As stated in [their readme](https://github.com/bloomberg/memray#building-from-source), we need to install `liblz4` and `libunwind` (Linux only).

What does this PR do:

Install `liblz4` and `libunwind` in the `deb-arm` and `rpm-arm64` Dockerfiles