### PR TITLE
Reduce image sizes

### DIFF
--- a/setup_go.sh
+++ b/setup_go.sh
@@ -7,7 +7,7 @@ set -ex
 # Note: the official go build uses the fourth option (bootstrap the build using go1.4), but according to the documentation
 # this shouldn't make a difference.
 
-# Upgrade bison 
+# Upgrade bison
 curl -sL -O "https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz"
 echo "${BISON_SHA256}  ./bison-${BISON_VERSION}.tar.gz" | sha256sum --check
 tar -zxvf "./bison-${BISON_VERSION}.tar.gz"

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -43,6 +43,9 @@ ln -sf /usr/local/binutils/bin/ld /usr/bin/ld
 
 ./all.bash
 
+# Remove go build files from the image
+rm -rf /usr/local/go/pkg/obj
+
 # Remove gimme
 rm -rf $HOME/.gimme
 rm /bin/gimme

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -49,3 +49,6 @@ rm -rf /usr/local/go/pkg/obj
 # Remove gimme
 rm -rf $HOME/.gimme
 rm /bin/gimme
+
+# Remove gimme downloaded files
+rm -rf /tmp/gimme


### PR DESCRIPTION
This PR removes the golang built objects from the image, which amount for ≃2GB we don't need
It also removes gimme files, which take about 150MB and aren't used once the install is complete