### PR TITLE
Revert "Upgrade invoke version"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # python development requirements for the Datadog Agent
-invoke==2.1.1
+invoke==1.7.3
 reno==3.5.0
 docker==6.0.1; python_version >= '3.7'
 docker==5.0.3; python_version < '3.7'


### PR DESCRIPTION
The upgrade to invoke 2.1.1 broke our public CI in `datadog-agent`.

Example: https://app.circleci.com/pipelines/github/DataDog/datadog-agent/79666/workflows/8faccc59-5d46-4949-be0e-ee3569355a05/jobs/976704

Can be reproduced locally by running `inv -e docker.integration-tests` with invoke 2.1.1 installed.