### PR TITLE
Re-add entrypoint for local usage of images

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -122,3 +122,9 @@ RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then set -ex \
 
 # Force umask to 0022
 RUN echo "umask 0022" >> /root/.bashrc
+
+# Entrypoint - only for local usage, Kubernetes-based Gitlab runners overwrite this
+COPY ./entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -196,3 +196,9 @@ RUN mkdir -p /go/src/github.com/DataDog/datadog-agent
 
 # Force umask to 0022
 RUN echo "umask 0022" >> /root/.bashrc
+
+# Entrypoint - only for local usage, Kubernetes-based Gitlab runners overwrite this
+COPY ./entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -l
+#!/bin/bash
 set -e
 
 source /root/.bashrc

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,20 +3,4 @@ set -e
 
 source /root/.bashrc
 
-if command -v conda; then
-  # Only try to use conda if it's installed.
-  # On ARM32 images, we use the system Python 3 because conda is not supported.
-  conda activate ddpy3
-fi
-
-if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then
-    export GIMME_ARCH=arm64
-elif [ "$DD_TARGET_ARCH" = "armhf" ] ; then
-    export GIMME_ARCH=arm
-fi
-
-if [ -n "$GIMME_GO_VERSION" ] ; then
-    eval "$(gimme)"
-fi
-
 exec "$@"

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -115,3 +115,9 @@ RUN chmod +x /build-gcc.sh \
 
 # Force umask to 0022
 RUN echo "umask 0022" >> /root/.bashrc
+
+# Entrypoint - only for local usage, Kubernetes-based Gitlab runners overwrite this
+COPY ./entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -99,3 +99,9 @@ ENV PATH="${GOPATH}/bin:${PATH}"
 
 # Force umask to 0022
 RUN echo "umask 0022" >> /root/.bashrc
+
+# Entrypoint - only for local usage, Kubernetes-based Gitlab runners overwrite this
+COPY ./entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -276,3 +276,9 @@ RUN chmod +x /build-gcc.sh \
 
 # Force umask to 0022
 RUN echo "umask 0022" >> /root/.bashrc
+
+# Entrypoint - only for local usage, Kubernetes-based Gitlab runners overwrite this
+COPY ./entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -175,3 +175,9 @@ RUN mkdir -p /usr/local/var/lib/rpm \
 
 # Force umask to 0022
 RUN echo "umask 0022" >> /root/.bashrc
+
+# Entrypoint - only for local usage, Kubernetes-based Gitlab runners overwrite this
+COPY ./entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
In #370, we removed entrypoints in all build images, as they cannot be used in our new CI infrastructure.

They are still useful for developers that want to run the image locally though, therefore this PR reintroduces their usage (without the gimme setup, which isn't needed anymore as we don't use gimme).