### PR TITLE
Update install_java.ps1 to use absolute path for java.zip

### DIFF
--- a/windows/helpers/phase3/install_java.ps1
+++ b/windows/helpers/phase3/install_java.ps1
@@ -7,7 +7,7 @@ Write-Host -ForegroundColor Green "Installing Java $ENV:JAVA_VERSION"
 ## https://aka.ms/download-jdk/microsoft-jdk-17.0.8-windows-x64.zip
 $javazip = "https://aka.ms/download-jdk/microsoft-jdk-$($ENV:JAVA_VERSION)-windows-x64.zip"
 
-$out = 'java.zip'
+$out = "$($PSScriptRoot)\java.zip"
 
 Write-Host -ForegroundColor Green "Downloading $javazip to $out"
 
@@ -18,7 +18,7 @@ mkdir c:\tmp\java
 
 Write-Host -ForegroundColor Green "Extracting $out to c:\tmp\java"
 
-Start-Process "7z" -ArgumentList 'x -oc:\tmp\java java.zip' -Wait
+Start-Process "7z" -ArgumentList "x -oc:\tmp\java $out" -Wait
 
 Write-Host -ForegroundColor Green "Removing temporary file $out"
 


### PR DESCRIPTION
When running the install script on a VM, `java.zip` was not downloaded to the correct directory (it was downloaded to `C:\Windows\System32\`). Update the script to download the .zip file to the same directory that the script is executing in and use `$out` to extract the file content.