### PR TITLE
Pin urllib3 to prevent botocore erroring with urllib3>=2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ PyYAML==5.4.1
 toml==0.10.2
 packaging==21.3
 awscli==1.23.4
+# urllib3, released on May 4th 2023, breaks botocore used by awscli
+# (removed DEFAULT_CIPHERS list from urllib3.util.ssl_)
+urllib3==1.26.15


### PR DESCRIPTION
urllib3 2.0.2 (released on May 4th) breaks botocore:

```
$ aws s3 sync --only-show-errors $S3_ARTIFACTS_URI $BUILD_CONTEXT
Traceback (most recent call last):
  File "/usr/local/bin/aws", line 19, in <module>
    import awscli.clidriver
  File "/usr/local/lib/python3.8/dist-packages/awscli/clidriver.py", line 17, in <module>
    import botocore.session
  File "/usr/local/lib/python3.8/dist-packages/botocore/session.py", line 26, in <module>
    import botocore.client
  File "/usr/local/lib/python3.8/dist-packages/botocore/client.py", line 15, in <module>
    from botocore import waiter, xform_name
  File "/usr/local/lib/python3.8/dist-packages/botocore/waiter.py", line 18, in <module>
    from botocore.docs.docstring import WaiterDocstring
  File "/usr/local/lib/python3.8/dist-packages/botocore/docs/__init__.py", line 15, in <module>
    from botocore.docs.service import ServiceDocumenter
  File "/usr/local/lib/python3.8/dist-packages/botocore/docs/service.py", line 14, in <module>
    from botocore.docs.client import ClientDocumenter, ClientExceptionsDocumenter
  File "/usr/local/lib/python3.8/dist-packages/botocore/docs/client.py", line 14, in <module>
    from botocore.docs.example import ResponseExampleDocumenter
  File "/usr/local/lib/python3.8/dist-packages/botocore/docs/example.py", line 13, in <module>
    from botocore.docs.shape import ShapeDocumenter
  File "/usr/local/lib/python3.8/dist-packages/botocore/docs/shape.py", line 19, in <module>
    from botocore.utils import is_json_value_header
  File "/usr/local/lib/python3.8/dist-packages/botocore/utils.py", line 34, in <module>
    import botocore.httpsession
  File "/usr/local/lib/python3.8/dist-packages/botocore/httpsession.py", line 21, in <module>
    from urllib3.util.ssl_ import (
ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_' (/usr/local/lib/python3.8/dist-packages/urllib3/util/ssl_.py)
```

This PR pins urllib3 on latest version < 2.