### PR TITLE
deb_x64: build go in `/usr/local/go` instead of `goroot`

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -160,7 +160,7 @@ RUN curl -Sl -O https://dd-agent-omnibus.s3.amazonaws.com/kernel-4.9-headers-deb
 COPY ./setup_go.sh /setup_go.sh
 RUN ./setup_go.sh
 
-ENV PATH="/goroot/bin:$PATH"
+ENV PATH="/usr/local/go/bin:$PATH"
 ENV PATH="/go/bin:$PATH"
 
 # Rust is needed to compile some python libs

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -34,7 +34,8 @@ echo "3d565d57ec28edb14be9e540cd3e628607ec5b791e78224c47250d36ce4aedf2  /bin/gim
 chmod +x /bin/gimme
 eval "$(gimme 1.18.9)"
 
-git clone --branch "go$GO_VERSION" --depth 1 https://go.googlesource.com/go goroot && cd goroot/src
+mkdir -p /usr/local/go/
+git clone --branch "go$GO_VERSION" --depth 1 https://go.googlesource.com/go /usr/local/go && cd /usr/local/go/src
 
 # we want tooling from binutils to take precedence, also override ld symlink
 export PATH=/usr/local/binutils/bin:$PATH


### PR DESCRIPTION
This PR allows go to be built in the same directory as the out of the box go (and the one used in arm64) -> in `/usr/local/go`. This will allows the internal profiling to merge the stack traces instead of showing duplicated stack traces for each architecture

Example of the issue: https://ddstaging.datadoghq.com/profiling/search?query=service%3Asecurity-agent&my_code=disabled&profile_type=heap-live-size&viz=flame_graph&start=1694522299795&end=1694525899795&paused=false

agent pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/19946462