### PR TITLE
Factorize requirements.txt files

### DIFF
--- a/datadog-ci-uploader/Dockerfile
+++ b/datadog-ci-uploader/Dockerfile
@@ -6,13 +6,11 @@ ENV DEBCONF_NONINTERACTIVE_SEEN true
 ENV N_VERSION=8.0.0
 ENV N_SHA256="e0af3182861d91bbc65478bfad7b25e7cbbe200a4f7443baeeaf9c2b732da776"
 ENV NODE_VERSION=16.13.0
-ENV AWSCLI_VERSION=1.16.240
-ENV CODEOWNERS_VERSION=0.4.0
-ENV INVOKE_VERSION=2.2.0
 ENV DATADOG_CI_VERSION=2.17.0
 
 RUN apt update && apt install -y curl git python3 python3-pip
-RUN pip install awscli==${AWSCLI_VERSION} codeowners==${CODEOWNERS_VERSION} invoke==${INVOKE_VERSION}
+COPY requirements/uploader.txt requirements.txt
+RUN pip install -r requirements.txt
 
 RUN curl -L https://raw.githubusercontent.com/tj/n/v${N_VERSION}/bin/n -o n \
     && echo "${N_SHA256}  n" | sha256sum --check \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,15 @@
 # python development requirements for the Datadog Agent
-invoke==2.2.0
 reno==3.5.0
 docker==6.0.1; python_version >= '3.7'
 docker==5.0.3; python_version < '3.7'
 docker-squash==1.0.9
 dulwich==0.20.45
-requests==2.27.1
 toml==0.10.2
 packaging==21.3
 # more recent boto3 has a bug which generates an import exception.
 # pin until this can be resolved.
 boto3==1.22.4
-botocore==1.25.4 ## for awscli
-awscli==1.23.4
+-r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/nschweitzer/requirements/requirements/common.txt
 # urllib3 major version 2, released on May 4th 2023, breaks botocore used
 # by awscli (removed DEFAULT_CIPHERS list from urllib3.util.ssl_)
 urllib3==1.26.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ packaging==21.3
 # more recent boto3 has a bug which generates an import exception.
 # pin until this can be resolved.
 boto3==1.22.4
--r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/nschweitzer/requirements/requirements/common.txt
+-r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements/common.txt
 # urllib3 major version 2, released on May 4th 2023, breaks botocore used
 # by awscli (removed DEFAULT_CIPHERS list from urllib3.util.ssl_)
 urllib3==1.26.15


### PR DESCRIPTION
Use reference to files for requirements.txt:
* prevent ci-uploader from having its own definition
* allows possibility to target these references from datadog-agent, so globally reduces the risk to have duplication in python module and versions