### PR TITLE
Upgrade invoke version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # python development requirements for the Datadog Agent
-invoke==1.7.3
+invoke==2.1.1
 reno==3.5.0
 docker==6.0.1; python_version >= '3.7'
 docker==5.0.3; python_version < '3.7'


### PR DESCRIPTION
Use an invoke version > 2 for python 3.11 support. See jira ticket below
https://datadoghq.atlassian.net/browse/AP-2019