### PR TITLE
bump rpm version to 4.14.3 on openSUSE images allowing sha256 signing

### DIFF
--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -161,7 +161,6 @@ RUN chmod +x /build-gcc.sh \
 RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.3.tar.bz2 \
     && cd /tmp \
     && echo "13711268181a6e201eb9d4eb06384a7fcc42dcc6c9057a62c53472cfc5ba44b5  rpm-4.14.3.tar.bz2" | sha256sum --check \
-    && cp /usr/include/linux/magic.h /usr/include/magic.h \
     && cp /usr/include/db4/db.h /usr/include/db.h \
     && tar -xjf /tmp/rpm-4.14.3.tar.bz2 \
     && cd rpm-4.14.3 \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -160,8 +160,7 @@ RUN chmod +x /build-gcc.sh \
 # Actually build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp
 # Cannot use HTTPS here: cert name is invalid
-RUN if [[ "$(cat /etc/redhat-release-major)" == 6 ]]; then \ 
-    curl -sL -o /tmp/rpm-4.15.1.tar.bz2 http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2 \
+RUN curl -sL -o /tmp/rpm-4.15.1.tar.bz2 http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2 \
     && echo "ddef45f9601cd12042edfc9b6e37efcca32814e1e0f4bb8682d08144a3e2d230  /tmp/rpm-4.15.1.tar.bz2" | sha256sum --check \
     && cd /tmp \
     && tar -xjf /tmp/rpm-4.15.1.tar.bz2 \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -170,7 +170,7 @@ RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/r
     && tar xzf db-4.5.20.tar.gz \
     && ln -s db-4.5.20 db \
     && cd db/build_unix/ \
-    && ./configure --with-posixmutexes  --without-lua CPPFLAGS="-I/usr/include/nspr4 -I/usr/include/nss3 -I/usr/include/db4/"\
+    && ../../configure --with-posixmutexes  --without-lua CPPFLAGS="-I/usr/include/nspr4 -I/usr/include/nss3 -I/usr/include/db4/"\
     && make \
     && make install \
     && cd / \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -157,6 +157,26 @@ RUN chmod +x /build-gcc.sh \
     && /build-gcc.sh \
     && rm /build-gcc.sh
 
+# Actually build new rpm
+COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp
+# Cannot use HTTPS here: cert name is invalid
+RUN if [[ "$(cat /etc/redhat-release-major)" == 6 ]]; then \ 
+    curl -sL -o /tmp/rpm-4.15.1.tar.bz2 http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2 \
+    && echo "ddef45f9601cd12042edfc9b6e37efcca32814e1e0f4bb8682d08144a3e2d230  /tmp/rpm-4.15.1.tar.bz2" | sha256sum --check \
+    && cd /tmp \
+    && tar -xjf /tmp/rpm-4.15.1.tar.bz2 \
+    && cd rpm-4.15.1 \
+    && cat /tmp/rpm-4.15.1-fix-rpmbuild-segfault.patch | patch -p1 \
+    && ./configure --without-lua --without-audit \
+    && make \
+    && make install \
+    && cd / \
+
+# Rebuild RPM database with the new rpm
+RUN if [[ "$(cat /etc/redhat-release-major)" == 6 ]]; then \ 
+    mkdir -p /usr/local/var/lib/rpm \
+    && cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages \
+
 # Entrypoint
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -159,10 +159,10 @@ RUN chmod +x /build-gcc.sh \
     && rm /build-gcc.sh
 
 RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.3.tar.bz2 \
+    && cd /tmp \
     && echo "13711268181a6e201eb9d4eb06384a7fcc42dcc6c9057a62c53472cfc5ba44b5  rpm-4.14.3.tar.bz2" | sha256sum --check \
     && cp /usr/include/linux/magic.h /usr/include/magic.h \
     && cp /usr/include/db4/db.h /usr/include/db.h \
-    && cd /tmp \
     && tar -xjf /tmp/rpm-4.15.1.tar.bz2 \
     && cd rpm-4.15.1 \
     && curl -sL -o db-4.5.20.tar.gz http://download.oracle.com/berkeley-db/db-4.5.20.tar.gz \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -67,7 +67,7 @@ RUN zypper clean -a && zypper --non-interactive refresh && \
       libopenssl1_0_0 libopenssl-devel make openssl perl perl-Module-Build \
       patch postgresql-devel procps rsync readline-devel rpm-build sqlite3-devel \
       tar xz which zlib-devel java mozilla-nspr-devel mozilla-nss-devel popt-devel \ 
-      libbeecrypt-devel file-magic libarchive-devel libdb-4_8 libdb-4_8-devel
+      libbeecrypt-devel file-magic file-devel libarchive-devel libdb-4_8 libdb-4_8-devel
 
 # Remove all zypper repositories in the image to prevent errors when using zypper.
 # While the repos are available right now, they might go out of order in the future,

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -162,8 +162,8 @@ RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/r
     && cd /tmp \
     && echo "13711268181a6e201eb9d4eb06384a7fcc42dcc6c9057a62c53472cfc5ba44b5  rpm-4.14.3.tar.bz2" | sha256sum --check \
     && tar -xjf /tmp/rpm-4.14.3.tar.bz2 \
-    && cd rpm-4.14.3/db/build_unix/ \
-    && ../../configure --with-posixmutexes --with-external-db --without-lua CPPFLAGS="-I/usr/include/nspr4 -I/usr/include/nss3 -I/usr/include/db4"\
+    && cd rpm-4.14.3/ \
+    && ./configure --with-posixmutexes --with-external-db --without-lua CPPFLAGS="-I/usr/include/nspr4 -I/usr/include/nss3 -I/usr/include/db4"\
     && make \
     && make install \
     && cd / \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -161,19 +161,14 @@ RUN chmod +x /build-gcc.sh \
 RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.3.tar.bz2 \
     && cd /tmp \
     && echo "13711268181a6e201eb9d4eb06384a7fcc42dcc6c9057a62c53472cfc5ba44b5  rpm-4.14.3.tar.bz2" | sha256sum --check \
-    && cp /usr/include/db4/db.h /usr/include/db.h \
     && tar -xjf /tmp/rpm-4.14.3.tar.bz2 \
-    && cd rpm-4.14.3 \
-    && curl -sL -o db-4.5.20.tar.gz http://download.oracle.com/berkeley-db/db-4.5.20.tar.gz \
-    && echo "f52cd5cea899823dd200d56556f70b33c55e48a33bb7b65ee128968dc10ca82d  db-4.5.20.tar.gz" | sha256sum --check \
-    && tar xzf db-4.5.20.tar.gz \
-    && ln -s db-4.5.20 db \
-    && cd db/build_unix/ \
-    && ../../configure --with-posixmutexes  --without-lua CPPFLAGS="-I/usr/include/nspr4 -I/usr/include/nss3"\
+    && cd rpm-4.14.3/db/build_unix/ \
+    && ../../configure --with-posixmutexes --with-external-db --without-lua CPPFLAGS="-I/usr/include/nspr4 -I/usr/include/nss3 -I/usr/include/db4"\
     && make \
     && make install \
     && cd / \
-    && rpm --version
+    && echo "/usr/local/lib/" >> /etc/ld.so.conf \
+    && ldconfig
 
 # Rebuild RPM database with the new rpm
 RUN mkdir -p /usr/local/var/lib/rpm \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -167,7 +167,6 @@ RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/r
     && make \
     && make install \
     && cd / \
-    && echo "/usr/local/lib/" >> /etc/ld.so.conf \
     && ldconfig
 
 # Rebuild RPM database with the new rpm

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -66,7 +66,8 @@ RUN zypper clean -a && zypper --non-interactive refresh && \
       gettext-runtime less libffi-devel libtool libcurl-devel libexpat-devel \
       libopenssl1_0_0 libopenssl-devel make openssl perl perl-Module-Build \
       patch postgresql-devel procps rsync readline-devel rpm-build sqlite3-devel \
-      tar xz which zlib-devel java
+      tar xz which zlib-devel java mozilla-nspr-devel mozilla-nss-devel popt-devel \ 
+      libbeecrypt-devel file-magic libarchive-devel libdb-4_8 libdb-4_8-devel
 
 # Remove all zypper repositories in the image to prevent errors when using zypper.
 # While the repos are available right now, they might go out of order in the future,
@@ -155,21 +156,26 @@ ENV PATH "~/.cargo/bin:${PATH}"
 COPY ./build-gcc.sh /build-gcc.sh
 RUN chmod +x /build-gcc.sh \
     && /build-gcc.sh \
-    && rm /build-gcc.sh
+    && rm /build-gcc.s
 
-# Actually build new rpm
-COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp
-# Cannot use HTTPS here: cert name is invalid
-RUN curl -sL -o /tmp/rpm-4.15.1.tar.bz2 http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2 \
-    && echo "ddef45f9601cd12042edfc9b6e37efcca32814e1e0f4bb8682d08144a3e2d230  /tmp/rpm-4.15.1.tar.bz2" | sha256sum --check \
+RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.3.tar.bz2 \
+    && echo "13711268181a6e201eb9d4eb06384a7fcc42dcc6c9057a62c53472cfc5ba44b5  rpm-4.14.3.tar.bz2" | sha256sum --check \
+    && cp /usr/include/linux/magic.h /usr/include/magic.h \
+    && cp /usr/include/db4/db.h /usr/include/db.h \
     && cd /tmp \
     && tar -xjf /tmp/rpm-4.15.1.tar.bz2 \
     && cd rpm-4.15.1 \
-    && cat /tmp/rpm-4.15.1-fix-rpmbuild-segfault.patch | patch -p1 \
-    && ./configure --without-lua --without-audit \
+    && curl -sL -o db-4.5.20.tar.gz http://download.oracle.com/berkeley-db/db-4.5.20.tar.gz \
+    && echo "f52cd5cea899823dd200d56556f70b33c55e48a33bb7b65ee128968dc10ca82d  db-4.5.20.tar.gz" | sha256sum --check \
+    && tar xzf db-4.5.20.tar.gz \
+    && ln -s db-4.5.20 db \
+    && cd db/build_unix/ \
+    && ./configure --with-posixmutexes  --without-lua CPPFLAGS="-I/usr/include/nspr4 -I/usr/include/nss3 -I/usr/include/db4/"\
     && make \
     && make install \
-    && cd /
+    && cd / \
+    && echo "/usr/local/lib/" >> /etc/ld.so.conf \
+    && ldconfig
 
 # Rebuild RPM database with the new rpm
 RUN mkdir -p /usr/local/var/lib/rpm \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -169,17 +169,16 @@ RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/r
     && tar xzf db-4.5.20.tar.gz \
     && ln -s db-4.5.20 db \
     && cd db/build_unix/ \
-    && ../../configure --with-posixmutexes  --without-lua CPPFLAGS="-I/usr/include/nspr4 -I/usr/include/nss3 -I/usr/include/db4/"\
+    && ../../configure --with-posixmutexes  --without-lua CPPFLAGS="-I/usr/include/nspr4 -I/usr/include/nss3"\
     && make \
     && make install \
     && cd / \
-    && echo "/usr/local/lib/" >> /etc/ld.so.conf \
-    && ldconfig
+    && rpm --version
 
 # Rebuild RPM database with the new rpm
 RUN mkdir -p /usr/local/var/lib/rpm \
-    && cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages
-
+    && cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages \
+    && /usr/local/bin/rpm --rebuilddb
 # Entrypoint
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -169,12 +169,11 @@ RUN curl -sL -o /tmp/rpm-4.15.1.tar.bz2 http://ftp.rpm.org/releases/rpm-4.15.x/r
     && ./configure --without-lua --without-audit \
     && make \
     && make install \
-    && cd / \
+    && cd /
 
 # Rebuild RPM database with the new rpm
-RUN if [[ "$(cat /etc/redhat-release-major)" == 6 ]]; then \ 
-    mkdir -p /usr/local/var/lib/rpm \
-    && cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages \
+RUN mkdir -p /usr/local/var/lib/rpm \
+    && cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages
 
 # Entrypoint
 COPY ./entrypoint.sh /

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -166,7 +166,6 @@ RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/r
     && ./configure --with-posixmutexes --with-external-db --without-lua CPPFLAGS="-I/usr/include/nspr4 -I/usr/include/nss3 -I/usr/include/db4"\
     && make \
     && make install \
-    && cd / \
     && ldconfig
 
 # Rebuild RPM database with the new rpm

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -163,8 +163,8 @@ RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/r
     && echo "13711268181a6e201eb9d4eb06384a7fcc42dcc6c9057a62c53472cfc5ba44b5  rpm-4.14.3.tar.bz2" | sha256sum --check \
     && cp /usr/include/linux/magic.h /usr/include/magic.h \
     && cp /usr/include/db4/db.h /usr/include/db.h \
-    && tar -xjf /tmp/rpm-4.15.1.tar.bz2 \
-    && cd rpm-4.15.1 \
+    && tar -xjf /tmp/rpm-4.14.3.tar.bz2 \
+    && cd rpm-4.14.3 \
     && curl -sL -o db-4.5.20.tar.gz http://download.oracle.com/berkeley-db/db-4.5.20.tar.gz \
     && echo "f52cd5cea899823dd200d56556f70b33c55e48a33bb7b65ee128968dc10ca82d  db-4.5.20.tar.gz" | sha256sum --check \
     && tar xzf db-4.5.20.tar.gz \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -156,7 +156,7 @@ ENV PATH "~/.cargo/bin:${PATH}"
 COPY ./build-gcc.sh /build-gcc.sh
 RUN chmod +x /build-gcc.sh \
     && /build-gcc.sh \
-    && rm /build-gcc.s
+    && rm /build-gcc.sh
 
 RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.3.tar.bz2 \
     && echo "13711268181a6e201eb9d4eb06384a7fcc42dcc6c9057a62c53472cfc5ba44b5  rpm-4.14.3.tar.bz2" | sha256sum --check \


### PR DESCRIPTION
Changes : 
  - openSUSE rpm version bump to 4.14.3.
  - allows openSUSE to sign rpms in sha256