### PR TITLE
[windows] Update container root certificates

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -63,6 +63,8 @@ COPY ./requirements.txt ./requirements-py2.txt /
 COPY ./python-packages-versions.txt /python-packages-versions.txt
 COPY ./windows/set_cpython_compiler.cmd set_cpython_compiler.cmd
 
+RUN .\helpers\update_root_certs.ps1
+
 COPY ./windows/helpers/phase1/*.ps1 c:/scripts/helpers/phase1/
 RUN .\install-all.ps1 -TargetContainer -Phase 1
 COPY ./windows/helpers/phase2/*.ps1 c:/scripts/helpers/phase2/

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -1,0 +1,51 @@
+# Taken from https://github.com/actions/runner-images/blob/59997be01ae4da61faedbb48aa5d57f5a5e391c3/images/win/scripts/Installers/Install-RootCA.ps1
+# MIT License
+# Copyright (c) 2020 GitHub
+
+function Invoke-WithRetry {
+     <#
+        .SYNOPSIS
+        Runs $command block until $BreakCondition or $RetryCount is reached.
+     #>
+
+     param([ScriptBlock]$Command, [ScriptBlock] $BreakCondition, [int] $RetryCount=5, [int] $Sleep=10)
+
+     $c = 0
+     while($c -lt $RetryCount){
+        $result = & $Command
+        if(& $BreakCondition){
+            break
+        }
+        Start-Sleep $Sleep
+        $c++
+     }
+     $result
+}
+
+function Import-SSTFromWU {
+    # Serialized Certificate Store File
+    $sstFile = "$env:TEMP\roots.sst"
+    # Generate SST from Windows Update
+    $result = Invoke-WithRetry { certutil.exe -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0}
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
+        exit $LASTEXITCODE
+    }
+
+    $result = certutil.exe -dump $sstFile
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[Error]: failed to dump $sstFile sst file`n$result"
+        exit $LASTEXITCODE
+    }
+
+    try {
+        Import-Certificate -FilePath $sstFile -CertStoreLocation Cert:\LocalMachine\Root
+    } catch {
+        Write-Host "[Error]: failed to import ROOT CA`n$_"
+        exit 1
+    }
+}
+
+Write-Host "Importing certificates from Windows Update"
+Import-SSTFromWU
+Write-Host "Imported certificates from Windows Update"


### PR DESCRIPTION
There is a possible timing issue in the test and build scripts in the `datadog-agent` repository: the base container doesn't contain some of the root certificates needed to install dependencies. These certificates are added while the container is running (probably by a Windows Update process), but if this happens too late, the test and build Windows jobs can fail ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent-old/-/jobs/253012823/raw)).

To prevent this, we force the certificates update to happen while the container is being built.

Long-term version of this short-term fix: https://github.com/DataDog/datadog-agent/pull/17207, which allows to not query the new certificates on every test / build, making it flaky (due to possible network issues).