### PR TITLE
Build circleci image with other agent buildimages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -207,6 +207,12 @@ build_kernel_version_testing_arm64:
     DOCKERFILE: kernel-version-testing/kernel-version-testing_arm64/Dockerfile
     IMAGE: kernel-version-testing_arm64
 
+build_circleci_runner:
+  extends: [ .build, .x64 ]
+  variables:
+    DOCKERFILE: circleci/Dockerfile
+    IMAGE: circleci-runner
+
 trigger_build_kernels:
   stage: trigger_build_kernels
   needs: [ "build_kernel_version_testing_x64" , "build_kernel_version_testing_arm64" ]
@@ -483,6 +489,12 @@ release_windows_ltsc2022_x64:
     IMAGE: windows_ltsc2022_x64
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64
     DOCKERHUB_TAG_PREFIX: "ltsc2022"
+
+release_circleci_runner:
+  extends: .release
+  needs: [ "build_circleci_runner" ]
+  variables:
+    IMAGE: circleci-runner
 
 notify-on-failure:
   extends: .slack-notifier-base

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -208,10 +208,19 @@ build_kernel_version_testing_arm64:
     IMAGE: kernel-version-testing_arm64
 
 build_circleci_runner:
-  extends: [ .build, .x64 ]
+  extends: [ .x64 ]
+  stage: build
+  except: [ tags ]
   variables:
     DOCKERFILE: circleci/Dockerfile
     IMAGE: circleci-runner
+  script:
+    # Dockerhub login
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
+    # Build
+    - docker build --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg DD_TARGET_ARCH=$DD_TARGET_ARCH $CUSTOM_BUILD_ARGS --tag datadog/agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}${ECR_TEST_ONLY} --file $DOCKERFILE .
+    - docker push datadog/agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}${ECR_TEST_ONLY}
 
 trigger_build_kernels:
   stage: trigger_build_kernels
@@ -491,10 +500,23 @@ release_windows_ltsc2022_x64:
     DOCKERHUB_TAG_PREFIX: "ltsc2022"
 
 release_circleci_runner:
-  extends: .release
+  stage: release
   needs: [ "build_circleci_runner" ]
   variables:
     IMAGE: circleci-runner
+  except: [ tags, schedules ]
+  only: [ master, main ]
+  tags: [ "runner:docker" ]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-notary:0.6.1
+  script:
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
+    - SRC_IMAGE=datadog/agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    - docker pull $SRC_IMAGE
+    - docker tag $SRC_IMAGE datadog/agent-buildimages-$IMAGE:latest
+    - docker push datadog/agent-buildimages-$IMAGE:latest
+  after_script:
+    - docker rmi datadog/agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7} datadog/agent-buildimages-$IMAGE:latest
 
 notify-on-failure:
   extends: .slack-notifier-base

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,8 +219,8 @@ build_circleci_runner:
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
     # Build
-    - docker build --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg DD_TARGET_ARCH=$DD_TARGET_ARCH $CUSTOM_BUILD_ARGS --tag datadog/agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}${ECR_TEST_ONLY} --file $DOCKERFILE .
-    - docker push datadog/agent-buildimages-$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}${ECR_TEST_ONLY}
+    - docker build --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg DD_TARGET_ARCH=$DD_TARGET_ARCH $CUSTOM_BUILD_ARGS --tag datadog/agent-buildimages-${IMAGE}${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7} --file $DOCKERFILE .
+    - docker push datadog/agent-buildimages-${IMAGE}${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
 
 trigger_build_kernels:
   stage: trigger_build_kernels

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -38,10 +38,10 @@ RUN set -ex \
         xz-utils
 
 # Golang
-ENV GO_VERSION 1.19.9
+ENV GO_VERSION 1.20.5
 ENV GOPATH /go
 RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz \
-  && echo "e858173b489ec1ddbe2374894f52f53e748feed09dde61be5b4b4ba2d73ef34b  /tmp/golang.tar.gz" | sha256sum --check \
+  && echo "d7ec48cde0d3d2be2c69203bc3e0a44de8660b9c09a6e85c4732a3f7dc442612 /tmp/golang.tar.gz" | sha256sum --check \
   && tar -C /usr/local -xzf /tmp/golang.tar.gz \
   && rm -f /tmp/golang.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -1,0 +1,77 @@
+# We cannot use Ubuntu 22.04 because the E2E tests
+# are currently using a Docker Compose v1 imaged based on Debian.
+# The glibc version is too old to allow running CGO binaries built on Ubuntu 22.04
+# We'll be able to migrate when we get rid of Docker Compose or use Docker Compose v2
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Pre-requisites
+# Python 3 dev is required for rtloader
+RUN set -ex \
+    && apt-get update && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        default-jre \
+        doxygen \
+        file \
+        g++ \
+        gcc \
+        git \
+        gnupg ca-certificates \
+        graphviz \
+        libpq-dev \
+        libsnmp-base \
+        libsnmp-dev \
+        libssl-dev \
+        libsystemd-dev \
+        make \
+        pkg-config \
+        python3 \
+        python3-dev \
+        python3-distutils \
+        python3-pip \
+        python3-setuptools \
+        python3-yaml \
+        snmp-mibs-downloader \
+        ssh \
+        xz-utils
+
+# Golang
+ENV GO_VERSION 1.19.9
+ENV GOPATH /go
+RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz \
+  && echo "e858173b489ec1ddbe2374894f52f53e748feed09dde61be5b4b4ba2d73ef34b  /tmp/golang.tar.gz" | sha256sum --check \
+  && tar -C /usr/local -xzf /tmp/golang.tar.gz \
+  && rm -f /tmp/golang.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV PATH="${GOPATH}/bin:${PATH}"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+
+# CMake
+ENV CMAKE_NAME cmake-3.13.3-Linux-x86_64
+ENV CMAKE_ARCHIVE $CMAKE_NAME.tar.gz
+ENV CMAKE_DEST_DIR /cmake
+ENV PATH $CMAKE_DEST_DIR/bin/:$PATH
+RUN set -ex \
+    && curl -sL -O https://github.com/Kitware/CMake/releases/download/v3.13.3/$CMAKE_ARCHIVE \
+    && tar xzf $CMAKE_ARCHIVE \
+    && mv $CMAKE_NAME $CMAKE_DEST_DIR \
+    && rm $CMAKE_ARCHIVE
+
+# Other dependencies
+RUN set -ex \
+    # clang-format
+    && echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list \
+    && curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && apt-get update \
+    && apt-get -t llvm-toolchain-focal install -y --no-install-recommends \
+        clang-format
+
+# Python
+COPY ./requirements.txt /
+COPY ./circleci/requirements.txt /circleci_requirements.txt
+RUN python3 -m pip install -r requirements.txt -r circleci_requirements.txt
+
+# Setup entrypoint
+WORKDIR $GOPATH

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -59,6 +59,18 @@ RUN set -ex \
     && mv $CMAKE_NAME $CMAKE_DEST_DIR \
     && rm $CMAKE_ARCHIVE
 
+# Codecov
+ENV CODECOV_VERSION=0.4.1
+RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
+    && curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/linux/codecov \
+    && curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/linux/codecov.SHA256SUM \
+    && curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/linux/codecov.SHA256SUM.sig \
+    && gpgv codecov.SHA256SUM.sig codecov.SHA256SUM \
+    && shasum -a 256 -c codecov.SHA256SUM \
+    && rm codecov.SHA256SUM.sig codecov.SHA256SUM \
+    && mv codecov /usr/local/bin/codecov \
+    && chmod +x /usr/local/bin/codecov
+
 # Other dependencies
 RUN set -ex \
     # clang-format

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -11,39 +11,39 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN set -ex \
     && apt-get update && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
-        curl \
-        default-jre \
-        doxygen \
-        file \
-        g++ \
-        gcc \
-        git \
-        gnupg ca-certificates \
-        graphviz \
-        libpq-dev \
-        libsnmp-base \
-        libsnmp-dev \
-        libssl-dev \
-        libsystemd-dev \
-        make \
-        pkg-config \
-        python3 \
-        python3-dev \
-        python3-distutils \
-        python3-pip \
-        python3-setuptools \
-        python3-yaml \
-        snmp-mibs-downloader \
-        ssh \
-        xz-utils
+    curl \
+    default-jre \
+    doxygen \
+    file \
+    g++ \
+    gcc \
+    git \
+    gnupg ca-certificates \
+    graphviz \
+    libpq-dev \
+    libsnmp-base \
+    libsnmp-dev \
+    libssl-dev \
+    libsystemd-dev \
+    make \
+    pkg-config \
+    python3 \
+    python3-dev \
+    python3-distutils \
+    python3-pip \
+    python3-setuptools \
+    python3-yaml \
+    snmp-mibs-downloader \
+    ssh \
+    xz-utils
 
 # Golang
-ENV GO_VERSION 1.20.5
+ENV GO_VERSION 1.20.6
 ENV GOPATH /go
 RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz \
-  && echo "d7ec48cde0d3d2be2c69203bc3e0a44de8660b9c09a6e85c4732a3f7dc442612 /tmp/golang.tar.gz" | sha256sum --check \
-  && tar -C /usr/local -xzf /tmp/golang.tar.gz \
-  && rm -f /tmp/golang.tar.gz
+    && echo "b945ae2bb5db01a0fb4786afde64e6fbab50b67f6fa0eb6cfa4924f16a7ff1eb /tmp/golang.tar.gz" | sha256sum --check \
+    && tar -C /usr/local -xzf /tmp/golang.tar.gz \
+    && rm -f /tmp/golang.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV PATH="${GOPATH}/bin:${PATH}"
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
@@ -78,7 +78,7 @@ RUN set -ex \
     && curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-get update \
     && apt-get -t llvm-toolchain-focal install -y --no-install-recommends \
-        clang-format
+    clang-format
 
 # Python
 COPY ./requirements.txt /

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -60,7 +60,7 @@ RUN set -ex \
     && rm $CMAKE_ARCHIVE
 
 # Codecov
-ENV CODECOV_VERSION=0.4.1
+ENV CODECOV_VERSION=0.6.1
 RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
     && curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/linux/codecov \
     && curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/linux/codecov.SHA256SUM \

--- a/circleci/requirements.txt
+++ b/circleci/requirements.txt
@@ -1,4 +1,4 @@
-wheel
+wheel==0.40.0
 black==22.10.0
 flake8-bugbear==22.10.27
 flake8-comprehensions==3.10.1

--- a/circleci/requirements.txt
+++ b/circleci/requirements.txt
@@ -1,0 +1,9 @@
+wheel
+black==22.10.0
+flake8-bugbear==22.10.27
+flake8-comprehensions==3.10.1
+flake8-unused-arguments==0.0.12
+flake8-use-fstring==1.4
+flake8==5.0.4
+isort==5.10.1
+vulture==2.6


### PR DESCRIPTION
Moved CircleCI image definition and construction alongside other buildimages used during DataDog Agent CI.
This will reduce the risk of misalignment between the various buildimages we have and might help improving efficiency of image modifications