### PR TITLE
Use a valid clang-format version

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -78,7 +78,8 @@ RUN set -ex \
     && curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-get update \
     && apt-get -t llvm-toolchain-focal install -y --no-install-recommends \
-    clang-format
+    clang-format-18 \
+    && ln -s /usr/bin/clang-format-18 /usr/bin/clang-format
 
 # Python
 COPY ./requirements.txt /


### PR DESCRIPTION
Seems there was an update on llvm that bumped to version 18 and clang-format in their repository depends upon `clang-format-17`, as states the error below ([gitlab job reference](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/302536532))
```
sudo apt-get -t llvm-toolchain-focal install -y --no-install-recommends \
>     clang-format
Reading package lists... Done
Building dependency tree
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 clang-format : Depends: clang-format-17 (>= 17~) but it is not installable
E: Unable to correct problems, you have held broken packages.
```
So using `clang-format-18` which is available and create a symlink for non-regression pending action on llvm side (could be tracked with this [issue](https://github.com/llvm/llvm-project/issues/64120))