### PR TITLE
Upload sha256 sum of kernel packages

### DIFF
--- a/.gitlab/kernel_version_testing.yml
+++ b/.gitlab/kernel_version_testing.yml
@@ -80,10 +80,12 @@ upload_kernel_packages_x64:
     - DIR=$(dirname $(head -n 1 packages.txt))
     - cat packages.txt
     - cd $DIR; tar -cf $KERNEL_PKG_NAME -T packages.txt
-    - sha256sum $KERNEL_PKG_NAME
-    - $S3_CP_CMD $KERNEL_PKG_NAME $S3_DD_AGENT_OMNIBUS_KERNEL_VERSION_TESTING_URI/kernel-packages-$ARCH.tar --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    - sha256sum $KERNEL_PKG_NAME > $KERNEL_PKG_SUM
+    - $S3_CP_CMD $KERNEL_PKG_NAME $S3_DD_AGENT_OMNIBUS_KERNEL_VERSION_TESTING_URI/$KERNEL_PKG_NAME --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    - $S3_CP_CMD $KERNEL_PKG_SUM $S3_DD_AGENT_OMNIBUS_KERNEL_VERSION_TESTING_URI/$KERNEL_PKG_SUM --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
   variables:
     KERNEL_PKG_NAME: kernel-packages-$ARCH.tar
+    KERNEL_PKG_SUM: kernel-packages-$ARCH.sum
     ARCH: "x86_64"
 
 upload_kernel_packages_arm64:
@@ -97,8 +99,10 @@ upload_kernel_packages_arm64:
     - DIR=$(dirname $(head -n 1 packages.txt))
     - cat packages.txt
     - cd $DIR; tar -cf $KERNEL_PKG_NAME -T packages.txt
-    - sha256sum $KERNEL_PKG_NAME
-    - $S3_CP_CMD $KERNEL_PKG_NAME $S3_DD_AGENT_OMNIBUS_KERNEL_VERSION_TESTING_URI/kernel-packages-$ARCH.tar --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    - sha256sum $KERNEL_PKG_NAME > $KERNEL_PKG_SUM
+    - $S3_CP_CMD $KERNEL_PKG_NAME $S3_DD_AGENT_OMNIBUS_KERNEL_VERSION_TESTING_URI/$KERNEL_PKG_NAME --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+    - $S3_CP_CMD $KERNEL_PKG_SUM $S3_DD_AGENT_OMNIBUS_KERNEL_VERSION_TESTING_URI/$KERNEL_PKG_SUM --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
   variables:
     KERNEL_PKG_NAME: kernel-packages-$ARCH.tar
+    KERNEL_PKG_SUM: kernel-packages-$ARCH.sum
     ARCH: "arm64"


### PR DESCRIPTION
This sum is used by the invoke task setting up the dev environment for the kernel matrix testing system to decide whether an update is required.