### PR TITLE
don't add conda path to PKG_CONFIG_LIBDIR

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -64,7 +64,7 @@ COPY python-packages-versions.txt setup_python.sh requirements.txt requirements-
 COPY requirements /requirements
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
-ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+ENV PKG_CONFIG_LIBDIR ""
 
 # External calls configuration
 COPY .awsconfig $HOME/.aws/config

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -114,7 +114,7 @@ COPY python-packages-versions.txt setup_python.sh requirements.txt requirements-
 COPY requirements /requirements
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
-ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+ENV PKG_CONFIG_LIBDIR ""
 
 # External calls configuration
 COPY .awsconfig $HOME/.aws/config

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -69,7 +69,7 @@ COPY python-packages-versions.txt setup_python.sh requirements.txt requirements-
 COPY requirements /requirements
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
-ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+ENV PKG_CONFIG_LIBDIR ""
 
 # External calls configuration
 COPY .awsconfig $HOME/.aws/config

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -152,7 +152,7 @@ COPY python-packages-versions.txt setup_python.sh requirements.txt requirements-
 COPY requirements /requirements
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
-ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+ENV PKG_CONFIG_LIBDIR ""
 
 # External calls configuration
 COPY .awsconfig $HOME/.aws/config

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -109,7 +109,7 @@ COPY python-packages-versions.txt setup_python.sh requirements.txt requirements-
 COPY requirements /requirements
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
-ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
+ENV PKG_CONFIG_LIBDIR ""
 
 # External calls configuration
 COPY .awsconfig $HOME/.aws/config


### PR DESCRIPTION
We don't want pkg-config to find packages outside of our install directory.

This is why we sometimes have to provide explicit path to some dependencies instead of relying on pkg-config doing its job