### PR TITLE
Allow building openscap using omnibus

### DIFF
--- a/build-gcc.sh
+++ b/build-gcc.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+
+GCC_VERSION=8.4.0
+GCC_SHA256=41e8b145832fc0b2b34c798ed25fb54a881b0cee4cd581b77c7dc92722c116a8
+PREFIX="${PREFIX:-/usr}"
+
+prepare_sources() {
+    local archive=$1
+    local extension="${archive##*.}"
+    local tar_arg
+
+    case $extension in
+      xz)
+        tar_arg=J
+        ;;
+      bz2)
+        tar_arg=j
+        ;;
+      gz)
+        tar_arg=z
+        ;;
+      *)
+        echo "Unsupported archive format $extension"
+        exit 1
+        ;;
+    esac
+
+    tar xv${tar_arg}f ${archive}
+}
+
+compile_with_autoconf() {
+    [ -e /etc/redhat-release ] && configure_args="--libdir=$PREFIX/lib64" || true
+    ./configure --prefix=$PREFIX $configure_args $*
+    cpu_count=$(grep process /proc/cpuinfo | wc -l)
+    make -j $cpu_count
+    make install
+}
+
+url="https://mirrors.kernel.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.gz"
+archive=$(basename $url)
+[ ! -e "$archive" ] && curl -LO $url || true
+echo "${GCC_SHA256}  ${archive}" | sha256sum --check
+
+prepare_sources $(basename $url)
+cd gcc-${GCC_VERSION}
+
+contrib/download_prerequisites --no-isl --no-graphite
+
+compile_with_autoconf \
+    --disable-nls \
+    --enable-languages=c,c++ \
+    --disable-multilib
+
+cd -

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -118,6 +118,10 @@ RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then set -ex \
     && PREFIX=/opt/gcc-${GCC_VERSION} /build-gcc.sh \
     && rm /build-gcc.sh ; fi
 
+# triehash
+COPY ./triehash.pl /usr/local/bin/triehash
+RUN chmod +x /usr/local/bin/triehash
+
 # Entrypoint
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -41,7 +41,7 @@ RUN grep -v return /root/.bashrc >> /root/newbashrc && cp /root/newbashrc /root/
 RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
     build-essential pkg-config tar libsystemd-dev libkrb5-dev \
     gettext libtool autopoint autoconf libtool-bin \
-    selinux-basics default-jre
+    selinux-basics default-jre flex
 
 # Update curl with a statically linked binary
 COPY --from=CURL_GETTER /curl-aarch64 /usr/local/bin/curl-aarch64

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -22,7 +22,7 @@ ARG CMAKE_SHA256="9f8d42ef0b33d1bea47afe15875435dac58503d6a3b58842b473fd811e6df1
 ARG CLANG_VERSION=8.0.0
 ARG CLANG_SHA256="a77eb8fde0a475c25d46dccdeb851a83cbeeeb11779fa2218ae19db9cd0e51f9"
 ARG DD_TARGET_ARCH=aarch64
-
+ARG GCC_VERSION=8.4.0
 
 # Environment
 ENV GOPATH /go
@@ -33,6 +33,7 @@ ENV CLANG_VERSION $CLANG_VERSION
 ENV CLANG_SHA256 $CLANG_SHA256
 ENV CONDA_PATH /root/miniforge3
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
+ENV GCC_VERSION $GCC_VERSION
 
 # Remove the early return on non-interactive shells, which makes sourcing the file not activate conda
 RUN grep -v return /root/.bashrc >> /root/newbashrc && cp /root/newbashrc /root/.bashrc
@@ -109,6 +110,13 @@ RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then curl -sL -o clang_llvm.tar.xz ht
     && tar xf clang_llvm.tar.xz --no-same-owner -kC / \
     && rm clang_llvm.tar.xz ; fi
 ENV PATH="/opt/clang/bin:$PATH"
+
+# gcc
+COPY ./build-gcc.sh /build-gcc.sh
+RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then set -ex \
+    chmod +x /build-gcc.sh \
+    && PREFIX=/opt/gcc-${GCC_VERSION} /build-gcc.sh \
+    && rm /build-gcc.sh ; fi
 
 # Entrypoint
 COPY ./entrypoint.sh /

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -194,6 +194,10 @@ RUN chmod +x /build-gcc.sh \
     && PREFIX=/opt/gcc-${GCC_VERSION} /build-gcc.sh \
     && rm /build-gcc.sh
 
+# triehash
+COPY ./triehash.pl /usr/local/bin/triehash
+RUN chmod +x /usr/local/bin/triehash
+
 # Entrypoint
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -28,6 +28,7 @@ ARG BISON_VERSION="3.8"
 ARG BISON_SHA256="d5d184d421aee15603939973a6b0f372f908edfb24c5bc740697497021ad9458"
 ARG BINUTILS_VERSION="2.39"
 ARG BINUTILS_SHA256="d12ea6f239f1ffe3533ea11ad6e224ffcb89eb5d01bbea589e9158780fa11f10"
+ARG GCC_VERSION=8.4.0
 
 # Environment
 ENV GOPATH /go
@@ -48,6 +49,7 @@ ENV BISON_VERSION $BISON_VERSION
 ENV BISON_SHA256 $BISON_SHA256
 ENV BINUTILS_VERSION $BINUTILS_VERSION
 ENV BINUTILS_SHA256 $BINUTILS_SHA256
+ENV GCC_VERSION $GCC_VERSION
 
 # Remove the early return on non-interactive shells, which makes sourcing the file not activate conda
 RUN grep -v return /root/.bashrc >> /root/newbashrc && cp /root/newbashrc /root/.bashrc
@@ -185,6 +187,12 @@ RUN curl -L -o patchelf-${PATCHELF_VERSION}.tar.gz https://github.com/NixOS/patc
     && cd - \
     && rm -rf patchelf-${PATCHELF_VERSION} \
     && rm patchelf-${PATCHELF_VERSION}.tar.gz
+
+# gcc
+COPY ./build-gcc.sh /build-gcc.sh
+RUN chmod +x /build-gcc.sh \
+    && PREFIX=/opt/gcc-${GCC_VERSION} /build-gcc.sh \
+    && rm /build-gcc.sh
 
 # Entrypoint
 COPY ./entrypoint.sh /

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -103,6 +103,10 @@ RUN curl -sL -o clang_llvm.tar.xz https://dd-agent-omnibus.s3.amazonaws.com/clan
     && rm clang_llvm.tar.xz
 ENV PATH="/opt/clang/bin:$PATH"
 
+# triehash
+COPY ./triehash.pl /usr/local/bin/triehash
+RUN chmod +x /usr/local/bin/triehash
+
 # Entrypoint
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -100,6 +100,10 @@ RUN GIMME_ARCH=arm gimme $GIMME_GO_VERSION
 
 COPY ./gobin.sh /etc/profile.d/
 
+# triehash
+COPY ./triehash.pl /usr/local/bin/triehash
+RUN chmod +x /usr/local/bin/triehash
+
 # Entrypoint
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -119,7 +119,7 @@ RUN if [[ "$(cat /etc/redhat-release-major)" == 6 ]]; then \
     && make \
     && make install \
     && cd / \
-    && rm -rf /tmp/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp/rpm-4.15.1.tar.bz2 /tmp/rpm-4.15.1; fi
+    && rm -rf /tmp/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp/rpm-4.15.1.tar.bz2 /tmp/rpm-4.15.1 /usr/local/include/rpm; fi
 
 # Rebuild RPM database with the new rpm
 RUN if [[ "$(cat /etc/redhat-release-major)" == 6 ]]; then \ 

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -30,6 +30,7 @@ ARG PERLBREW_SHA256="c3996e4fae37a0ae01839cdd73752fb7b17e81bac2a8b39712463a7d518
 ARG PERL_VERSION=5.36.0
 ARG BINUTILS_VERSION="2.39"
 ARG BINUTILS_SHA256="d12ea6f239f1ffe3533ea11ad6e224ffcb89eb5d01bbea589e9158780fa11f10"
+ARG GCC_VERSION=8.4.0
 
 # Environment
 ENV GOPATH /go
@@ -270,6 +271,12 @@ RUN curl -sSL -o perlbrew-install.sh "https://raw.githubusercontent.com/gugod/Ap
     && perlbrew switch "${PERL_VERSION}" \
     && echo "source /root/perl5/perlbrew/etc/bashrc" >> /root/.bashrc \
     && rm perlbrew-install.sh
+
+# gcc
+COPY ./build-gcc.sh /build-gcc.sh
+RUN chmod +x /build-gcc.sh \
+    && PREFIX=/opt/gcc-${GCC_VERSION} /build-gcc.sh \
+    && rm /build-gcc.sh
 
 # Entrypoint
 COPY ./entrypoint.sh /

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -278,6 +278,9 @@ RUN chmod +x /build-gcc.sh \
     && PREFIX=/opt/gcc-${GCC_VERSION} /build-gcc.sh \
     && rm /build-gcc.sh
 
+# triehash
+COPY ./triehash.pl /usr/local/bin/triehash
+
 # Entrypoint
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -61,7 +61,7 @@ RUN sed -i "s/baseurl=http:\/\/download.opensuse.org\/update\/42.1\//baseurl=htt
 # Install all distro-level dependencies
 RUN zypper clean -a && zypper --non-interactive refresh && \
     zypper --non-interactive install \
-      bison bzip2 curl gawk gcc48 gcc48-c++ gdbm-devel gettext-tools git \
+      bison bzip2 curl flex gawk gcc48 gcc48-c++ gdbm-devel gettext-tools git \
       gettext-runtime less libffi-devel libtool libcurl-devel libexpat-devel \
       libopenssl1_0_0 libopenssl-devel make openssl perl perl-Module-Build \
       patch postgresql-devel procps rsync readline-devel rpm-build sqlite3-devel \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -156,6 +156,10 @@ RUN chmod +x /build-gcc.sh \
     && PREFIX=/opt/gcc-${GCC_VERSION} /build-gcc.sh \
     && rm /build-gcc.sh
 
+# triehash
+COPY ./triehash.pl /usr/local/bin/triehash
+RUN chmod +x /usr/local/bin/triehash
+
 # Entrypoint
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -26,6 +26,7 @@ ARG RUST_VERSION=1.60.0
 ARG RUSTC_SHA256="3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338"
 ARG RUSTUP_VERSION=1.24.3
 ARG RUSTUP_SHA256="3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338"
+ARG GCC_VERSION=8.4.0
 
 # Environment
 ENV GOPATH /go
@@ -40,6 +41,7 @@ ENV CONDA_PATH /root/miniconda3
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 ENV RUST_VERSION $RUST_VERSION
 ENV RUSTC_SHA256 $RUSTC_SHA256
+ENV GCC_VERSION $GCC_VERSION
 
 ENV PATH="/opt/datadog/bin:${PATH}"
 
@@ -147,6 +149,12 @@ RUN curl -sSL -o rustup-init https://static.rust-lang.org/rustup/archive/${RUSTU
     && echo "${RUSTC_SHA256}  $HOME/.cargo/bin/rustc" | sha256sum --check \
     && rm ./rustup-init
 ENV PATH "~/.cargo/bin:${PATH}"
+
+# gcc
+COPY ./build-gcc.sh /build-gcc.sh
+RUN chmod +x /build-gcc.sh \
+    && PREFIX=/opt/gcc-${GCC_VERSION} /build-gcc.sh \
+    && rm /build-gcc.sh
 
 # Entrypoint
 COPY ./entrypoint.sh /

--- a/triehash.pl
+++ b/triehash.pl
@@ -1,0 +1,728 @@
+#!/usr/bin/env perl
+#
+# Copyright (C) 2016 Julian Andres Klode <jak@jak-linux.org>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+=encoding utf8
+
+=head1 NAME
+
+triehash - Generate a perfect hash function derived from a trie.
+
+=cut
+
+use strict;
+use warnings;
+use utf8;
+use Getopt::Long;
+
+=head1 SYNOPSIS
+
+B<triehash> [S<I<option>>] [S<I<input file>>]
+
+=head1 DESCRIPTION
+
+triehash takes a list of words in input file and generates a function and
+an enumeration to describe the word
+
+=head1 INPUT FILE FORMAT
+
+The file consists of multiple lines of the form:
+
+    [label ~ ] word [= value]
+
+This maps word to value, and generates an enumeration with entries of the form:
+
+    label = value
+
+If I<label> is undefined, the word will be used, the minus character will be
+replaced by an underscore. If value is undefined it is counted upwards from
+the last value.
+
+There may also be one line of the format
+
+    [ label ~] = value
+
+Which defines the value to be used for non-existing keys. Note that this also
+changes default value for other keys, as for normal entries. So if you place
+
+    = 0
+
+at the beginning of the file, unknown strings map to 0, and the other strings
+map to values starting with 1. If label is not specified, the default is
+I<Unknown>.
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<-C>I<.c file> B<--code>=I<.c file>
+
+Generate code in the given file.
+
+=item B<-H>I<header file> B<--header>=I<header file>
+
+Generate a header in the given file, containing a declaration of the hash
+function and an enumeration.
+
+=item B<--enum-name=>I<word>
+
+The name of the enumeration.
+
+=item B<--function-name=>I<word>
+
+The name of the function.
+
+=item B<--label-prefix=>I<word>
+
+The prefix to use for labels.
+
+=item B<--label-uppercase>
+
+Uppercase label names when normalizing them.
+
+=item B<--namespace=>I<name>
+
+Put the function and enum into a namespace (C++)
+
+=item B<--class=>I<name>
+
+Put the function and enum into a class (C++)
+
+=item B<--enum-class>
+
+Generate an enum class instead of an enum (C++)
+
+=item B<--counter-name=>I<name>
+
+Use I<name> for a counter that is set to the latest entry in the enumeration
++ 1. This can be useful for defining array sizes.
+
+=item B<--ignore-case>
+
+Ignore case for words.
+
+=item B<--multi-byte>=I<value>
+
+Generate code reading multiple bytes at once. The value is a string of power
+of twos to enable. The default value is 320 meaning that 8, 4, and single byte
+reads are enabled. Specify 0 to disable multi-byte completely, or add 2 if you
+also want to allow 2-byte reads. 2-byte reads are disabled by default because
+they negatively affect performance on older Intel architectures.
+
+This generates code for both multiple bytes and single byte reads, but only
+enables the multiple byte reads of GNU C compatible compilers, as the following
+extensions are used:
+
+=over 8
+
+=item Byte-aligned integers
+
+We must be able to generate integers that are aligned to a single byte using:
+
+    typedef uint64_t __attribute__((aligned (1))) triehash_uu64;
+
+=item Byte-order
+
+The macros __BYTE_ORDER__ and __ORDER_LITTLE_ENDIAN__ must be defined.
+
+=back
+
+We forcefully disable multi-byte reads on platforms where the variable
+I<__ARM_ARCH> is defined and I<__ARM_FEATURE_UNALIGNED> is not defined,
+as there is a measurable overhead from emulating the unaligned reads on
+ARM.
+
+=item B<--language=>I<language>
+
+Generate a file in the specified language. Currently known are 'C' and 'tree',
+the latter generating a tree.
+
+=item B<--include=>I<header>
+
+Add the header to the include statements of the header file. The value must
+be surrounded by quotes or angle brackets for C code. May be specified multiple
+times.
+
+=back
+
+=cut
+
+my $unknown = -1;
+my $unknown_label = undef;
+my $counter_start = 0;
+my $enum_name = 'PerfectKey';
+my $function_name = 'PerfectHash';
+my $enum_class = 0;
+
+my $code_name = '-';
+my $header_name = '-';
+my $code;
+my $header;
+my $label_prefix = undef;
+my $label_uppercase = 0;
+my $ignore_case = 0;
+my $multi_byte = '320';
+my $language = 'C';
+my $counter_name = undef;
+my @includes = ();
+
+
+Getopt::Long::config('default',
+                     'bundling',
+                     'no_getopt_compat',
+                     'no_auto_abbrev',
+                     'permute',
+                     'auto_help');
+
+GetOptions ('code|C=s' => \$code_name,
+            'header|H=s'   => \$header_name,
+            'function-name=s' => \$function_name,
+            'label-prefix=s' => \$label_prefix,
+            'label-uppercase' => \$label_uppercase,
+            'ignore-case' => \$ignore_case,
+            'enum-name=s' => \$enum_name,
+            'language|l=s' => \$language,
+            'multi-byte=s' => \$multi_byte,
+            'enum-class' => \$enum_class,
+            'include=s' => \@includes,
+            'counter-name=s' => \$counter_name)
+    or die('Could not parse options!');
+
+
+# This implements a simple trie. Each node has three attributes:
+#
+# children - A hash of keys to other nodes
+# value    - The value to be stored here
+# label    - A named representation of the value.
+#
+# The key at each level of the trie can consist of one or more bytes, and the
+# trie can be normalized to a form where all keys at a level have the same
+# length using rebuild_tree().
+package Trie {
+
+    sub new {
+        my $class = shift;
+        my $self = {};
+        bless $self, $class;
+
+        $self->{children} = {};
+        $self->{value} = undef;
+        $self->{label} = undef;
+
+        return $self;
+    }
+
+    # Return the largest power of 2 smaller or equal to the argument
+    sub alignpower2 {
+        my ($self, $length) = @_;
+
+        return 8 if ($length >= 8 && $multi_byte =~ /3/);
+        return 4 if ($length >= 4 && $multi_byte =~ /2/);
+        return 2 if ($length >= 2 && $multi_byte =~ /1/);
+
+        return 1;
+    }
+
+    # Split the key into a head block and a tail
+    sub split_key {
+        my ($self, $key) = @_;
+        my $length = length $key;
+        my $split = $self->alignpower2($length);
+
+        return (substr($key, 0, $split), substr($key, $split));
+    }
+
+    # Given a key, a label, and a value, insert that into the tree, possibly
+    # replacing an existing node.
+    sub insert {
+        my ($self, $key, $label, $value) = @_;
+
+        if (length($key) == 0) {
+            $self->{label} = $label;
+            $self->{value} = $value;
+            return;
+        }
+
+        my ($child, $tail) = $self->split_key($key);
+
+        $self->{children}{$child} = Trie->new if (!defined($self->{children}{$child}));
+
+        $self->{children}{$child}->insert($tail, $label, $value);
+    }
+
+    # Construct a new trie that only contains words of a given length. This
+    # is used to split up the common trie after knowing all words, so we can
+    # switch on the expected word length first, and have the per-trie function
+    # implement simple longest prefix matching.
+    sub filter_depth {
+        my ($self, $togo) = @_;
+
+        my $new = Trie->new;
+
+        if ($togo != 0) {
+            my $found = 0;
+            foreach my $key (sort keys %{$self->{children}}) {
+                if ($togo > length($key) || defined $self->{children}{$key}->{value}) {
+                    my $child = $self->{children}{$key}->filter_depth($togo - length($key));
+
+                    $new->{children}{$key}= $child if defined $child;
+                    $found = 1 if defined $child;
+                }
+            }
+            return if (!$found);
+        } else {
+            $new->{value} = $self->{value};
+            $new->{label} = $self->{label};
+        }
+
+        return $new;
+    }
+
+    # (helper for rebuild_tree)
+    # Reinsert all value nodes into the specified $trie, prepending $prefix
+    # to their $paths.
+    sub reinsert_value_nodes_into {
+        my ($self, $trie, $prefix) = @_;
+
+        $trie->insert($prefix, $self->{label}, $self->{value}) if (defined $self->{value});
+
+        foreach my $key (sort keys %{$self->{children}}) {
+            $self->{children}{$key}->reinsert_value_nodes_into($trie, $prefix . $key);
+        }
+    }
+
+    # (helper for rebuild_tree)
+    # Find the earliest point to split a key. Normally, we split at the maximum
+    # power of 2 that is greater or equal than the length of the key. When we
+    # are building an ASCII-optimised case-insensitive trie that simply ORs
+    # each byte with 0x20, we need to split at the first ambiguous character:
+    #
+    # For example, the words a-bc and a\rbc are identical in such a situation:
+    #       '-' | 0x20 == '-' == '\r' | 0x20
+    # We cannot simply switch on all 4 bytes at once, but need to split before
+    # the ambiguous character so we can process the ambiguous character on its
+    # own.
+    sub find_earlier_split {
+        my ($self, $key) = @_;
+
+        if ($ignore_case) {
+            for my $i (0..length($key)-1) {
+                # If the key starts with an ambiguous character, we need to
+                # take only it. Otherwise, we need to take everything
+                # before the character.
+                return $self->alignpower2($i || 1) if (main::ambiguous(substr($key, $i, 1)));
+            }
+        }
+        return $self->alignpower2(length $key);
+    }
+
+    # This rebuilds the trie, splitting each key before ambiguous characters
+    # as explained in find_earlier_split(), and then chooses the smallest
+    # such split at each level, so that all keys at all levels have the same
+    # length (so we can use a multi-byte switch).
+    sub rebuild_tree {
+        my $self = shift;
+        # Determine if/where we need to split before an ambiguous character
+        my $new_split = 99999999999999999;
+        foreach my $key (sort keys %{$self->{children}}) {
+            my $special_length = $self->find_earlier_split($key);
+            $new_split = $special_length if ($special_length < $new_split);
+        }
+
+        # Start building a new uniform trie
+        my $newself = Trie->new;
+        $newself->{label} = $self->{label};
+        $newself->{value} = $self->{value};
+        $newself->{children} = {};
+
+        foreach my $key (sort keys %{$self->{children}}) {
+            my $head = substr($key, 0, $new_split);
+            my $tail = substr($key, $new_split);
+            # Rebuild the child node at $head, pushing $tail downwards
+            $newself->{children}{$head} //= Trie->new;
+            $self->{children}{$key}->reinsert_value_nodes_into($newself->{children}{$head}, $tail);
+            # We took up to one special character of each key label. There might
+            # be more, so we need to rebuild recursively.
+            $newself->{children}{$head} = $newself->{children}{$head}->rebuild_tree();
+        }
+
+        return $newself;
+    }
+}
+
+# Code generator for C and C++
+package CCodeGen {
+    my $static = ($code_name eq $header_name) ? "static " : "";
+    my $enum_specifier = $enum_class ? "enum class" : "enum";
+
+    sub new {
+        my $class = shift;
+        my $self = {};
+        bless $self, $class;
+
+        return $self;
+    }
+
+    sub open_output {
+        my $self = shift;
+        if ($code_name ne '-') {
+            open($code, '>', $code_name) or die "Cannot open $code_name: $!" ;
+        } else {
+            $code = *STDOUT;
+        }
+        if($code_name eq $header_name) {
+            $header = $code;
+        } elsif ($header_name ne '-') {
+            open($header, '>', $header_name) or die "Cannot open $header_name: $!" ;
+        } else {
+            $header = *STDOUT;
+        }
+    }
+
+    sub mangle_label {
+        my ($self, $label) = @_;
+
+        $label = $label_prefix . $label if defined($label_prefix);
+        $label = uc $label if $label_uppercase;
+
+        return $label;
+    }
+
+    sub word_to_label {
+        my ($self, $word) = @_;
+
+        $word =~ s/_/__/g;
+        $word =~ s/-/_/g;
+
+        return $self->mangle_label($word);
+    }
+
+    # Return a case label, by shifting and or-ing bytes in the word
+    sub case_label {
+        my ($self, $key) = @_;
+
+        return sprintf("'%s'", substr($key, 0, 1)) if not $multi_byte;
+
+        my $output = '0';
+
+        for my $i (0..length($key)-1) {
+            $output .= sprintf("| onechar('%s', %d, %d)", substr($key, $i, 1), 8 * $i, 8*length($key));
+        }
+
+        return $output;
+    }
+
+    # Return an appropriate read instruction for $length bytes from $offset
+    sub switch_key {
+        my ($self, $offset, $length) = @_;
+
+        return "string[$offset]" if $length == 1;
+        return sprintf("*((triehash_uu%s*) &string[$offset])", $length * 8);
+    }
+
+    # Render the trie so that it matches the longest prefix.
+    sub print_table {
+        my ($self, $trie, $fh, $indent, $index) = @_;
+        $indent //= 0;
+        $index //= 0;
+
+        # If we have children, try to match them.
+        if (%{$trie->{children}}) {
+            # The difference between lowercase and uppercase alphabetical characters
+            # is that they have one bit flipped. If we have alphabetical characters
+            # in the search space, and the entire search space works fine if we
+            # always turn on the flip, just OR the character we are switching over
+            # with the bit.
+            my $want_use_bit = 0;
+            my $can_use_bit = 1;
+            my $key_length = 0;
+            foreach my $key (sort keys %{$trie->{children}}) {
+                $can_use_bit &= not main::ambiguous($key);
+                $want_use_bit |= ($key =~ /^[a-zA-Z]+$/);
+                $key_length = length($key);
+            }
+
+            if ($ignore_case && $can_use_bit && $want_use_bit) {
+                printf { $fh } (('    ' x $indent) . "switch(%s | 0x%s) {\n", $self->switch_key($index, $key_length), '20' x $key_length);
+            } else {
+                printf { $fh } (('    ' x $indent) . "switch(%s) {\n", $self->switch_key($index, $key_length));
+            }
+
+            my $notfirst = 0;
+            foreach my $key (sort keys %{$trie->{children}}) {
+                if ($notfirst) {
+                    printf { $fh } ('    ' x $indent . "    break;\n");
+                }
+                if ($ignore_case) {
+                    printf { $fh } ('    ' x $indent . "case %s:\n", $self->case_label(lc($key)));
+                    printf { $fh } ('    ' x $indent . "case %s:\n", $self->case_label(uc($key))) if lc($key) ne uc($key) && !($can_use_bit && $want_use_bit);
+                } else {
+                    printf { $fh } ('    ' x $indent . "case %s:\n", $self->case_label($key));
+                }
+
+                $self->print_table($trie->{children}{$key}, $fh, $indent + 1, $index + length($key));
+
+                $notfirst=1;
+            }
+
+            printf { $fh } ('    ' x $indent . "}\n");
+        }
+
+
+        # This node has a value, so it is a possible end point. If no children
+        # matched, we have found our longest prefix.
+        if (defined $trie->{value}) {
+            printf { $fh } ('    ' x $indent . "return %s;\n", ($enum_class ? "${enum_name}::" : '').$trie->{label});
+        }
+
+    }
+
+    sub print_words {
+        my ($self, $trie, $fh, $indent, $sofar) = @_;
+
+        $indent //= 0;
+        $sofar //= '';
+
+
+        printf { $fh } ('    ' x $indent."%s = %s,\n", $trie->{label}, $trie->{value}) if defined $trie->{value};
+
+        foreach my $key (sort keys %{$trie->{children}}) {
+            $self->print_words($trie->{children}{$key}, $fh, $indent, $sofar . $key);
+        }
+    }
+
+    sub print_functions {
+        my ($self, $trie, %lengths) = @_;
+        foreach my $local_length (sort { $a <=> $b } (keys %lengths)) {
+            print { $code } ("static enum ${enum_name} ${function_name}${local_length}(const char *string)\n");
+            print { $code } ("{\n");
+            $self->print_table($trie->filter_depth($local_length)->rebuild_tree(), $code, 1);
+            printf { $code } ("    return %s$unknown_label;\n", ($enum_class ? "${enum_name}::" : ''));
+            print { $code } ("}\n");
+        }
+    }
+
+    sub main {
+        my ($self, $trie, $num_values, %lengths) = @_;
+        print { $header } ("#ifndef TRIE_HASH_${function_name}\n");
+        print { $header } ("#define TRIE_HASH_${function_name}\n");
+        print { $header } ("#include <stddef.h>\n");
+        print { $header } ("#include <stdint.h>\n");
+        foreach my $include (@includes) {
+            print { $header } ("#include $include\n");
+        }
+        printf { $header } ("enum { $counter_name = $num_values };\n") if (defined($counter_name));
+        print { $header } ("${enum_specifier} ${enum_name} {\n");
+        $self->print_words($trie, $header, 1);
+        printf { $header } ("    $unknown_label = $unknown,\n");
+        print { $header } ("};\n");
+        print { $header } ("${static}enum ${enum_name} ${function_name}(const char *string, size_t length);\n");
+
+        print { $code } ("#include \"$header_name\"\n") if ($header_name ne $code_name);
+
+        if ($multi_byte) {
+            print { $code } ("#ifdef __GNUC__\n");
+            foreach my $i ((16, 32, 64)) {
+                print { $code } ("typedef uint${i}_t __attribute__((aligned (1))) triehash_uu${i};\n");
+                print { $code } ("typedef char static_assert${i}[__alignof__(triehash_uu${i}) == 1 ? 1 : -1];\n");
+            }
+
+            print { $code } ("#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__\n");
+            print { $code } ("#define onechar(c, s, l) (((uint64_t)(c)) << (s))\n");
+            print { $code } ("#else\n");
+            print { $code } ("#define onechar(c, s, l) (((uint64_t)(c)) << (l-8-s))\n");
+            print { $code } ("#endif\n");
+            print { $code } ("#if (!defined(__ARM_ARCH) || defined(__ARM_FEATURE_UNALIGNED)) && !defined(TRIE_HASH_NO_MULTI_BYTE)\n");
+            print { $code } ("#define TRIE_HASH_MULTI_BYTE\n");
+            print { $code } ("#endif\n");
+            print { $code } ("#endif /*GNUC */\n");
+
+            print { $code } ("#ifdef TRIE_HASH_MULTI_BYTE\n");
+            $self->print_functions($trie, %lengths);
+            $multi_byte = 0;
+            print { $code } ("#else\n");
+            $self->print_functions($trie, %lengths);
+            print { $code } ("#endif /* TRIE_HASH_MULTI_BYTE */\n");
+        } else {
+            $self->print_functions($trie, %lengths);
+        }
+
+        print { $code } ("${static}enum ${enum_name} ${function_name}(const char *string, size_t length)\n");
+        print { $code } ("{\n");
+        print { $code } ("    switch (length) {\n");
+        foreach my $local_length (sort { $a <=> $b } (keys %lengths)) {
+            print { $code } ("    case $local_length:\n");
+            print { $code } ("        return ${function_name}${local_length}(string);\n");
+        }
+        print { $code } ("    default:\n");
+        printf { $code } ("        return %s$unknown_label;\n", ($enum_class ? "${enum_name}::" : ''));
+        print { $code } ("    }\n");
+        print { $code } ("}\n");
+
+        # Print end of header here, in case header and code point to the same file
+        print { $header } ("#endif                       /* TRIE_HASH_${function_name} */\n");
+    }
+}
+
+# A character is ambiguous if the 1<<5 (0x20) bit does not correspond to the
+# lower case bit. A word is ambiguous if any character is. This definition is
+# used to check if we can perform the |0x20 optimization when building a case-
+# insensitive trie.
+sub ambiguous {
+    my $word = shift;
+
+    foreach my $char (split //, $word) {
+        # If 0x20 does not solely indicate lowercase, it is ambiguous
+        return 1 if ord(lc($char)) != (ord($char) | 0x20);
+        return 1 if ord(uc($char)) != (ord($char) & ~0x20);
+    }
+
+    return 0;
+}
+
+sub build_trie {
+    my $codegen = shift;
+    my $trie = Trie->new;
+
+    my $counter = $counter_start;
+    my $prev_value;
+    my %lengths;
+
+    open(my $input, '<', $ARGV[0]) or die "Cannot open $ARGV[0]: $!";
+    while (my $line = <$input>) {
+        my ($label, $word, $value) = $line =~ m{
+            (?:\s*([^~\s]+)\s*~)?      # Label ~
+            (?:\s*([^~=\s]+))?         # Word
+            (?:\s*=\s*([^\s]+)\s+)?    # = Value
+            \s*
+        }x;
+
+        if (defined $word) {
+            $label //= $codegen->word_to_label($word);
+            $value //= defined $prev_value ? $prev_value + 1 : 0;
+
+            $trie->insert($word, $label, $value);
+            $lengths{length($word)} = 1;
+        } elsif (defined $value) {
+            $unknown = $value;
+            $unknown_label = $codegen->mangle_label($label) if defined $label;
+        } else {
+            die "Invalid line: $line";
+        }
+
+        $prev_value = $value;
+        $counter = $value + 1 if $value >= $counter;
+    }
+
+    $unknown_label //= $codegen->mangle_label('Unknown');
+
+    return ($trie, $counter, %lengths);
+}
+
+# Generates an ASCII art tree
+package TreeCodeGen {
+
+    sub new {
+        my $class = shift;
+        my $self = {};
+        bless $self, $class;
+
+        return $self;
+    }
+
+    sub mangle_label {
+        my ($self, $label) = @_;
+        return $label;
+    }
+
+    sub word_to_label {
+        my ($self, $word) = @_;
+        return $word;
+    }
+
+    sub main {
+        my ($self, $trie, $counter, %lengths) = @_;
+        printf { $code } ("┌────────────────────────────────────────────────────┐\n");
+        printf { $code } ("│                   Initial trie                     │\n");
+        printf { $code } ("└────────────────────────────────────────────────────┘\n");
+        $self->print($trie);
+        printf { $code } ("┌────────────────────────────────────────────────────┐\n");
+        printf { $code } ("│                   Rebuilt trie                     │\n");
+        printf { $code } ("└────────────────────────────────────────────────────┘\n");
+        $self->print($trie->rebuild_tree());
+
+        foreach my $local_length (sort { $a <=> $b } (keys %lengths)) {
+            printf { $code } ("┌────────────────────────────────────────────────────┐\n");
+            printf { $code } ("│              Trie for words of length %-4d         │\n", $local_length);
+            printf { $code } ("└────────────────────────────────────────────────────┘\n");
+            $self->print($trie->filter_depth($local_length)->rebuild_tree());
+        }
+    }
+
+    sub open_output {
+        my $self = shift;
+        if ($code_name ne '-') {
+            open($code, '>:encoding(utf8)', $code_name) or die "Cannot open $ARGV[0]: $!" ;
+        } else {
+            $code = *STDOUT;
+            binmode($code, ':encoding(utf8)');
+        }
+    }
+
+    # Print a trie
+    sub print {
+        my ($self, $trie, $depth) = @_;
+        $depth //= 0;
+
+        print { $code } (' → ') if defined($trie->{label});
+        print { $code } ($trie->{label} // '', "\n");
+        foreach my $key (sort keys %{$trie->{children}}) {
+            print { $code } ('│   ' x ($depth), "├── $key");
+            $self->print($trie->{children}{$key}, $depth + 1);
+        }
+    }
+}
+
+my %codegens = (
+    C => 'CCodeGen',
+    tree => 'TreeCodeGen',
+);
+
+
+defined($codegens{$language}) or die "Unknown language $language. Valid choices: ", join(', ', keys %codegens);
+my $codegen = $codegens{$language}->new();
+my ($trie, $counter, %lengths) = build_trie($codegen);
+
+$codegen->open_output();
+$codegen->main($trie, $counter, %lengths);
+
+
+=head1 LICENSE
+
+triehash is available under the MIT/Expat license, see the source code
+for more information.
+
+=head1 AUTHOR
+
+Julian Andres Klode <jak@jak-linux.org>
+
+=cut
+


### PR DESCRIPTION
This PR makes it possible to compile openscap using omnibus.

In particular, it:
- compiles and installs gcc 8.4.0 to be able to compile
APT and openscap which require a modern C++ compiler.
- installs triehash - to compile APT - which is only available as a package
on Ubuntu and not available any more on latest LTS.
- installs flex to compile RPM

