### PR TITLE
Back to standard clang-format installation

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -78,8 +78,7 @@ RUN set -ex \
     && curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-get update \
     && apt-get -t llvm-toolchain-focal install -y --no-install-recommends \
-    clang-format-18 \
-    && ln -s /usr/bin/clang-format-18 /usr/bin/clang-format
+    clang-format
 
 # Python
 COPY ./requirements.txt /


### PR DESCRIPTION
Patch [done](https://github.com/llvm/llvm-project/issues/64120) on LLVM side , we can use back the standard (latest) version