### PR TITLE
Add yq to deb x86 runner

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -72,7 +72,7 @@ RUN echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf.d/20datadog
 RUN apt-get update && apt-get install -y fakeroot procps bzip2 \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libpq-dev libz-dev \
   libsystemd-journal-dev rpm tar gettext libtool autopoint autoconf pkg-config flex \
-  selinux-basics libtool software-properties-common default-jre texinfo
+  selinux-basics libtool software-properties-common default-jre texinfo wget
 
 # Ubuntu 14.04 comes with gcc 4.8 by default, which has a tough time compiling newer Go versions
 # NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall
@@ -99,6 +99,8 @@ RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.
 
 RUN git config --global user.email "package@datadoghq.com"
 RUN git config --global user.name "Bits"
+
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.34.2/yq_linux_386 -O /usr/bin/yq && chmod +x /usr/bin/yq
 
 # IBM MQ
 RUN mkdir -p /opt/mqm \


### PR DESCRIPTION
Adds `yq` to the deb-x64 dockerfile so it is available when the updated patch script for setting the image tag on agent staging clusters is called: https://github.com/DataDog/k8s-datadog-agent-ops/pull/2253