### PR TITLE
[CI] Bump `SETUP_IMAGE_NAME` to a more recent docker image to have Python `3.9` instead of `3.8`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ variables:
   # the buildimage for the highest Windows version supported.
   # This image must use the same Windows version as the Windows version of the Gitlab runner used in .winrelease
   WINDOWS_RELEASE_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_ltsc2022_x64
-  SETUP_IMAGE_NAME: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:v16026304-782441d # Image used during setup task, must contains pyinvoke
+  SETUP_IMAGE_NAME: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:v19805261-b468a29 # Image used during setup task, must contains pyinvoke
   S3_CP_CMD: aws s3 cp $S3_CP_OPTIONS
   S3_PERMANENT_ARTIFACTS_URI: s3://dd-ci-persistent-artefacts-build-stable/datadog-agent
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded


### PR DESCRIPTION
This PR bumps `SETUP_IMAGE_NAME` to `486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:v19805261-b468a29` ([from here](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/325576687#L1900)).

It fixes the [get_agent_version](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/325569268) job for #443 that broke when trying to run an invoke task that needed python `>= 3.9`.