### PR TITLE
Increase retry count to fix windows root certificate retrieval

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -308,8 +308,6 @@ build_windows_1809_x64:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_1809_x64
     DD_TARGET_ARCH: x64
-  retry: 1
-  # Network issues prevent root certificates update, it is more efficient to retry the job than to retry the certificate update function
 
 build_windows_ltsc2022_x64:
   extends: .winbuild
@@ -318,8 +316,6 @@ build_windows_ltsc2022_x64:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_ltsc2022_x64
     DD_TARGET_ARCH: x64
-  retry: 1
-  # Network issues prevent root certificates update, it is more efficient to retry the job than to retry the certificate update function
 
 .test_windows:
   extends: .test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -308,6 +308,8 @@ build_windows_1809_x64:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_1809_x64
     DD_TARGET_ARCH: x64
+  retry: 1
+  # Network issues prevent root certificates update, it is more efficient to retry the job than to retry the certificate update function
 
 build_windows_ltsc2022_x64:
   extends: .winbuild
@@ -316,6 +318,8 @@ build_windows_ltsc2022_x64:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_ltsc2022_x64
     DD_TARGET_ARCH: x64
+  retry: 1
+  # Network issues prevent root certificates update, it is more efficient to retry the job than to retry the certificate update function
 
 .test_windows:
   extends: .test

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -27,7 +27,7 @@ function Import-SSTFromWU {
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update
-    $result = Invoke-WithRetry { certutil.exe -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0} 10
+    $result = Invoke-WithRetry { certutil.exe -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0} 30
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
         exit $LASTEXITCODE

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -28,7 +28,7 @@ function Import-SSTFromWU {
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update
-    $result = Invoke-WithRetry { certutil.exe -v -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0} 30
+    $result = Invoke-WithRetry { certutil.exe -v -f -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0} 30
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
         exit $LASTEXITCODE

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -8,7 +8,7 @@ function Invoke-WithRetry {
         Runs $command block until $BreakCondition or $RetryCount is reached.
      #>
 
-     param([ScriptBlock]$Command, [ScriptBlock] $BreakCondition, [int] $RetryCount=10, [int] $Sleep=60)
+     param([ScriptBlock]$Command, [ScriptBlock] $BreakCondition, [int] $RetryCount=20, [int] $Sleep=30)
 
      $c = 0
      while($c -lt $RetryCount){

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -25,6 +25,9 @@ function Invoke-WithRetry {
 }
 
 function Import-SSTFromWU {
+
+    # Test network
+    Test-Connection -TargetName www.google.com
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -13,11 +13,9 @@ function Invoke-WithRetry {
      $c = 0
      while($c -lt $RetryCount){
         $result = & $Command
-        Write-Host "Result: $result, exitCode: $LASTEXITCODE, iteration: $c"
         if(& $BreakCondition){
             break
         }
-        Get-Content -Path "$env:TEMP\roots.sst"
         Start-Sleep $Sleep
         $c++
      }
@@ -26,12 +24,10 @@ function Invoke-WithRetry {
 
 function Import-SSTFromWU {
 
-    # Test network
-    Invoke-WithRetry { Test-Connection -ComputerName www.google.com } {$LASTEXITCODE -eq 0} 30
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update
-    $result = Invoke-WithRetry { certutil.exe -v -f -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0} 30
+    $result = Invoke-WithRetry { certutil.exe -v -f -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0} 10 60
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
         exit $LASTEXITCODE

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -27,7 +27,7 @@ function Import-SSTFromWU {
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update
-    $result = Invoke-WithRetry { certutil.exe -v -f -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0} 10 60
+    $result = Invoke-WithRetry { certutil.exe -v -f -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0}
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
         exit $LASTEXITCODE

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -27,7 +27,7 @@ function Import-SSTFromWU {
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update
-    $result = Invoke-WithRetry { certutil.exe -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0} 30
+    $result = Invoke-WithRetry { certutil.exe -generateSSTFromWU $sstFile -v } {$LASTEXITCODE -eq 0} 30
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
         exit $LASTEXITCODE

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -13,6 +13,7 @@ function Invoke-WithRetry {
      $c = 0
      while($c -lt $RetryCount){
         $result = & $Command
+        Write-Host "Result: $result, exitCode: $LASTEXITCODE, iteration: $c"
         if(& $BreakCondition){
             break
         }

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -27,7 +27,7 @@ function Invoke-WithRetry {
 function Import-SSTFromWU {
 
     # Test network
-    Test-Connection -TargetName www.google.com
+    Invoke-WithRetry { Test-Connection -TargetName www.google.com } {$LASTEXITCODE -eq 0} 30
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -17,6 +17,7 @@ function Invoke-WithRetry {
         if(& $BreakCondition){
             break
         }
+        Get-Content -Path "$env:TEMP\roots.sst"
         Start-Sleep $Sleep
         $c++
      }

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -24,7 +24,6 @@ function Invoke-WithRetry {
 }
 
 function Import-SSTFromWU {
-
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -27,7 +27,7 @@ function Invoke-WithRetry {
 function Import-SSTFromWU {
 
     # Test network
-    Invoke-WithRetry { Test-Connection -TargetName www.google.com } {$LASTEXITCODE -eq 0} 30
+    Invoke-WithRetry { Test-Connection -ComputerName www.google.com } {$LASTEXITCODE -eq 0} 30
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -27,7 +27,7 @@ function Import-SSTFromWU {
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update
-    $result = Invoke-WithRetry { certutil.exe -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0}
+    $result = Invoke-WithRetry { certutil.exe -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0} 10
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
         exit $LASTEXITCODE

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -27,7 +27,7 @@ function Import-SSTFromWU {
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update
-    $result = Invoke-WithRetry { certutil.exe -generateSSTFromWU $sstFile -v } {$LASTEXITCODE -eq 0} 30
+    $result = Invoke-WithRetry { certutil.exe -v -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0} 30
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
         exit $LASTEXITCODE

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -28,7 +28,7 @@ function Import-SSTFromWU {
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update
-    $result = Invoke-WithRetry { certutil.exe -v -f -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0}
+    $result = Invoke-WithRetry { certutil.exe -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0}
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
         exit $LASTEXITCODE

--- a/windows/helpers/update_root_certs.ps1
+++ b/windows/helpers/update_root_certs.ps1
@@ -8,7 +8,7 @@ function Invoke-WithRetry {
         Runs $command block until $BreakCondition or $RetryCount is reached.
      #>
 
-     param([ScriptBlock]$Command, [ScriptBlock] $BreakCondition, [int] $RetryCount=5, [int] $Sleep=10)
+     param([ScriptBlock]$Command, [ScriptBlock] $BreakCondition, [int] $RetryCount=10, [int] $Sleep=60)
 
      $c = 0
      while($c -lt $RetryCount){
@@ -16,6 +16,7 @@ function Invoke-WithRetry {
         if(& $BreakCondition){
             break
         }
+        Write-Host "Failed to execute function, retrying in $Sleep s. $($c+1)/$RetryCount"
         Start-Sleep $Sleep
         $c++
      }


### PR DESCRIPTION
`certutil.exe -generateSSTFromWU $sstFile` is flaky and sometime fails to update certificate from Windows Update. It is likely to be a network problem. 

Increasing retry count and sleeping time fixes the problem.  It will retry every minute during a maximum of 10 minutes, in most cases the problem is fixed after 3 or 4 minutes.

