### PR TITLE
[deb/rpm-x64] remove installation of golangci-lint

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -163,13 +163,6 @@ RUN ./setup_go.sh
 ENV PATH="/goroot/bin:$PATH"
 ENV PATH="/go/bin:$PATH"
 
-# Download and install golangci-lint
-RUN curl -sSfL -o golangci-lint-install.sh https://raw.githubusercontent.com/golangci/golangci-lint/v1.44.2/install.sh \
-    && echo "1c2edb726aad6bf7d260d95c370bd9ec0fb1a8651e6db6f77f250dd66067de0c  golangci-lint-install.sh" | sha256sum --check \
-    && sh ./golangci-lint-install.sh -b $GOPATH/bin v1.21.0 \
-    && echo "942efc00799b83aebaf6628c34e1151467b7fa21f0cfd78554279dc73f8c8ef3  $GOPATH/bin/golangci-lint" | sha256sum --check \
-    && rm golangci-lint-install.sh
-
 # Rust is needed to compile some python libs
 RUN curl -sSL -o rustup-init https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init \
     && echo "${RUSTUP_SHA256}  rustup-init" | sha256sum --check \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -249,13 +249,6 @@ RUN if [[ "$(cat /etc/redhat-release-major)" == 6 ]]; then \
       && echo "fa9186082638633fbae5229060c68b06875f58682fb7aa4941aa171fb638b78f  /etc/yum.repos.d/fedora-devtoolset-3.repo" | sha256sum --check \
       && yum --enablerepo=copr:copr.fedorainfracloud.org:rhscl:devtoolset-3 -y install devtoolset-3-gcc && yum clean all; fi
 
-# Download and install golangci-lint
-RUN curl -sSfL -o golangci-lint-install.sh https://raw.githubusercontent.com/golangci/golangci-lint/v1.44.2/install.sh \
-    && echo "1c2edb726aad6bf7d260d95c370bd9ec0fb1a8651e6db6f77f250dd66067de0c  golangci-lint-install.sh" | sha256sum --check \
-    && sh ./golangci-lint-install.sh -b $GOPATH/bin v1.21.0 \
-    && echo "942efc00799b83aebaf6628c34e1151467b7fa21f0cfd78554279dc73f8c8ef3  $GOPATH/bin/golangci-lint" | sha256sum --check \
-    && rm golangci-lint-install.sh
-
 # Rust is needed to compile some python libs
 RUN curl -sSL -o rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init" \
     && echo "${RUSTUP_SHA256}  rustup-init" | sha256sum --check \


### PR DESCRIPTION
`golangci-lint` is installed in the agent pipeline via `inv install-tools` now.

Moreover the script was installing https://github.com/golangci/golangci-lint/releases/tag/v1.21.0 version of golangci-lint using the install script from https://github.com/golangci/golangci-lint/releases/tag/v1.44.2 while the agent actually requires https://github.com/DataDog/datadog-agent/blob/a4ed3a1042c5ed1d66bc48d29384287ad0ac0bce/internal/tools/go.mod#L8

Agent pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/17342786
(AFAIK no need for a full pipeline here, only test jobs really bring value)