### PR TITLE
suse: enable RPM xz compression by installing xz-devel

### DIFF
--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -69,7 +69,8 @@ RUN zypper clean -a && zypper --non-interactive refresh && \
       libopenssl1_0_0 libopenssl-devel make openssl perl perl-Module-Build \
       patch postgresql-devel procps rsync readline-devel rpm-build sqlite3-devel \
       tar xz which zlib-devel java mozilla-nspr-devel mozilla-nss-devel popt-devel \
-      libbeecrypt-devel file-magic file-devel libarchive-devel libdb-4_8 libdb-4_8-devel
+      libbeecrypt-devel file-magic file-devel libarchive-devel libdb-4_8 libdb-4_8-devel \
+      xz-devel
 
 # Remove all zypper repositories in the image to prevent errors when using zypper.
 # While the repos are available right now, they might go out of order in the future,


### PR DESCRIPTION
Once liblzma is available, our own `rpmbuild` executable can also use `xz` compression