### PR TITLE
Use pyenv to download python 3.7 for btfgen images.

### DIFF
--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -17,8 +17,7 @@ RUN curl -s -S -L https://raw.githubusercontent.com/pyenv/pyenv-installer/a08318
 RUN echo "33ba007f17d31215349fd0a693a77fd3d332063fb3a44b8994dfde87728b94e1  pyenv-installer.sh" | sha256sum --check
 RUN bash pyenv-installer.sh
 
-ENV PYENV_ROOT="$HOME/.pyenv"
-ENV PATH="$PYENV_ROOT/bin:$PATH"
+RUN exec "$SHELL"
 
 RUN pyenv global pypy-3.7.9
 RUN python --version

--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	curl \
 	git \
 	ninja-build \
+    patch \
 	python3 \
 	python3-pip \
 	xz-utils
@@ -17,7 +18,7 @@ RUN curl -s -S -L https://raw.githubusercontent.com/pyenv/pyenv-installer/a08318
 RUN echo "33ba007f17d31215349fd0a693a77fd3d332063fb3a44b8994dfde87728b94e1  pyenv-installer.sh" | sha256sum --check
 RUN bash pyenv-installer.sh
 
-RUN ~/.pyenv/bin/pyenv install -s 3.7.9
+RUN ~/.pyenv/bin/pyenv install 3.7.9
 RUN ~/.pyenv/bin/pyenv global 3.7.9
 RUN python --version
 

--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -13,4 +13,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3-pip \
 	xz-utils
 
+RUN curl -s -S -L https://raw.githubusercontent.com/pyenv/pyenv-installer/a08318c86abe0ebb68e0301e5d6861a860b8c765/bin/pyenv-installer > pyenv-installer.sh
+RUN echo "33ba007f17d31215349fd0a693a77fd3d332063fb3a44b8994dfde87728b94e1  pyenv-installer.sh" | sha256sum --check
+RUN bash pyenv-installer.sh
+
+ENV PYENV_ROOT="$HOME/.pyenv"
+ENV PATH="$PYENV_ROOT/bin:$PATH"
+
+RUN pyenv global pypy-3.7.9
+RUN python --version
+
 RUN pip install awscli==${AWSCLI_VERSION} invoke==${INVOKE_VERSION}

--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -17,9 +17,8 @@ RUN curl -s -S -L https://raw.githubusercontent.com/pyenv/pyenv-installer/a08318
 RUN echo "33ba007f17d31215349fd0a693a77fd3d332063fb3a44b8994dfde87728b94e1  pyenv-installer.sh" | sha256sum --check
 RUN bash pyenv-installer.sh
 
-RUN source ~/.bashrc
-
-RUN pyenv global pypy-3.7.9
+RUN ~/.pyenv/bin/pyenv install -s 3.7.9
+RUN ~/.pyenv/bin/pyenv global 3.7.9
 RUN python --version
 
 RUN pip install awscli==${AWSCLI_VERSION} invoke==${INVOKE_VERSION}

--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -s -S -L https://raw.githubusercontent.com/pyenv/pyenv-installer/a08318
 RUN echo "33ba007f17d31215349fd0a693a77fd3d332063fb3a44b8994dfde87728b94e1  pyenv-installer.sh" | sha256sum --check
 RUN bash pyenv-installer.sh
 
-RUN exec "$SHELL"
+RUN source ~/.bashrc
 
 RUN pyenv global pypy-3.7.9
 RUN python --version

--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -6,20 +6,25 @@ ENV INVOKE_VERSION=1.6.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	bpftool \
+    build-essential \
 	curl \
 	git \
+    libssl-dev \
+    zlib1g-dev \
 	ninja-build \
     patch \
-	python3 \
 	python3-pip \
 	xz-utils
+
+ENV PYENV_ROOT="${HOME}/.pyenv"
+ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 
 RUN curl -s -S -L https://raw.githubusercontent.com/pyenv/pyenv-installer/a08318c86abe0ebb68e0301e5d6861a860b8c765/bin/pyenv-installer > pyenv-installer.sh
 RUN echo "33ba007f17d31215349fd0a693a77fd3d332063fb3a44b8994dfde87728b94e1  pyenv-installer.sh" | sha256sum --check
 RUN bash pyenv-installer.sh
 
-RUN ~/.pyenv/bin/pyenv install 3.7.9
-RUN ~/.pyenv/bin/pyenv global 3.7.9
+RUN pyenv install -s 3.7.9
+RUN pyenv global 3.7.9
 RUN python --version
 
 RUN pip install awscli==${AWSCLI_VERSION} invoke==${INVOKE_VERSION}

--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -5,16 +5,16 @@ ENV AWSCLI_VERSION=1.25.55
 ENV INVOKE_VERSION=1.6.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-	bpftool \
+    bpftool \
     build-essential \
-	curl \
-	git \
+    curl \
+    git \
     libssl-dev \
     zlib1g-dev \
-	ninja-build \
+    ninja-build \
     patch \
-	python3-pip \
-	xz-utils
+    python3-pip \
+    xz-utils
 
 ENV PYENV_ROOT="${HOME}/.pyenv"
 ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"


### PR DESCRIPTION
debian:bookworm download python 3.11, which causes problems for invoke. Downgrading debian is not desirable because bookworm ships with the version of bpftool needed by this image. 