### PR TITLE
Pin bundler to 2.4.20

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -27,6 +27,7 @@ ARG CLANG_SHA256="a77eb8fde0a475c25d46dccdeb851a83cbeeeb11779fa2218ae19db9cd0e51
 ARG DD_TARGET_ARCH=aarch64
 ARG GCC_VERSION=10.4.0
 ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
+ARG BUNDLER_VERSION=2.4.20
 
 # Environment
 ENV GOPATH /go
@@ -38,6 +39,7 @@ ENV CLANG_SHA256 $CLANG_SHA256
 ENV CONDA_PATH /root/miniforge3
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 ENV GCC_VERSION $GCC_VERSION
+ENV BUNDLER_VERSION $BUNDLER_VERSION
 
 # Remove the early return on non-interactive shells, which makes sourcing the file not activate conda
 RUN grep -v return /root/.bashrc >> /root/newbashrc && cp /root/newbashrc /root/.bashrc
@@ -79,7 +81,7 @@ RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then \
     else \
         /bin/bash -l -c "rvm install --with-openssl-dir=${CONDA_PATH} --with-arch='armv7-a' -C '--build' -C 'arm-linux-gnueabihf' 2.7 && rvm cleanup all" ; \
     fi
-RUN /bin/bash -l -c "gem install bundler --no-document"
+RUN /bin/bash -l -c "gem install bundler --version $BUNDLER_VERSION --no-document"
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /root/.bashrc
 
 # Go

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -30,6 +30,7 @@ ARG BINUTILS_VERSION="2.39"
 ARG BINUTILS_SHA256="d12ea6f239f1ffe3533ea11ad6e224ffcb89eb5d01bbea589e9158780fa11f10"
 ARG GCC_VERSION=10.4.0
 ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
+ARG BUNDLER_VERSION=2.4.20
 
 # Environment
 ENV GOPATH /go
@@ -51,6 +52,7 @@ ENV BISON_SHA256 $BISON_SHA256
 ENV BINUTILS_VERSION $BINUTILS_VERSION
 ENV BINUTILS_SHA256 $BINUTILS_SHA256
 ENV GCC_VERSION $GCC_VERSION
+ENV BUNDLER_VERSION $BUNDLER_VERSION
 
 # Remove the early return on non-interactive shells, which makes sourcing the file not activate conda
 RUN grep -v return /root/.bashrc >> /root/newbashrc && cp /root/newbashrc /root/.bashrc
@@ -125,7 +127,7 @@ RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/bi
     && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
-RUN /bin/bash -l -c "gem install bundler --no-document"
+RUN /bin/bash -l -c "gem install bundler --version $BUNDLER_VERSION --no-document"
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /root/.bashrc
 
 # CMake

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -20,6 +20,7 @@ ARG CLANG_SHA256="a77eb8fde0a475c25d46dccdeb851a83cbeeeb11779fa2218ae19db9cd0e51
 ARG DD_TARGET_ARCH=aarch64
 ARG GCC_VERSION=10.4.0
 ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
+ARG BUNDLER_VERSION=2.4.20
 
 # Environment
 ENV GOPATH /go
@@ -31,6 +32,7 @@ ENV CLANG_SHA256 $CLANG_SHA256
 ENV CONDA_PATH /root/miniforge3
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 ENV GCC_VERSION $GCC_VERSION
+ENV BUNDLER_VERSION $BUNDLER_VERSION
 
 # The last two lines contain dependencies for build of newer rpm
 RUN yum -y install @development which perl-core perl-ExtUtils-MakeMaker ncurses-compat-libs git procps \
@@ -80,7 +82,7 @@ RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/bi
     && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
-RUN /bin/bash -l -c "gem install bundler --no-document"
+RUN /bin/bash -l -c "gem install bundler --version $BUNDLER_VERSION --no-document"
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /root/.bashrc
 
 # Go

--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -14,11 +14,13 @@ FROM ${BASE_IMAGE}
 ARG GO_VERSION=1.20.10
 ARG GO_SHA256_LINUX_ARMV6L=a2229772434dee3dde1e974ef5ae7936160a05a1b82c57cc5c64660479aa98cb
 ARG DD_TARGET_ARCH=armhf
+ARG BUNDLER_VERSION=2.4.20
 
 # Environment
 ENV GOPATH /go
 ENV GO_VERSION $GO_VERSION
 ENV DD_TARGET_ARCH $DD_TARGET_ARCH
+ENV BUNDLER_VERSION $BUNDLER_VERSION
 
 # configure yum and rpm for running on non-armv7l architectures
 RUN echo "armhfp" > /etc/yum/vars/basearch && \
@@ -82,7 +84,7 @@ RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/bi
     && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install --with-arch='armv7-a' -C '--build' -C 'arm-linux-gnueabihf' 2.7 && rvm cleanup all"
-RUN /bin/bash -l -c "gem install bundler --no-document"
+RUN /bin/bash -l -c "gem install bundler --version $BUNDLER_VERSION --no-document"
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /root/.bashrc
 
 # CONDA

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -34,6 +34,7 @@ ARG BINUTILS_VERSION="2.39"
 ARG BINUTILS_SHA256="d12ea6f239f1ffe3533ea11ad6e224ffcb89eb5d01bbea589e9158780fa11f10"
 ARG GCC_VERSION=10.4.0
 ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
+ARG BUNDLER_VERSION=2.4.20
 
 # Environment
 ENV GOPATH /go
@@ -57,6 +58,7 @@ ENV BINUTILS_VERSION $BINUTILS_VERSION
 ENV BINUTILS_SHA256 $BINUTILS_SHA256
 ENV BASE_IMAGE $BASE_IMAGE
 ENV GCC_VERSION $GCC_VERSION
+ENV BUNDLER_VERSION $BUNDLER_VERSION
 
 # persist RHEL major for readable output
 RUN echo $(cat /etc/redhat-release | cut -d'.' -f1 | awk '{print $NF}') > /etc/redhat-release-major
@@ -163,7 +165,7 @@ RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/bi
     && rm get-rvm.sh
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.6 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
-RUN /bin/bash -l -c "gem install bundler --no-document"
+RUN /bin/bash -l -c "gem install bundler --version $BUNDLER_VERSION --no-document"
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /root/.bashrc
 
 # Upgrade binutils

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -30,6 +30,7 @@ ARG RUSTUP_VERSION=1.24.3
 ARG RUSTUP_SHA256="3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338"
 ARG GCC_VERSION=10.4.0
 ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
+ARG BUNDLER_VERSION=2.4.20
 
 # Environment
 ENV GOPATH /go
@@ -45,6 +46,7 @@ ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 ENV RUST_VERSION $RUST_VERSION
 ENV RUSTC_SHA256 $RUSTC_SHA256
 ENV GCC_VERSION $GCC_VERSION
+ENV BUNDLER_VERSION $BUNDLER_VERSION
 
 ENV PATH="/opt/datadog/bin:${PATH}"
 
@@ -120,7 +122,7 @@ RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/bi
     && rm get-rvm.sh
 RUN bash -l -c "rvm autolibs disable" # do not try to fetch requirements from system repos
 RUN bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
-RUN bash -l -c "gem install bundler --version 2.4.20 --no-document"
+RUN bash -l -c "gem install bundler --version $BUNDLER_VERSION --no-document"
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /root/.bashrc
 
 # CMake

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -120,7 +120,7 @@ RUN curl -sSL -o get-rvm.sh https://raw.githubusercontent.com/rvm/rvm/1.29.12/bi
     && rm get-rvm.sh
 RUN bash -l -c "rvm autolibs disable" # do not try to fetch requirements from system repos
 RUN bash -l -c "rvm install 2.7 --with-openssl-dir=${CONDA_PATH} && rvm cleanup all"
-RUN bash -l -c "gem install bundler --no-document"
+RUN bash -l -c "gem install bundler --version 2.4.20 --no-document"
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /root/.bashrc
 
 # CMake


### PR DESCRIPTION
This is because https://github.com/rubygems/rubygems/pull/6980 breaks omnibus-software installation with:

```
cd omnibus && bundle install --verbose
Running `bundle install --verbose` with bundler 2.4.21
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Found changes from the lockfile, re-resolving dependencies because the dependencies in your gemfile changed, you added a new platform to your gemfile
Fetching https://github.com/DataDog/omnibus-software.git
Bundler::Source::Git::GitCommandError: Git error: command `git fetch --force --quiet /usr/local/rvm/gems/ruby-2.7.2/cache/bundler/git/omnibus-software-4ef95424cd4e7a7e161deab780b42ac49a9dd55b --depth 1 355614adf[75](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/352601500#L75)a4d1a061624c08a942347b05a5727` in directory /usr/local/rvm/gems/ruby-2.7.2/bundler/gems/omnibus-software-355614adf75a has failed.
/usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/source/git/git_proxy.rb:371:in `run_command'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/source/git/git_proxy.rb:2[77](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/352601500#L77):in `git'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/source/git/git_proxy.rb:134:in `copy_to'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/source/git.rb:1[79](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/352601500#L79):in `specs'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/source.rb:58:in `spec_names'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/source_map.rb:21:in `block in all_requirements'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/source_map.rb:20:in `map'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/source_map.rb:20:in `all_requirements'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/definition.rb:894:in `source_requirements'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/definition.rb:513:in `resolution_packages'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/definition.rb:495:in `resolver'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/definition.rb:570:in `start_resolution'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/definition.rb:301:in `resolve'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/definition.rb:523:in `materialize'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/definition.rb:200:in `specs'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/installer.rb:231:in `ensure_specs_are_compatible!'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/installer.rb:[83](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/352601500#L83):in `block in run'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/process_lock.rb:12:in `block in lock'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/process_lock.rb:9:in `open'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/process_lock.rb:9:in `lock'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/installer.rb:71:in `run'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/installer.rb:23:in `install'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/cli/install.rb:62:in `run'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/cli.rb:261:in `block in install'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/settings.rb:142:in `temporary'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/cli.rb:260:in `install'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/cli.rb:34:in `dispatch'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/vendor/thor/lib/thor/base.rb:4[85](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/352601500#L85):in `start'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/cli.rb:28:in `start'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/exe/bundle:37:in `block in <top (required)>'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
  /usr/local/rvm/gems/ruby-2.7.2/gems/bundler-2.4.21/exe/bundle:29:in `<top (required)>'
  /usr/local/rvm/gems/ruby-2.7.2/bin/bundle:23:in `load'
  /usr/local/rvm/gems/ruby-2.7.2/bin/bundle:23:in `<main>'
  /usr/local/rvm/gems/ruby-2.7.2/bin/ruby_executable_hooks:22:in `eval'
  /usr/local/rvm/gems/ruby-2.7.2/bin/ruby_executable_hooks:22:in `<main>'
```

This happens in all Linux test jobs using bundler except rpm-arm64, which has git 2.40 which is new enough.