### PR TITLE
CI: fix setup-env error detection

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ get_agent_version:
   stage: setup
   image: $SETUP_IMAGE_NAME
   script:
-    - export VERSION=$(inv agent.version)
+    - VERSION=$(inv agent.version)
     - echo "AGENT_VERSION=$VERSION"
     - echo "AGENT_VERSION=$VERSION" >> version.env
   artifacts:


### PR DESCRIPTION
When using `export FOO=$(something)` the overall command will always return a success code, even if the subshell failed. In this case since we don't need to export the variable anyway, we can remove it and properly detect failures