### PR TITLE
Update the python install script.

### DIFF
--- a/windows/modules/DDDeveloper/main.psm1
+++ b/windows/modules/DDDeveloper/main.psm1
@@ -68,6 +68,11 @@ function Use-BuildEnv {
     # enable RIDK in this shell
     & $Env:RIDK enable
 
+    # activate the development python venv
+    $venvdir = "$($Env:USERPROFILE)\.ddbuild\agentdev\scripts\activate.ps1"
+    & $venvdir
+
+
     # load the developer prompt
     . $PSScriptRoot\prompt.ps1
 }


### PR DESCRIPTION
When installing on developer machine (not in build container) noticed the unexpected side-effect that various python requirements couldn't be installed due to lack of write permissions.

In the developer install case, install a virtual environment.  Update the powershell module to load that virtual environment so that the developer mode is always working on that private environment