### PR TITLE
Lastest cython release fails build on old distros

### DIFF
--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,2 +1,4 @@
+# Old os which cannot use recent wheel use pip install from source that fails with cython 3.0.0
+cython<3.0.0
 requests==2.27.1
 PyYAML==5.4.1

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,4 +1,1 @@
-# Old os which cannot use recent wheel use pip install from source that fails with cython 3.0.0
-cython<3.0.0
 requests==2.27.1
-PyYAML==5.3.1

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,4 +1,4 @@
 # Old os which cannot use recent wheel use pip install from source that fails with cython 3.0.0
 cython<3.0.0
 requests==2.27.1
-PyYAML==5.4.1
+PyYAML==5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# Old os which cannot use recent wheel use pip install from source that fails with cython 3.0.0
+cython<3.0.0
 # python development requirements for the Datadog Agent
 invoke==1.7.3
 reno==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-# Old os which cannot use recent wheel use pip install from source that fails with cython 3.0.0
-cython<3.0.0
 # python development requirements for the Datadog Agent
 invoke==1.7.3
 reno==3.5.0
@@ -8,7 +6,6 @@ docker==5.0.3; python_version < '3.7'
 docker-squash==1.0.9
 dulwich==0.20.45
 requests==2.27.1
-PyYAML==5.4.1
 toml==0.10.2
 packaging==21.3
 # more recent boto3 has a bug which generates an import exception.

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -87,6 +87,7 @@ pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION}
 pip install setuptools==${DD_SETUPTOOLS_VERSION}
 pip install --no-build-isolation "cython<3.0.0" PyYAML==5.4.1
 pip install -r requirements-py2.txt
+pip uninstall -y cython # remove cython to prevent further issue with nghttp2
 
 # Update pip, setuptools and misc deps
 conda activate ddpy3
@@ -94,6 +95,7 @@ pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION_PY3}
 pip install setuptools==${DD_SETUPTOOLS_VERSION_PY3}
 pip install --no-build-isolation "cython<3.0.0" PyYAML==5.4.1
 pip install -r requirements.txt
+pip uninstall -y cython # remove cython to prevent further issue with nghttp2
 
 
 if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -53,7 +53,7 @@ case $DD_TARGET_ARCH in
     rm Python-3.9.5.tgz
     ln -sf /usr/bin/python3.9 /usr/bin/python3
 
-    python3 -m pip install distro==1.4.0
+    python3 -m pip install distro==1.4.0 wheel==0.40.0
     python3 -m pip install --no-build-isolation "cython<3.0.0" PyYAML==5.4.1
     python3 -m pip install -r requirements.txt
     exit 0

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -54,6 +54,7 @@ case $DD_TARGET_ARCH in
     ln -sf /usr/bin/python3.9 /usr/bin/python3
 
     python3 -m pip install distro==1.4.0
+    python3 -m pip install --no-build-isolation "cython<3.0.0" PyYAML==5.4.1
     python3 -m pip install -r requirements.txt
     exit 0
     ;;
@@ -73,6 +74,7 @@ source /root/.bashrc
 
 # Make sure requirements are installed also on the system python
 # This is needed because some tests jobs (py2 test jobs) run invoke using the system python
+python3 -m pip install --no-build-isolation "cython<3.0.0" PyYAML==5.4.1
 python3 -m pip install -r requirements.txt
 
 # Setup pythons
@@ -83,12 +85,14 @@ conda create -n ddpy3 python python=$PY3_VERSION
 conda activate ddpy2
 pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION}
 pip install setuptools==${DD_SETUPTOOLS_VERSION}
+pip install --no-build-isolation "cython<3.0.0" PyYAML==5.4.1
 pip install -r requirements-py2.txt
 
 # Update pip, setuptools and misc deps
 conda activate ddpy3
 pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION_PY3}
 pip install setuptools==${DD_SETUPTOOLS_VERSION_PY3}
+pip install --no-build-isolation "cython<3.0.0" PyYAML==5.4.1
 pip install -r requirements.txt
 
 


### PR DESCRIPTION
On old distributions, like on CentOS 6, which uses glibc 2.12 - pip cannot use manylinux 2.17 wheels (which require glibc 2.17), unlike our other builders. If a wheel is only distributed this way ([which is the case for oracledb](https://pypi.org/project/oracledb/#files)), then pip falls back to the source install, which is failing with cython 3.0.0.