### PR TITLE
remove rvm and build ruby from source

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -63,6 +63,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${CONDA_PATH}/lib/"
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -64,23 +64,14 @@ RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
-# RVM
-COPY ./rvm/gpg-keys /gpg-keys
-RUN gpg --import /gpg-keys/*
-RUN rm -rf /gpg-keys
-RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
-    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version 1.29.12 \
-    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
-    && rm get-rvm.sh
-
-RUN /bin/bash -l -c "rvm autolibs read-fail" # do not try to fetch requirements from system repos
+# Ruby
+COPY ./setup_ruby.sh /setup_ruby.sh
 RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then \
-        /bin/bash -l -c "rvm install --with-openssl-dir=${CONDA_PATH} 2.7 && rvm cleanup all" ; \
+        ./setup_ruby.sh ; \
     else \
-        /bin/bash -l -c "rvm install --with-openssl-dir=${CONDA_PATH} --with-arch='armv7-a' -C '--build' -C 'arm-linux-gnueabihf' 2.7 && rvm cleanup all" ; \
+        RUBY_WITH_ARCH="armv7-a" RUBY_BUILD_ARCH="arm-linux-gnueabihf" ./setup_ruby.sh; \
     fi
-RUN /bin/bash -l -c "gem install bundler --no-document"
+RUN gem install bundler --no-document
 
 # Gimme
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -63,7 +63,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
-RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
+RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/z-conda-ld.conf
 RUN ldconfig
 
 # Ruby

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -42,7 +42,9 @@ RUN grep -v return /root/.bashrc >> /root/newbashrc && cp /root/newbashrc /root/
 RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
     build-essential pkg-config tar libsystemd-dev libkrb5-dev \
     gettext libtool autopoint autoconf libtool-bin \
-    selinux-basics default-jre flex
+    selinux-basics default-jre flex bison libffi-dev libgdbm-dev \
+    libncurses5-dev libsqlite3-dev libyaml-dev sqlite3 zlib1g-dev \
+    libgmp-dev libreadline6-dev libssl-dev
 
 # Update curl with a statically linked binary
 COPY --from=CURL_GETTER /curl-aarch64 /usr/local/bin/curl-aarch64
@@ -71,7 +73,8 @@ RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/bi
     && bash get-rvm.sh stable --version 1.29.12 \
     && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
-RUN /bin/bash -l -c "rvm requirements"
+
+RUN /bin/bash -l -c "rvm autolibs read-fail" # do not try to fetch requirements from system repos
 RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then \
         /bin/bash -l -c "rvm install --with-openssl-dir=${CONDA_PATH} 2.7 && rvm cleanup all" ; \
     else \

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -64,6 +64,7 @@ RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
+RUN ldconfig
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -63,7 +63,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
-ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${CONDA_PATH}/lib/"
+RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -115,7 +115,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
-ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${CONDA_PATH}/lib/"
+RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -117,17 +117,10 @@ ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
 # RVM
-COPY ./rvm/gpg-keys /gpg-keys
-RUN gpg --import /gpg-keys/*
-RUN rm -rf /gpg-keys
-RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
-    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version 1.29.12 \
-    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
-    && rm get-rvm.sh
-RUN /bin/bash -l -c "rvm autolibs read-fail" # do not try to fetch requirements from system repos
-RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
-RUN /bin/bash -l -c "gem install bundler --no-document"
+COPY ./setup_ruby.sh /setup_ruby.sh
+RUN ./setup_ruby.sh
+RUN ruby --version
+RUN gem install bundler --no-document
 
 # CMake
 RUN set -ex \

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -116,6 +116,7 @@ RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
+RUN ldconfig
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -115,6 +115,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${CONDA_PATH}/lib/"
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -72,7 +72,8 @@ RUN echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf.d/20datadog
 RUN apt-get update && apt-get install -y fakeroot procps bzip2 \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libpq-dev libz-dev \
   libsystemd-journal-dev rpm tar gettext libtool autopoint autoconf pkg-config flex \
-  selinux-basics libtool software-properties-common default-jre texinfo
+  selinux-basics libtool software-properties-common default-jre texinfo \
+  gawk bison libffi-dev libgdbm-dev libncurses5-dev libsqlite3-dev libyaml-dev sqlite3 libgmp-dev libreadline6-dev
 
 # Ubuntu 14.04 comes with gcc 4.8 by default, which has a tough time compiling newer Go versions
 # NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall
@@ -124,7 +125,7 @@ RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/bi
     && bash get-rvm.sh stable --version 1.29.12 \
     && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
-RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm autolibs read-fail" # do not try to fetch requirements from system repos
 RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -116,10 +116,9 @@ RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
-# RVM
+# Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh
 RUN ./setup_ruby.sh
-RUN ruby --version
 RUN gem install bundler --no-document
 
 # CMake

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -115,7 +115,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
-RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
+RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/z-conda-ld.conf
 RUN ldconfig
 
 # Ruby

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -71,7 +71,6 @@ RUN bash miniconda.sh -b -p $CONDA_PATH
 RUN rm miniconda.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
-ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${CONDA_PATH}/lib/"
 
 # RVM
 COPY ./rvm/gpg-keys /gpg-keys

--- a/omnibus-nikos_x64/Dockerfile
+++ b/omnibus-nikos_x64/Dockerfile
@@ -71,6 +71,7 @@ RUN bash miniconda.sh -b -p $CONDA_PATH
 RUN rm miniconda.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${CONDA_PATH}/lib/"
 
 # RVM
 COPY ./rvm/gpg-keys /gpg-keys

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -69,18 +69,10 @@ RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
-# RVM
-COPY ./rvm/gpg-keys /gpg-keys
-RUN gpg --import /gpg-keys/*
-RUN rm -rf /gpg-keys
-RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
-    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version 1.29.12 \
-    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
-    && rm get-rvm.sh
-RUN /bin/bash -l -c "rvm autolibs read-fail" # do not try to fetch requirements from system repos
-RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
-RUN /bin/bash -l -c "gem install bundler --no-document"
+# Ruby
+COPY ./setup_ruby.sh /setup_ruby.sh
+RUN ./setup_ruby.sh
+RUN gem install bundler --no-document
 
 # Gimme
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/gimme

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -36,7 +36,7 @@ RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-lib
     libtool autoconf policycoreutils-python \
     bzip2-devel e2fsprogs-devel file-devel libacl-devel libarchive-devel libattr-devel \
     libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel java \
-    libffi-devel readline-devel ruby sqlite-devel libyaml-devel \
+    libffi-devel readline-devel sqlite-devel libyaml-devel \
     && yum clean all
 
 COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -69,6 +69,7 @@ RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
+RUN ldconfig
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -68,7 +68,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
-ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${CONDA_PATH}/lib/"
+RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -36,6 +36,7 @@ RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-lib
     libtool autoconf policycoreutils-python \
     bzip2-devel e2fsprogs-devel file-devel libacl-devel libarchive-devel libattr-devel \
     libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel java \
+    libffi-devel readline-devel ruby sqlite-devel libyaml-devel \
     && yum clean all
 
 COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
@@ -77,7 +78,7 @@ RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/bi
     && bash get-rvm.sh stable --version 1.29.12 \
     && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
-RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm autolibs read-fail" # do not try to fetch requirements from system repos
 RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -68,7 +68,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
-RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
+RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/z-conda-ld.conf
 RUN ldconfig
 
 # Ruby

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -68,6 +68,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${CONDA_PATH}/lib/"
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -35,6 +35,7 @@ RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-lib
     libtool autoconf policycoreutils-python \
     bzip2-devel e2fsprogs-devel file-devel libacl-devel libarchive-devel libattr-devel \
     libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel java \
+    libffi-devel readline-devel ruby sqlite-devel \
     && yum clean all
 
 COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
@@ -78,7 +79,7 @@ RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/bi
     && bash get-rvm.sh stable --version 1.29.12 \
     && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
-RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm autolibs read-fail" # do not try to fetch requirements from system repos
 RUN /bin/bash -l -c "rvm install --with-arch='armv7-a' -C '--build' -C 'arm-linux-gnueabihf' 2.7 && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 

--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -70,18 +70,10 @@ RUN git clone --depth 1 https://github.com/DataDog/fakearmv7l ; \
         rm -rf ./fakearmv7l ; \
         export LD_PRELOAD="/usr/local/lib/libfakearmv7l.so"
 
-# RVM
-COPY ./rvm/gpg-keys /gpg-keys
-RUN gpg --import /gpg-keys/*
-RUN rm -rf /gpg-keys
-RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
-    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version 1.29.12 \
-    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
-    && rm get-rvm.sh
-RUN /bin/bash -l -c "rvm autolibs read-fail" # do not try to fetch requirements from system repos
-RUN /bin/bash -l -c "rvm install --with-arch='armv7-a' -C '--build' -C 'arm-linux-gnueabihf' 2.7 && rvm cleanup all"
-RUN /bin/bash -l -c "gem install bundler --no-document"
+# Ruby
+COPY ./setup_ruby.sh /setup_ruby.sh
+RUN RUBY_WITH_ARCH="armv7-a" RUBY_BUILD_ARCH="arm-linux-gnueabihf" ./setup_ruby.sh
+RUN gem install bundler --no-document
 
 # Pip & Invoke
 COPY ./python-packages-versions.txt /python-packages-versions.txt

--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -35,7 +35,7 @@ RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-lib
     libtool autoconf policycoreutils-python \
     bzip2-devel e2fsprogs-devel file-devel libacl-devel libarchive-devel libattr-devel \
     libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel java \
-    libffi-devel readline-devel ruby sqlite-devel \
+    libffi-devel readline-devel sqlite-devel \
     && yum clean all
 
 COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -75,7 +75,7 @@ RUN yum -y install \
   bzip2-devel e2fsprogs-devel file-devel libacl-devel libattr-devel \
   libxml2-devel lzo-devel nss nss-devel popt-devel postgresql-devel sharutils xz-devel java \
   texinfo \
-  libffi-devel readline-devel ruby sqlite-devel \
+  libffi-devel readline-devel sqlite-devel \
   && yum clean all
 
 RUN if [[ $(cat /etc/redhat-release-major) != 6 ]]; then \ 

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -148,7 +148,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
-ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${CONDA_PATH}/lib/"
+RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -148,7 +148,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
-RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
+RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/z-conda-ld.conf
 RUN ldconfig
 
 # Ruby

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -75,6 +75,7 @@ RUN yum -y install \
   bzip2-devel e2fsprogs-devel file-devel libacl-devel libattr-devel \
   libxml2-devel lzo-devel nss nss-devel popt-devel postgresql-devel sharutils xz-devel java \
   texinfo \
+  libffi-devel readline-devel ruby sqlite-devel \
   && yum clean all
 
 RUN if [[ $(cat /etc/redhat-release-major) != 6 ]]; then \ 
@@ -82,9 +83,6 @@ RUN if [[ $(cat /etc/redhat-release-major) != 6 ]]; then \
     fi
 
 COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
-
-# We install our own ruby, let's remove the system one. It made rvm fail to build ruby for some reason
-RUN yum remove -y ruby
 
 # Autoconf
 # We need a newer version of autoconf to compile procps-ng and also new rpm version (installing 2.69 over 2.63).
@@ -160,8 +158,8 @@ RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/bi
     && bash get-rvm.sh stable --version 1.29.12 \
     && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
-RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.6 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
+RUN /bin/bash -l -c "rvm autolibs read-fail" # do not try to fetch requirements from system repos
+RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 
 # Upgrade binutils

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -149,18 +149,10 @@ RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
-# RVM
-COPY ./rvm/gpg-keys /gpg-keys
-RUN gpg --import /gpg-keys/*
-RUN rm -rf /gpg-keys
-RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
-    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version 1.29.12 \
-    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
-    && rm get-rvm.sh
-RUN /bin/bash -l -c "rvm autolibs read-fail" # do not try to fetch requirements from system repos
-RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
-RUN /bin/bash -l -c "gem install bundler --no-document"
+# Ruby
+COPY ./setup_ruby.sh /setup_ruby.sh
+RUN ./setup_ruby.sh
+RUN gem install bundler --no-document
 
 # Upgrade binutils
 RUN curl -sL -O "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.gz" \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -148,6 +148,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${CONDA_PATH}/lib/"
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -149,6 +149,7 @@ RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
+RUN ldconfig
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -34,7 +34,7 @@ case $DD_TARGET_ARCH in
     if [ -f /etc/debian_version ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
         DEBIAN_FRONTEND=noninteractive apt-get update && \
         DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        zip wget build-essential checkinstall libreadline-gplv2-dev \
+        zip wget build-essential checkinstall \
         libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev \
         libc6-dev libbz2-dev libffi-dev zlib1g-dev
     elif [ -f /etc/redhat-release ] || [ "$DISTRIBUTION" == "RedHat" ] || [ "$DISTRIBUTION" == "CentOS" ] || [ "$DISTRIBUTION" == "Amazon" ]; then

--- a/setup_ruby.sh
+++ b/setup_ruby.sh
@@ -11,10 +11,16 @@ curl -OL https://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR/ruby-$RUBY_VERSION.tar
 tar -xzf ruby-$RUBY_VERSION.tar.gz
 rm -rf ruby-$RUBY_VERSION.tar.gz
 
+CONFIGURE_ARGS=""
+
+if [[ -z "$SKIP_CONDA_SSL" ]]; then
+    CONFIGURE_ARGS="$CONFIGURE_ARGS --with-openssl-dir=$CONDA_PATH"
+fi
+
 mkdir -p ruby-$RUBY_VERSION/build
 
 pushd ruby-$RUBY_VERSION/build
-../configure --with-openssl-dir="$CONDA_PATH"
+../configure $CONFIGURE_ARGS
 make install
 popd
 

--- a/setup_ruby.sh
+++ b/setup_ruby.sh
@@ -5,6 +5,7 @@ set -ex
 RUBY_MAJOR=2.7
 RUBY_VERSION=2.7.7
 RUBY_SHA256="e10127db691d7ff36402cfe88f418c8d025a3f1eea92044b162dd72f0b8c7b90"
+RUBYGEMS_VERSION=3.4.8
 
 curl -OL https://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR/ruby-$RUBY_VERSION.tar.gz
 echo "$RUBY_SHA256  ruby-$RUBY_VERSION.tar.gz" | sha256sum --check
@@ -33,9 +34,13 @@ CFLAGS="$CFLAGS" CCFLAGS="$CFLAGS" CXXFLAGS="$CFLAGS" ../configure $CONFIGURE_AR
 make install
 popd
 
-git clone https://github.com/rubygems/rubygems.git ruby-$RUBY_VERSION/build-gems
-pushd ruby-$RUBY_VERSION/build-gems
+curl -OL https://rubygems.org/rubygems/rubygems-$RUBYGEMS_VERSION.tgz
+tar -xzf rubygems-$RUBYGEMS_VERSION.tgz
+rm -rf rubygems-$RUBYGEMS_VERSION.tgz
+
+pushd rubygems-$RUBYGEMS_VERSION
 ruby setup.rb
 popd
 
 rm -rf ruby-$RUBY_VERSION
+rm -rf rubygems-$RUBYGEMS_VERSION

--- a/setup_ruby.sh
+++ b/setup_ruby.sh
@@ -14,7 +14,15 @@ rm -rf ruby-$RUBY_VERSION.tar.gz
 CONFIGURE_ARGS=""
 
 if [[ -z "$SKIP_CONDA_SSL" ]]; then
-    CONFIGURE_ARGS="$CONFIGURE_ARGS --with-openssl-dir=$CONDA_PATH"
+    CONFIGURE_ARGS="$CONFIGURE_ARGS --with-openssl-dir='$CONDA_PATH'"
+fi
+
+if [[ -n "$RUBY_WITH_ARCH" ]]; then
+    CONFIGURE_ARGS="$CONFIGURE_ARGS --with-arch='$RUBY_WITH_ARCH'"
+fi
+
+if [[ -n "$RUBY_BUILD_ARCH" ]]; then
+    CONFIGURE_ARGS="$CONFIGURE_ARGS -C '--build' -C '$RUBY_BUILD_ARCH'"
 fi
 
 mkdir -p ruby-$RUBY_VERSION/build

--- a/setup_ruby.sh
+++ b/setup_ruby.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -ex
+
+RUBY_MAJOR=2.7
+RUBY_VERSION=2.7.7
+
+RUN apt-get -y update && apt-get -y install curl make gcc libssl-dev
+
+curl -OL https://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR/ruby-$RUBY_VERSION.tar.gz
+tar -xzf ruby-$RUBY_VERSION.tar.gz
+rm -rf ruby-$RUBY_VERSION.tar.gz
+
+mkdir -p ruby-$RUBY_VERSION/build
+
+pushd ruby-$RUBY_VERSION/build
+../configure --with-openssl-dir="$CONDA_PATH"
+make install
+popd
+
+rm -rf ruby-$RUBY_VERSION

--- a/setup_ruby.sh
+++ b/setup_ruby.sh
@@ -33,4 +33,9 @@ CFLAGS="$CFLAGS" CCFLAGS="$CFLAGS" CXXFLAGS="$CFLAGS" ../configure $CONFIGURE_AR
 make install
 popd
 
+git clone https://github.com/rubygems/rubygems.git ruby-$RUBY_VERSION/build-gems
+pushd ruby-$RUBY_VERSION/build-gems
+ruby setup.rb
+popd
+
 rm -rf ruby-$RUBY_VERSION

--- a/setup_ruby.sh
+++ b/setup_ruby.sh
@@ -11,7 +11,7 @@ echo "$RUBY_SHA256  ruby-$RUBY_VERSION.tar.gz" | sha256sum --check
 tar -xzf ruby-$RUBY_VERSION.tar.gz
 rm -rf ruby-$RUBY_VERSION.tar.gz
 
-CONFIGURE_ARGS="--disable-install-doc --enable-shared"
+CONFIGURE_ARGS="--disable-install-doc --enable-shared --with-baseruby=no"
 CFLAGS="-O3"
 
 if [[ -z "$SKIP_CONDA_SSL" ]]; then

--- a/setup_ruby.sh
+++ b/setup_ruby.sh
@@ -12,12 +12,8 @@ echo "$RUBY_SHA256  ruby-$RUBY_VERSION.tar.gz" | sha256sum --check
 tar -xzf ruby-$RUBY_VERSION.tar.gz
 rm -rf ruby-$RUBY_VERSION.tar.gz
 
-CONFIGURE_ARGS="--disable-install-doc --enable-shared --with-baseruby=no"
+CONFIGURE_ARGS="--disable-install-doc --enable-shared --with-baseruby=no --with-openssl-dir='$CONDA_PATH'"
 CFLAGS="-O3"
-
-if [[ -z "$SKIP_CONDA_SSL" ]]; then
-    CONFIGURE_ARGS="$CONFIGURE_ARGS --with-openssl-dir='$CONDA_PATH'"
-fi
 
 if [[ -n "$RUBY_WITH_ARCH" ]]; then
     CFLAGS="$CFLAGS -march=$RUBY_WITH_ARCH"

--- a/setup_ruby.sh
+++ b/setup_ruby.sh
@@ -4,31 +4,32 @@ set -ex
 
 RUBY_MAJOR=2.7
 RUBY_VERSION=2.7.7
-
-RUN apt-get -y update && apt-get -y install curl make gcc libssl-dev
+RUBY_SHA256="e10127db691d7ff36402cfe88f418c8d025a3f1eea92044b162dd72f0b8c7b90"
 
 curl -OL https://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR/ruby-$RUBY_VERSION.tar.gz
+echo "$RUBY_SHA256  ruby-$RUBY_VERSION.tar.gz" | sha256sum --check
 tar -xzf ruby-$RUBY_VERSION.tar.gz
 rm -rf ruby-$RUBY_VERSION.tar.gz
 
-CONFIGURE_ARGS=""
+CONFIGURE_ARGS="--disable-install-doc --enable-shared"
+CFLAGS="-O3"
 
 if [[ -z "$SKIP_CONDA_SSL" ]]; then
     CONFIGURE_ARGS="$CONFIGURE_ARGS --with-openssl-dir='$CONDA_PATH'"
 fi
 
 if [[ -n "$RUBY_WITH_ARCH" ]]; then
-    CONFIGURE_ARGS="$CONFIGURE_ARGS --with-arch='$RUBY_WITH_ARCH'"
+    CFLAGS="$CFLAGS -march=$RUBY_WITH_ARCH"
 fi
 
 if [[ -n "$RUBY_BUILD_ARCH" ]]; then
-    CONFIGURE_ARGS="$CONFIGURE_ARGS -C '--build' -C '$RUBY_BUILD_ARCH'"
+    CONFIGURE_ARGS="$CONFIGURE_ARGS --build $RUBY_BUILD_ARCH"
 fi
 
 mkdir -p ruby-$RUBY_VERSION/build
 
 pushd ruby-$RUBY_VERSION/build
-../configure $CONFIGURE_ARGS
+CFLAGS="$CFLAGS" CCFLAGS="$CFLAGS" CXXFLAGS="$CFLAGS" ../configure $CONFIGURE_ARGS
 make install
 popd
 

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -107,6 +107,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${CONDA_PATH}/lib/"
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -66,7 +66,7 @@ RUN zypper clean -a && zypper --non-interactive refresh && \
       gettext-runtime less libffi-devel libtool libcurl-devel libexpat-devel \
       libopenssl1_0_0 libopenssl-devel make openssl perl perl-Module-Build \
       patch postgresql-devel procps rsync readline-devel rpm-build sqlite3-devel \
-      tar xz which zlib-devel java
+      tar xz which zlib-devel java libyaml-devel gcc-c++
 
 # Remove all zypper repositories in the image to prevent errors when using zypper.
 # While the repos are available right now, they might go out of order in the future,
@@ -117,7 +117,7 @@ RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/bi
     && bash get-rvm.sh stable --version 1.29.12 \
     && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
     && rm get-rvm.sh
-RUN bash -l -c "rvm autolibs disable" # do not try to fetch requirements from system repos
+RUN bash -l -c "rvm autolibs read-fail" # do not try to fetch requirements from system repos
 RUN bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
 RUN bash -l -c "gem install bundler --no-document"
 

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -108,6 +108,7 @@ RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
+RUN ldconfig
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -107,7 +107,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
-RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
+RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/z-conda-ld.conf
 RUN ldconfig
 
 # Ruby

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -108,18 +108,10 @@ RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
-# RVM
-COPY ./rvm/gpg-keys /gpg-keys
-RUN gpg --import /gpg-keys/*
-RUN rm -rf /gpg-keys
-RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/binscripts/rvm-installer \
-    && echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e  get-rvm.sh" | sha256sum --check \
-    && bash get-rvm.sh stable --version 1.29.12 \
-    && echo "d2de0b610ee321489e5c673fe749e13be8fb34c0aa08a74446d87f95a17de730  /usr/local/rvm/bin/rvm" | sha256sum --check \
-    && rm get-rvm.sh
-RUN bash -l -c "rvm autolibs read-fail" # do not try to fetch requirements from system repos
-RUN bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
-RUN bash -l -c "gem install bundler --no-document"
+# Ruby
+COPY ./setup_ruby.sh /setup_ruby.sh
+RUN ./setup_ruby.sh
+RUN gem install bundler --no-document
 
 # CMake
 RUN set -ex \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -107,7 +107,7 @@ COPY ./requirements.txt ./requirements-py2.txt /
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
-ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${CONDA_PATH}/lib/"
+RUN echo "${CONDA_PATH}/lib" >> /etc/ld.so.conf.d/conda-ld.conf
 
 # Ruby
 COPY ./setup_ruby.sh /setup_ruby.sh


### PR DESCRIPTION
This PR removes the use of rvm to install ruby and simply build ruby from source instead. This means that ruby is directly in path and removes one of the dependency on the entrypoint scripts

This PR does not migrate the omnibus images, because they are not as important (only used by a manual job), and because we are in the process of removing them

Agent pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/13956713