### PR TITLE
Install GCC 10.4.0

### DIFF
--- a/build-gcc.sh
+++ b/build-gcc.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$GCC_VERSION" ] || [ -z "$GCC_SHA256" ]; then
+	echo "The GCC_VERSION and GCC_SHA256 environment variables should be defined to run this script" >&2
+	exit 1
+fi
+
+PREFIX=/opt/gcc-${GCC_VERSION}
+
+compile_with_autoconf() {
+	LIB=lib
+	if [[ "$DD_TARGET_ARCH" == *64* ]]; then
+		LIB=lib64
+	fi
+	[ -e /etc/redhat-release ] && configure_args="--libdir=$PREFIX/$LIB" || true
+	./configure --prefix=$PREFIX $configure_args $*
+	cpu_count=$(grep process /proc/cpuinfo | wc -l)
+	make -j $cpu_count --silent
+	make install
+}
+
+url="https://mirrors.kernel.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.gz"
+archive=$(basename $url)
+[ ! -e "$archive" ] && curl -LO $url || true
+echo "${GCC_SHA256}  ${archive}" | sha256sum --check
+
+tar xzf $(basename $url)
+cd "gcc-${GCC_VERSION}"
+
+contrib/download_prerequisites
+
+compile_with_autoconf \
+    --disable-nls \
+    --enable-languages=c,c++ \
+    --disable-multilib
+
+cd -
+
+rm -rf "gcc-${GCC_VERSION}" "gcc-${GCC_VERSION}.tar.gz"

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -22,7 +22,8 @@ ARG CMAKE_SHA256="9f8d42ef0b33d1bea47afe15875435dac58503d6a3b58842b473fd811e6df1
 ARG CLANG_VERSION=8.0.0
 ARG CLANG_SHA256="a77eb8fde0a475c25d46dccdeb851a83cbeeeb11779fa2218ae19db9cd0e51f9"
 ARG DD_TARGET_ARCH=aarch64
-
+ARG GCC_VERSION=10.4.0
+ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
 
 # Environment
 ENV GOPATH /go
@@ -33,6 +34,7 @@ ENV CLANG_VERSION $CLANG_VERSION
 ENV CLANG_SHA256 $CLANG_SHA256
 ENV CONDA_PATH /root/miniforge3
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
+ENV GCC_VERSION $GCC_VERSION
 
 # Remove the early return on non-interactive shells, which makes sourcing the file not activate conda
 RUN grep -v return /root/.bashrc >> /root/newbashrc && cp /root/newbashrc /root/.bashrc
@@ -109,6 +111,13 @@ RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then curl -sL -o clang_llvm.tar.xz ht
     && tar xf clang_llvm.tar.xz --no-same-owner -kC / \
     && rm clang_llvm.tar.xz ; fi
 ENV PATH="/opt/clang/bin:$PATH"
+
+# gcc
+COPY ./build-gcc.sh /build-gcc.sh
+RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then set -ex \
+    chmod +x /build-gcc.sh \
+    && /build-gcc.sh \
+    && rm /build-gcc.sh ; fi
 
 # Entrypoint
 COPY ./entrypoint.sh /

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -28,6 +28,8 @@ ARG BISON_VERSION="3.8"
 ARG BISON_SHA256="d5d184d421aee15603939973a6b0f372f908edfb24c5bc740697497021ad9458"
 ARG BINUTILS_VERSION="2.39"
 ARG BINUTILS_SHA256="d12ea6f239f1ffe3533ea11ad6e224ffcb89eb5d01bbea589e9158780fa11f10"
+ARG GCC_VERSION=10.4.0
+ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
 
 # Environment
 ENV GOPATH /go
@@ -48,6 +50,7 @@ ENV BISON_VERSION $BISON_VERSION
 ENV BISON_SHA256 $BISON_SHA256
 ENV BINUTILS_VERSION $BINUTILS_VERSION
 ENV BINUTILS_SHA256 $BINUTILS_SHA256
+ENV GCC_VERSION $GCC_VERSION
 
 # Remove the early return on non-interactive shells, which makes sourcing the file not activate conda
 RUN grep -v return /root/.bashrc >> /root/newbashrc && cp /root/newbashrc /root/.bashrc
@@ -185,6 +188,12 @@ RUN curl -L -o patchelf-${PATCHELF_VERSION}.tar.gz https://github.com/NixOS/patc
     && cd - \
     && rm -rf patchelf-${PATCHELF_VERSION} \
     && rm patchelf-${PATCHELF_VERSION}.tar.gz
+
+# gcc
+COPY ./build-gcc.sh /build-gcc.sh
+RUN chmod +x /build-gcc.sh \
+    && /build-gcc.sh \
+    && rm /build-gcc.sh
 
 # Entrypoint
 COPY ./entrypoint.sh /

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -16,7 +16,8 @@ ARG CMAKE_SHA256="9f8d42ef0b33d1bea47afe15875435dac58503d6a3b58842b473fd811e6df1
 ARG CLANG_VERSION=8.0.0
 ARG CLANG_SHA256="a77eb8fde0a475c25d46dccdeb851a83cbeeeb11779fa2218ae19db9cd0e51f9"
 ARG DD_TARGET_ARCH=aarch64
-
+ARG GCC_VERSION=10.4.0
+ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
 
 # Environment
 ENV GOPATH /go
@@ -27,6 +28,7 @@ ENV CLANG_VERSION $CLANG_VERSION
 ENV CLANG_SHA256 $CLANG_SHA256
 ENV CONDA_PATH /root/miniforge3
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
+ENV GCC_VERSION $GCC_VERSION
 
 # The last two lines contain dependencies for build of newer rpm
 RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-libs git procps \
@@ -102,6 +104,12 @@ RUN curl -sL -o clang_llvm.tar.xz https://dd-agent-omnibus.s3.amazonaws.com/clan
     && tar xf clang_llvm.tar.xz --no-same-owner -kC / \
     && rm clang_llvm.tar.xz
 ENV PATH="/opt/clang/bin:$PATH"
+
+# gcc
+COPY ./build-gcc.sh /build-gcc.sh
+RUN chmod +x /build-gcc.sh \
+    && /build-gcc.sh \
+    && rm /build-gcc.sh
 
 # Entrypoint
 COPY ./entrypoint.sh /

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -30,6 +30,8 @@ ARG PERLBREW_SHA256="c3996e4fae37a0ae01839cdd73752fb7b17e81bac2a8b39712463a7d518
 ARG PERL_VERSION=5.36.0
 ARG BINUTILS_VERSION="2.39"
 ARG BINUTILS_SHA256="d12ea6f239f1ffe3533ea11ad6e224ffcb89eb5d01bbea589e9158780fa11f10"
+ARG GCC_VERSION=10.4.0
+ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
 
 # Environment
 ENV GOPATH /go
@@ -52,6 +54,7 @@ ENV PERL_VERSION $PERL_VERSION
 ENV BINUTILS_VERSION $BINUTILS_VERSION
 ENV BINUTILS_SHA256 $BINUTILS_SHA256
 ENV BASE_IMAGE $BASE_IMAGE
+ENV GCC_VERSION $GCC_VERSION
 
 # persist RHEL major for readable output
 RUN echo $(cat /etc/redhat-release | cut -d'.' -f1 | awk '{print $NF}') > /etc/redhat-release-major
@@ -270,6 +273,12 @@ RUN curl -sSL -o perlbrew-install.sh "https://raw.githubusercontent.com/gugod/Ap
     && perlbrew switch "${PERL_VERSION}" \
     && echo "source /root/perl5/perlbrew/etc/bashrc" >> /root/.bashrc \
     && rm perlbrew-install.sh
+
+# gcc
+COPY ./build-gcc.sh /build-gcc.sh
+RUN chmod +x /build-gcc.sh \
+    && /build-gcc.sh \
+    && rm /build-gcc.sh
 
 # Entrypoint
 COPY ./entrypoint.sh /

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -26,6 +26,8 @@ ARG RUST_VERSION=1.60.0
 ARG RUSTC_SHA256="3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338"
 ARG RUSTUP_VERSION=1.24.3
 ARG RUSTUP_SHA256="3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338"
+ARG GCC_VERSION=10.4.0
+ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
 
 # Environment
 ENV GOPATH /go
@@ -40,6 +42,7 @@ ENV CONDA_PATH /root/miniconda3
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 ENV RUST_VERSION $RUST_VERSION
 ENV RUSTC_SHA256 $RUSTC_SHA256
+ENV GCC_VERSION $GCC_VERSION
 
 ENV PATH="/opt/datadog/bin:${PATH}"
 
@@ -147,6 +150,12 @@ RUN curl -sSL -o rustup-init https://static.rust-lang.org/rustup/archive/${RUSTU
     && echo "${RUSTC_SHA256}  $HOME/.cargo/bin/rustc" | sha256sum --check \
     && rm ./rustup-init
 ENV PATH "~/.cargo/bin:${PATH}"
+
+# gcc
+COPY ./build-gcc.sh /build-gcc.sh
+RUN chmod +x /build-gcc.sh \
+    && /build-gcc.sh \
+    && rm /build-gcc.sh
 
 # Entrypoint
 COPY ./entrypoint.sh /


### PR DESCRIPTION
This change installs GCC 10.4.0 on the following build images:

 - deb-arm
 - deb-x64
 - rpm-arm64
 - rpm-x64
 - suse-x64

We chose to provide our own GCC version, because the GCC versions available as part of CentOS 6, openSUSE 42.1 and Ubuntu 14.04 weren't recent enough to build OpenSCAP and some of its dependencies.

We chose GCC 10.4.0, because it was the most recent version that could be built using the GCC versions available on our distributions. GCC 11 and upper include libcody, which is written in C++11 and requires a more recent GCC version to be built.

This change is the result of a collaborative work between Sylvain Baubeau, Pierre Guilleminot and David du Colombier.