### PR TITLE
[Pipeline] Replace tests by running a datadog-agent child pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -466,55 +466,55 @@ build_windows_ltsc2022_x64:
 
 release_deb_x64:
   extends: .release
-  needs: ["test_deb_x64"]
+  needs: ["trigger_tests"]
   variables:
     IMAGE: deb_x64
 
 release_rpm_x64:
   extends: .release
-  needs: ["test_rpm_x64"]
+  needs: ["trigger_tests"]
   variables:
     IMAGE: rpm_x64
 
 release_suse_x64:
   extends: .release
-  needs: ["test_suse_x64"]
+  needs: ["trigger_tests"]
   variables:
     IMAGE: suse_x64
 
 release_deb_arm64:
   extends: .release
-  needs: ["test_deb_arm64"]
+  needs: ["trigger_tests"]
   variables:
     IMAGE: deb_arm64
 
 release_rpm_arm64:
   extends: .release
-  needs: ["test_rpm_arm64"]
+  needs: ["trigger_tests"]
   variables:
     IMAGE: rpm_arm64
 
 release_system-probe_x64:
   extends: .release
-  needs: ["test_system-probe_x64"]
+  needs: ["trigger_tests"]
   variables:
     IMAGE: system-probe_x64
 
 release_system-probe_arm64:
   extends: .release
-  needs: ["test_system-probe_arm64"]
+  needs: ["trigger_tests"]
   variables:
     IMAGE: system-probe_arm64
 
 release_datadog-ci-uploader:
   extends: .release
-  needs: ["build_datadog-ci-uploader"]
+  needs: ["trigger_tests"]
   variables:
     IMAGE: datadog-ci-uploader
 
 release_windows_1809_x64:
   extends: .winrelease
-  needs: ["build_windows_ltsc2022_x64", "test_windows_1809_x64"]
+  needs: ["trigger_tests"]
   variables:
     IMAGE: windows_1809_x64
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64
@@ -522,7 +522,7 @@ release_windows_1809_x64:
 
 release_windows_ltsc2022_x64:
   extends: .winrelease
-  needs: ["build_windows_ltsc2022_x64", "test_windows_ltsc2022_x64"]
+  needs: ["trigger_tests"]
   variables:
     IMAGE: windows_ltsc2022_x64
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -382,21 +382,21 @@ build_windows_ltsc2022_x64:
     - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
     - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
 
-test_windows_1809_x64:
-  extends: .test_windows
-  tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["get_agent_version", "build_windows_1809_x64"]
-  variables:
-    ARCH: x64
-    IMAGE: windows_1809_x64
-
-test_windows_ltsc2022_x64:
-  extends: .test_windows
-  tags: ["runner:windows-docker", "windowsversion:2022"]
-  needs: ["get_agent_version", "build_windows_ltsc2022_x64"]
-  variables:
-    ARCH: x64
-    IMAGE: windows_ltsc2022_x64
+#test_windows_1809_x64:
+#  extends: .test_windows
+#  tags: ["runner:windows-docker", "windowsversion:1809"]
+#  needs: ["get_agent_version", "build_windows_1809_x64"]
+#  variables:
+#    ARCH: x64
+#    IMAGE: windows_1809_x64
+#
+#test_windows_ltsc2022_x64:
+#  extends: .test_windows
+#  tags: ["runner:windows-docker", "windowsversion:2022"]
+#  needs: ["get_agent_version", "build_windows_ltsc2022_x64"]
+#  variables:
+#    ARCH: x64
+#    IMAGE: windows_ltsc2022_x64
 
 .release:
   stage: release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -258,6 +258,10 @@ trigger_build_kernels:
     - source /root/.bashrc
     - inv -e deps
   script:
+    - inv check-go-version
+    - inv -e system-probe.build --strip-object-files
+    # fail if references to glibc >= 2.18
+    - objdump -p $CI_PROJECT_DIR/$SYSTEM_PROBE_BINARIES_DIR/system-probe | egrep 'GLIBC_2\.(1[8-9]|[2-9][0-9])' && exit 1
     - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
 
 test_deb_x64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -295,7 +295,7 @@ trigger_tests:
   timeout: 2h 00m
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
-    - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
+    - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,8))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"
     - $SRC_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:${SRC_TAG}"
     - .\build-container.ps1 -Arch $DD_TARGET_ARCH -Tag $SRC_IMAGE
@@ -303,7 +303,7 @@ trigger_tests:
     - If ($CI_PIPELINE_SOURCE -ne "schedule") { docker push $SRC_IMAGE } else { exit 0 }
     - If ($lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
   after_script:
-    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
+    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,8))
 
 build_windows_1809_x64:
   extends: .winbuild

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -249,8 +249,14 @@ trigger_tests:
   variables:
     RUN_KITCHEN_TESTS: "false"
     BUCKET_BRANCH: "dev"
-    DATADOG_AGENT_BUILDIMAGES: "${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    DATADOG_AGENT_BUILDIMAGES: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     DATADOG_AGENT_BUILDIMAGES_SUFFIX: "${ECR_TEST_ONLY}"
+    DATADOG_AGENT_WINBUILDIMAGES_SUFFIX: "${ECR_TEST_ONLY}"
+    DATADOG_AGENT_WINBUILDIMAGES: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX: "${ECR_TEST_ONLY}"
+    DATADOG_AGENT_ARMBUILDIMAGES: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX: "${ECR_TEST_ONLY}"
+    DATADOG_AGENT_SYSPROBE_BUILDIMAGES: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   trigger:
     project: DataDog/datadog-agent
     strategy: depend
@@ -272,42 +278,6 @@ trigger_tests:
   script:
     - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
 
-test_deb_x64:
-  extends: .test_agent6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_deb_x64"]
-  tags: ["runner:main"]
-
-test_deb_arm64:
-  extends: .test_agent6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_deb_arm64"]
-  tags: ["runner:docker-arm", "platform:arm64"]
-
-test_rpm_x64:
-  extends: .test_agent6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_rpm_x64"]
-  tags: ["runner:main"]
-
-test_rpm_x64_testing:
-  extends: .test_agent6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64_testing${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_rpm_x64_testing"]
-  tags: ["runner:main"]
-
-test_rpm_arm64:
-  extends: .test_agent6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_rpm_arm64"]
-  tags: ["runner:docker-arm", "platform:arm64"]
-
-test_suse_x64:
-  extends: .test_agent6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_suse_x64"]
-  tags: ["runner:main"]
-
 .test_system_probe:
   extends: .test
   before_script:
@@ -318,22 +288,6 @@ test_suse_x64:
     - inv -e deps
   script:
     - inv -e system-probe.build
-
-test_system-probe_x64:
-  extends: .test_system_probe
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_system-probe_x64"]
-  tags: ["runner:main"]
-  variables:
-    ARCH: amd64
-
-test_system-probe_arm64:
-  extends: .test_system_probe
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_system-probe_arm64"]
-  tags: ["runner:docker-arm", "platform:arm64"]
-  variables:
-    ARCH: arm64
 
 .winbuild: &winbuild
   stage: build
@@ -382,22 +336,6 @@ build_windows_ltsc2022_x64:
   after_script:
     - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
     - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
-
-test_windows_1809_x64:
-  extends: .test_windows
-  tags: ["runner:windows-docker", "windowsversion:1809"]
-  needs: ["get_agent_version", "build_windows_1809_x64"]
-  variables:
-    ARCH: x64
-    IMAGE: windows_1809_x64
-
-test_windows_ltsc2022_x64:
-  extends: .test_windows
-  tags: ["runner:windows-docker", "windowsversion:2022"]
-  needs: ["get_agent_version", "build_windows_ltsc2022_x64"]
-  variables:
-    ARCH: x64
-    IMAGE: windows_ltsc2022_x64
 
 .release:
   stage: release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -254,85 +254,85 @@ trigger_tests:
     project: DataDog/datadog-agent
     strategy: depend
 
-#.test:
-#  stage: test
-#  except: [tags, schedules]
-#
-#.test_agent6:
-#  extends: .test
-#  before_script:
-#    - rm -r /go/src/github.com/DataDog/datadog-agent || true
-#    - echo "Cloning $AGENT_VERSION branch of datadog-agent repository"
-#    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
-#    - cd /go/src/github.com/DataDog/datadog-agent
-#    - VERSION="nightly"
-#    - source /root/.bashrc
-#    - inv -e deps
-#  script:
-#    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
-#
-#test_deb_x64:
-#  extends: .test_agent6
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-#  needs: ["get_agent_version", "build_deb_x64"]
-#  tags: ["runner:main"]
-#
-#test_deb_arm64:
-#  extends: .test_agent6
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-#  needs: ["get_agent_version", "build_deb_arm64"]
-#  tags: ["runner:docker-arm", "platform:arm64"]
-#
-#test_rpm_x64:
-#  extends: .test_agent6
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-#  needs: ["get_agent_version", "build_rpm_x64"]
-#  tags: ["runner:main"]
-#
-#test_rpm_x64_testing:
-#  extends: .test_agent6
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64_testing${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-#  needs: ["get_agent_version", "build_rpm_x64_testing"]
-#  tags: ["runner:main"]
-#
-#test_rpm_arm64:
-#  extends: .test_agent6
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-#  needs: ["get_agent_version", "build_rpm_arm64"]
-#  tags: ["runner:docker-arm", "platform:arm64"]
-#
-#test_suse_x64:
-#  extends: .test_agent6
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-#  needs: ["get_agent_version", "build_suse_x64"]
-#  tags: ["runner:main"]
-#
-#.test_system_probe:
-#  extends: .test
-#  before_script:
-#    - rm -r /go/src/github.com/DataDog/datadog-agent || true
-#    - echo "Cloning ${AGENT_VERSION} branch of datadog-agent repository"
-#    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
-#    - cd /go/src/github.com/DataDog/datadog-agent
-#    - inv -e deps
-#  script:
-#    - inv -e system-probe.build
-#
-#test_system-probe_x64:
-#  extends: .test_system_probe
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-#  needs: ["get_agent_version", "build_system-probe_x64"]
-#  tags: ["runner:main"]
-#  variables:
-#    ARCH: amd64
-#
-#test_system-probe_arm64:
-#  extends: .test_system_probe
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-#  needs: ["get_agent_version", "build_system-probe_arm64"]
-#  tags: ["runner:docker-arm", "platform:arm64"]
-#  variables:
-#    ARCH: arm64
+.test:
+  stage: test
+  except: [tags, schedules]
+
+.test_agent6:
+  extends: .test
+  before_script:
+    - rm -r /go/src/github.com/DataDog/datadog-agent || true
+    - echo "Cloning $AGENT_VERSION branch of datadog-agent repository"
+    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
+    - cd /go/src/github.com/DataDog/datadog-agent
+    - VERSION="nightly"
+    - source /root/.bashrc
+    - inv -e deps
+  script:
+    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
+
+test_deb_x64:
+  extends: .test_agent6
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+  needs: ["get_agent_version", "build_deb_x64"]
+  tags: ["runner:main"]
+
+test_deb_arm64:
+  extends: .test_agent6
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+  needs: ["get_agent_version", "build_deb_arm64"]
+  tags: ["runner:docker-arm", "platform:arm64"]
+
+test_rpm_x64:
+  extends: .test_agent6
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+  needs: ["get_agent_version", "build_rpm_x64"]
+  tags: ["runner:main"]
+
+test_rpm_x64_testing:
+  extends: .test_agent6
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64_testing${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+  needs: ["get_agent_version", "build_rpm_x64_testing"]
+  tags: ["runner:main"]
+
+test_rpm_arm64:
+  extends: .test_agent6
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+  needs: ["get_agent_version", "build_rpm_arm64"]
+  tags: ["runner:docker-arm", "platform:arm64"]
+
+test_suse_x64:
+  extends: .test_agent6
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+  needs: ["get_agent_version", "build_suse_x64"]
+  tags: ["runner:main"]
+
+.test_system_probe:
+  extends: .test
+  before_script:
+    - rm -r /go/src/github.com/DataDog/datadog-agent || true
+    - echo "Cloning ${AGENT_VERSION} branch of datadog-agent repository"
+    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
+    - cd /go/src/github.com/DataDog/datadog-agent
+    - inv -e deps
+  script:
+    - inv -e system-probe.build
+
+test_system-probe_x64:
+  extends: .test_system_probe
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+  needs: ["get_agent_version", "build_system-probe_x64"]
+  tags: ["runner:main"]
+  variables:
+    ARCH: amd64
+
+test_system-probe_arm64:
+  extends: .test_system_probe
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+  needs: ["get_agent_version", "build_system-probe_arm64"]
+  tags: ["runner:docker-arm", "platform:arm64"]
+  variables:
+    ARCH: arm64
 
 .winbuild: &winbuild
   stage: build
@@ -366,37 +366,37 @@ build_windows_ltsc2022_x64:
     IMAGE: windows_ltsc2022_x64
     DD_TARGET_ARCH: x64
 
-#.test_windows:
-#  extends: .test
-#  timeout: 3h 00m
-#  script:
-#    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
-#    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
-#    - Write-Host "Cloning $AGENT_VERSION branch of the datadog-agent repository"
-#    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent datadog-agent
-#    - cd datadog-agent
-#    - $VERSION="nightly"
-#    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS_DD_WCS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true -e S3_OMNIBUS_CACHE_BUCKET="${S3_OMNIBUS_CACHE_BUCKET}" -e S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS="${S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS}" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
-#    - If ($lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-#  after_script:
-#    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
-#    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
-#
-#test_windows_1809_x64:
-#  extends: .test_windows
-#  tags: ["runner:windows-docker", "windowsversion:1809"]
-#  needs: ["get_agent_version", "build_windows_1809_x64"]
-#  variables:
-#    ARCH: x64
-#    IMAGE: windows_1809_x64
-#
-#test_windows_ltsc2022_x64:
-#  extends: .test_windows
-#  tags: ["runner:windows-docker", "windowsversion:2022"]
-#  needs: ["get_agent_version", "build_windows_ltsc2022_x64"]
-#  variables:
-#    ARCH: x64
-#    IMAGE: windows_ltsc2022_x64
+.test_windows:
+  extends: .test
+  timeout: 3h 00m
+  script:
+    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
+    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
+    - Write-Host "Cloning $AGENT_VERSION branch of the datadog-agent repository"
+    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent datadog-agent
+    - cd datadog-agent
+    - $VERSION="nightly"
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS_DD_WCS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true -e S3_OMNIBUS_CACHE_BUCKET="${S3_OMNIBUS_CACHE_BUCKET}" -e S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS="${S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS}" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
+    - If ($lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+  after_script:
+    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
+    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
+
+test_windows_1809_x64:
+  extends: .test_windows
+  tags: ["runner:windows-docker", "windowsversion:1809"]
+  needs: ["get_agent_version", "build_windows_1809_x64"]
+  variables:
+    ARCH: x64
+    IMAGE: windows_1809_x64
+
+test_windows_ltsc2022_x64:
+  extends: .test_windows
+  tags: ["runner:windows-docker", "windowsversion:2022"]
+  needs: ["get_agent_version", "build_windows_ltsc2022_x64"]
+  variables:
+    ARCH: x64
+    IMAGE: windows_ltsc2022_x64
 
 .release:
   stage: release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,7 +154,6 @@ build_rpm_armhf:
     DOCKERFILE: rpm-armhf/Dockerfile
     IMAGE: rpm_armhf
     BASE_IMAGE: arm32v7/centos:7
-    DD_TARGET_ARCH: armhf
 
 build_system-probe_x64:
   extends: [.build, .x64]
@@ -243,89 +242,97 @@ trigger_build_kernels:
       - local: .gitlab/kernel_version_testing.yml
     strategy: depend
 
-.test:
+trigger_tests:
   stage: test
   except: [tags, schedules]
-
-.test_agent6:
-  extends: .test
-  before_script:
-    - rm -r /go/src/github.com/DataDog/datadog-agent || true
-    - echo "Cloning $AGENT_VERSION branch of datadog-agent repository"
-    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
-    - cd /go/src/github.com/DataDog/datadog-agent
-    - VERSION="nightly"
-    - source /root/.bashrc
-    - inv -e deps
-  script:
-    - inv check-go-version
-    - inv -e system-probe.build --strip-object-files
-    # fail if references to glibc >= 2.18
-    - objdump -p $CI_PROJECT_DIR/$SYSTEM_PROBE_BINARIES_DIR/system-probe | egrep 'GLIBC_2\.(1[8-9]|[2-9][0-9])' && exit 1
-    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
-
-test_deb_x64:
-  extends: .test_agent6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_deb_x64"]
-  tags: ["runner:main"]
-
-test_deb_arm64:
-  extends: .test_agent6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_deb_arm64"]
-  tags: ["runner:docker-arm", "platform:arm64"]
-
-test_rpm_x64:
-  extends: .test_agent6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_rpm_x64"]
-  tags: ["runner:main"]
-
-test_rpm_x64_testing:
-  extends: .test_agent6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64_testing${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_rpm_x64_testing"]
-  tags: ["runner:main"]
-
-test_rpm_arm64:
-  extends: .test_agent6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_rpm_arm64"]
-  tags: ["runner:docker-arm", "platform:arm64"]
-
-test_suse_x64:
-  extends: .test_agent6
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_suse_x64"]
-  tags: ["runner:main"]
-
-.test_system_probe:
-  extends: .test
-  before_script:
-    - rm -r /go/src/github.com/DataDog/datadog-agent || true
-    - echo "Cloning ${AGENT_VERSION} branch of datadog-agent repository"
-    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
-    - cd /go/src/github.com/DataDog/datadog-agent
-    - inv -e deps
-  script:
-    - inv -e system-probe.build
-
-test_system-probe_x64:
-  extends: .test_system_probe
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_system-probe_x64"]
-  tags: ["runner:main"]
   variables:
-    ARCH: amd64
+    RUN_KITCHEN_TESTS: "false"
+    BUCKET_BRANCH: "dev"
+    DATADOG_AGENT_BUILDIMAGES: "${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    DATADOG_AGENT_BUILDIMAGES_SUFFIX: "${ECR_TEST_ONLY}"
+  trigger:
+    project: DataDog/datadog-agent
+    strategy: depend
 
-test_system-probe_arm64:
-  extends: .test_system_probe
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
-  needs: ["get_agent_version", "build_system-probe_arm64"]
-  tags: ["runner:docker-arm", "platform:arm64"]
-  variables:
-    ARCH: arm64
+#.test:
+#  stage: test
+#  except: [tags, schedules]
+#
+#.test_agent6:
+#  extends: .test
+#  before_script:
+#    - rm -r /go/src/github.com/DataDog/datadog-agent || true
+#    - echo "Cloning $AGENT_VERSION branch of datadog-agent repository"
+#    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
+#    - cd /go/src/github.com/DataDog/datadog-agent
+#    - VERSION="nightly"
+#    - source /root/.bashrc
+#    - inv -e deps
+#  script:
+#    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
+#
+#test_deb_x64:
+#  extends: .test_agent6
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+#  needs: ["get_agent_version", "build_deb_x64"]
+#  tags: ["runner:main"]
+#
+#test_deb_arm64:
+#  extends: .test_agent6
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+#  needs: ["get_agent_version", "build_deb_arm64"]
+#  tags: ["runner:docker-arm", "platform:arm64"]
+#
+#test_rpm_x64:
+#  extends: .test_agent6
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+#  needs: ["get_agent_version", "build_rpm_x64"]
+#  tags: ["runner:main"]
+#
+#test_rpm_x64_testing:
+#  extends: .test_agent6
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64_testing${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+#  needs: ["get_agent_version", "build_rpm_x64_testing"]
+#  tags: ["runner:main"]
+#
+#test_rpm_arm64:
+#  extends: .test_agent6
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+#  needs: ["get_agent_version", "build_rpm_arm64"]
+#  tags: ["runner:docker-arm", "platform:arm64"]
+#
+#test_suse_x64:
+#  extends: .test_agent6
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+#  needs: ["get_agent_version", "build_suse_x64"]
+#  tags: ["runner:main"]
+#
+#.test_system_probe:
+#  extends: .test
+#  before_script:
+#    - rm -r /go/src/github.com/DataDog/datadog-agent || true
+#    - echo "Cloning ${AGENT_VERSION} branch of datadog-agent repository"
+#    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
+#    - cd /go/src/github.com/DataDog/datadog-agent
+#    - inv -e deps
+#  script:
+#    - inv -e system-probe.build
+#
+#test_system-probe_x64:
+#  extends: .test_system_probe
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+#  needs: ["get_agent_version", "build_system-probe_x64"]
+#  tags: ["runner:main"]
+#  variables:
+#    ARCH: amd64
+#
+#test_system-probe_arm64:
+#  extends: .test_system_probe
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
+#  needs: ["get_agent_version", "build_system-probe_arm64"]
+#  tags: ["runner:docker-arm", "platform:arm64"]
+#  variables:
+#    ARCH: arm64
 
 .winbuild: &winbuild
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -366,22 +366,22 @@ build_windows_ltsc2022_x64:
     IMAGE: windows_ltsc2022_x64
     DD_TARGET_ARCH: x64
 
-.test_windows:
-  extends: .test
-  timeout: 3h 00m
-  script:
-    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
-    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
-    - Write-Host "Cloning $AGENT_VERSION branch of the datadog-agent repository"
-    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent datadog-agent
-    - cd datadog-agent
-    - $VERSION="nightly"
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS_DD_WCS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true -e S3_OMNIBUS_CACHE_BUCKET="${S3_OMNIBUS_CACHE_BUCKET}" -e S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS="${S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS}" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
-    - If ($lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-  after_script:
-    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
-    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
-
+#.test_windows:
+#  extends: .test
+#  timeout: 3h 00m
+#  script:
+#    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
+#    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
+#    - Write-Host "Cloning $AGENT_VERSION branch of the datadog-agent repository"
+#    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent datadog-agent
+#    - cd datadog-agent
+#    - $VERSION="nightly"
+#    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS_DD_WCS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true -e S3_OMNIBUS_CACHE_BUCKET="${S3_OMNIBUS_CACHE_BUCKET}" -e S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS="${S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS}" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
+#    - If ($lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+#  after_script:
+#    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
+#    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
+#
 #test_windows_1809_x64:
 #  extends: .test_windows
 #  tags: ["runner:windows-docker", "windowsversion:1809"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,6 +154,7 @@ build_rpm_armhf:
     DOCKERFILE: rpm-armhf/Dockerfile
     IMAGE: rpm_armhf
     BASE_IMAGE: arm32v7/centos:7
+    DD_TARGET_ARCH: armhf
 
 build_system-probe_x64:
   extends: [.build, .x64]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -261,34 +261,6 @@ trigger_tests:
     project: DataDog/datadog-agent
     strategy: depend
 
-.test:
-  stage: test
-  except: [tags, schedules]
-
-.test_agent6:
-  extends: .test
-  before_script:
-    - rm -r /go/src/github.com/DataDog/datadog-agent || true
-    - echo "Cloning $AGENT_VERSION branch of datadog-agent repository"
-    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
-    - cd /go/src/github.com/DataDog/datadog-agent
-    - VERSION="nightly"
-    - source /root/.bashrc
-    - inv -e deps
-  script:
-    - inv -e agent.omnibus-build --release-version "$VERSION" --major-version "6" --python-runtimes "2,3" --base-dir /.omnibus --skip-deps
-
-.test_system_probe:
-  extends: .test
-  before_script:
-    - rm -r /go/src/github.com/DataDog/datadog-agent || true
-    - echo "Cloning ${AGENT_VERSION} branch of datadog-agent repository"
-    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent /go/src/github.com/DataDog/datadog-agent
-    - cd /go/src/github.com/DataDog/datadog-agent
-    - inv -e deps
-  script:
-    - inv -e system-probe.build
-
 .winbuild: &winbuild
   stage: build
   except: [tags]
@@ -321,26 +293,11 @@ build_windows_ltsc2022_x64:
     IMAGE: windows_ltsc2022_x64
     DD_TARGET_ARCH: x64
 
-.test_windows:
-  extends: .test
-  timeout: 3h 00m
-  script:
-    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
-    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
-    - Write-Host "Cloning $AGENT_VERSION branch of the datadog-agent repository"
-    - git clone -b $AGENT_VERSION https://github.com/DataDog/datadog-agent datadog-agent
-    - cd datadog-agent
-    - $VERSION="nightly"
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$VERSION" -e MAJOR_VERSION="6" -e PY_RUNTIMES="2,3" -e AWS_NETWORKING=true -e SIGN_WINDOWS_DD_WCS=true -e TARGET_ARCH="$ARCH" -e NEW_BUILDER=true -e S3_OMNIBUS_CACHE_BUCKET="${S3_OMNIBUS_CACHE_BUCKET}" -e S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS="${S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS}" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7)) c:\mnt\tasks\winbuildscripts\buildwin.bat
-    - If ($lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-  after_script:
-    - if (Test-Path datadog-agent) { remove-item -recurse -force datadog-agent }
-    - docker rmi 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:v${CI_PIPELINE_ID}-$($CI_COMMIT_SHA.SubString(0,7))
-
 .release:
   stage: release
   except: [tags, schedules]
   only: [master, main]
+  needs: ["trigger_tests"]
   tags: ["runner:docker"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-notary:0.6.1
   script:
@@ -365,7 +322,7 @@ build_windows_ltsc2022_x64:
   tags: ["runner:windows-docker", "windowsversion:2022"]
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
-    - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
+    - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,8))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"
     - $SRC_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:${SRC_TAG}"
     - mkdir ci-scripts
@@ -397,7 +354,7 @@ build_windows_ltsc2022_x64:
     - cat ci-scripts/docker-publish.ps1
     - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS_DD_WCS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine ${WINDOWS_RELEASE_IMAGE}:${SRC_TAG} powershell -C C:\mnt\ci-scripts\docker-publish.ps1
   after_script:
-    - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,7))
+    - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,8))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"
     - $SRC_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:${SRC_TAG}"
     - docker rmi $SRC_IMAGE 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:latest
@@ -405,55 +362,46 @@ build_windows_ltsc2022_x64:
 
 release_deb_x64:
   extends: .release
-  needs: ["trigger_tests"]
   variables:
     IMAGE: deb_x64
 
 release_rpm_x64:
   extends: .release
-  needs: ["trigger_tests"]
   variables:
     IMAGE: rpm_x64
 
 release_suse_x64:
   extends: .release
-  needs: ["trigger_tests"]
   variables:
     IMAGE: suse_x64
 
 release_deb_arm64:
   extends: .release
-  needs: ["trigger_tests"]
   variables:
     IMAGE: deb_arm64
 
 release_rpm_arm64:
   extends: .release
-  needs: ["trigger_tests"]
   variables:
     IMAGE: rpm_arm64
 
 release_system-probe_x64:
   extends: .release
-  needs: ["trigger_tests"]
   variables:
     IMAGE: system-probe_x64
 
 release_system-probe_arm64:
   extends: .release
-  needs: ["trigger_tests"]
   variables:
     IMAGE: system-probe_arm64
 
 release_datadog-ci-uploader:
   extends: .release
-  needs: ["trigger_tests"]
   variables:
     IMAGE: datadog-ci-uploader
 
 release_windows_1809_x64:
   extends: .winrelease
-  needs: ["trigger_tests"]
   variables:
     IMAGE: windows_1809_x64
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64
@@ -461,7 +409,6 @@ release_windows_1809_x64:
 
 release_windows_ltsc2022_x64:
   extends: .winrelease
-  needs: ["trigger_tests"]
   variables:
     IMAGE: windows_ltsc2022_x64
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -458,6 +458,12 @@ release_circleci_runner_gcr:
     project: DataDog/public-images
     strategy: depend
 
+notify-pipeline-trigger:
+  stage: notify
+  tags: ["runner:docker"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10-py3
+  script:
+    echo Notifying triggered datadog-agent pipeline
 
 notify-images-available:
   extends: .slack-notifier-base


### PR DESCRIPTION
Since [we’re building system probe in omnibus](https://github.com/DataDog/datadog-agent/pull/19492), datadog-agent-buildimages CI is failing because tests are trying to build the agent without building system-probe, which is now required. Hence we're replacing tests by a datadog-agent child pipeline to fix current and future issues about how the agent is builded.
Full details on [this document](https://docs.google.com/document/d/1udjaYBdw82ZV7aVsJ9ZeFPVzlcDLLgY9c2xr5Zo1Jag/edit).
