### PR TITLE
Add patchelf to our linux images

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -28,6 +28,8 @@ ARG DD_TARGET_ARCH=aarch64
 ARG GCC_VERSION=10.4.0
 ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
 ARG BUNDLER_VERSION=2.4.20
+ARG PATCHELF_VERSION=0.13.1
+ARG PATCHELF_SHA256="f6d5ecdb51ad78e963233cfde15020f9eebc9d9c7c747aaed54ce39c284ad019"
 
 # Environment
 ENV GOPATH /go
@@ -69,6 +71,19 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 # External calls configuration
 COPY .awsconfig $HOME/.aws/config
 COPY .curlrc .wgetrc $HOME/
+
+# Patchelf
+RUN curl -L -o patchelf-${PATCHELF_VERSION}.tar.gz https://github.com/NixOS/patchelf/archive/refs/tags/${PATCHELF_VERSION}.tar.gz \
+    && echo "${PATCHELF_SHA256}  patchelf-${PATCHELF_VERSION}.tar.gz" | sha256sum --check \
+    && tar xvzf patchelf-${PATCHELF_VERSION}.tar.gz \
+    && cd patchelf-${PATCHELF_VERSION}  \
+    && ./bootstrap.sh \
+    && ./configure \
+    && make \
+    && make install \
+    && cd - \
+    && rm -rf patchelf-${PATCHELF_VERSION} \
+    && rm patchelf-${PATCHELF_VERSION}.tar.gz
 
 # RVM
 COPY ./rvm/gpg-keys /gpg-keys

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -21,6 +21,8 @@ ARG DD_TARGET_ARCH=aarch64
 ARG GCC_VERSION=10.4.0
 ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
 ARG BUNDLER_VERSION=2.4.20
+ARG PATCHELF_VERSION=0.13.1
+ARG PATCHELF_SHA256="f6d5ecdb51ad78e963233cfde15020f9eebc9d9c7c747aaed54ce39c284ad019"
 
 # Environment
 ENV GOPATH /go
@@ -74,6 +76,19 @@ ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 # External calls configuration
 COPY .awsconfig $HOME/.aws/config
 COPY .curlrc .wgetrc $HOME/
+
+# Patchelf
+RUN curl -L -o patchelf-${PATCHELF_VERSION}.tar.gz https://github.com/NixOS/patchelf/archive/refs/tags/${PATCHELF_VERSION}.tar.gz \
+    && echo "${PATCHELF_SHA256}  patchelf-${PATCHELF_VERSION}.tar.gz" | sha256sum --check \
+    && tar xvzf patchelf-${PATCHELF_VERSION}.tar.gz \
+    && cd patchelf-${PATCHELF_VERSION}  \
+    && ./bootstrap.sh \
+    && ./configure \
+    && make \
+    && make install \
+    && cd - \
+    && rm -rf patchelf-${PATCHELF_VERSION} \
+    && rm patchelf-${PATCHELF_VERSION}.tar.gz
 
 # RVM
 COPY ./rvm/gpg-keys /gpg-keys

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -35,6 +35,8 @@ ARG BINUTILS_SHA256="d12ea6f239f1ffe3533ea11ad6e224ffcb89eb5d01bbea589e9158780fa
 ARG GCC_VERSION=10.4.0
 ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
 ARG BUNDLER_VERSION=2.4.20
+ARG PATCHELF_VERSION=0.13.1
+ARG PATCHELF_SHA256="f6d5ecdb51ad78e963233cfde15020f9eebc9d9c7c747aaed54ce39c284ad019"
 
 # Environment
 ENV GOPATH /go
@@ -280,6 +282,22 @@ COPY build-gcc.sh /
 RUN chmod +x /build-gcc.sh \
     && /build-gcc.sh \
     && rm /build-gcc.sh
+
+# Patchelf. This needs a compiler that can handle C++11
+RUN curl -L -o patchelf-${PATCHELF_VERSION}.tar.gz https://github.com/NixOS/patchelf/archive/refs/tags/${PATCHELF_VERSION}.tar.gz \
+    && echo "${PATCHELF_SHA256}  patchelf-${PATCHELF_VERSION}.tar.gz" | sha256sum --check \
+    && tar xvzf patchelf-${PATCHELF_VERSION}.tar.gz \
+    && cd patchelf-${PATCHELF_VERSION}  \
+    && ./bootstrap.sh \
+    && ./configure CC=/opt/gcc-${GCC_VERSION}/bin/gcc \
+        CXX=/opt/gcc-${GCC_VERSION}/bin/g++ \
+        CXXFLAGS='-static-libstdc++' \
+    && make -j$(nproc) \
+    && make install \
+    && cd - \
+    && rm -rf patchelf-${PATCHELF_VERSION} \
+    && rm patchelf-${PATCHELF_VERSION}.tar.gz
+
 
 # Force umask to 0022
 RUN echo "umask 0022" >> /root/.bashrc

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -70,7 +70,7 @@ RUN zypper clean -a && zypper --non-interactive refresh && \
       patch postgresql-devel procps rsync readline-devel rpm-build sqlite3-devel \
       tar xz which zlib-devel java mozilla-nspr-devel mozilla-nss-devel popt-devel \
       libbeecrypt-devel file-magic file-devel libarchive-devel libdb-4_8 libdb-4_8-devel \
-      xz-devel
+      xz-devel patchelf
 
 # Remove all zypper repositories in the image to prevent errors when using zypper.
 # While the repos are available right now, they might go out of order in the future,

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -31,6 +31,8 @@ ARG RUSTUP_SHA256="3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4
 ARG GCC_VERSION=10.4.0
 ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
 ARG BUNDLER_VERSION=2.4.20
+ARG BINUTILS_VERSION="2.39"
+ARG BINUTILS_SHA256="d12ea6f239f1ffe3533ea11ad6e224ffcb89eb5d01bbea589e9158780fa11f10"
 
 # Environment
 ENV GOPATH /go
@@ -47,6 +49,8 @@ ENV RUST_VERSION $RUST_VERSION
 ENV RUSTC_SHA256 $RUSTC_SHA256
 ENV GCC_VERSION $GCC_VERSION
 ENV BUNDLER_VERSION $BUNDLER_VERSION
+ENV BINUTILS_VERSION $BINUTILS_VERSION
+ENV BINUTILS_SHA256 $BINUTILS_SHA256
 
 ENV PATH="/opt/datadog/bin:${PATH}"
 
@@ -70,7 +74,7 @@ RUN zypper clean -a && zypper --non-interactive refresh && \
       patch postgresql-devel procps rsync readline-devel rpm-build sqlite3-devel \
       tar xz which zlib-devel java mozilla-nspr-devel mozilla-nss-devel popt-devel \
       libbeecrypt-devel file-magic file-devel libarchive-devel libdb-4_8 libdb-4_8-devel \
-      xz-devel patchelf
+      xz-devel patchelf makeinfo
 
 # Remove all zypper repositories in the image to prevent errors when using zypper.
 # While the repos are available right now, they might go out of order in the future,
@@ -165,6 +169,20 @@ COPY build-gcc.sh /
 RUN chmod +x /build-gcc.sh \
     && /build-gcc.sh \
     && rm /build-gcc.sh
+
+# Upgrade binutils
+RUN curl -sL -O "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.gz" \
+    && echo "${BINUTILS_SHA256}  ./binutils-${BINUTILS_VERSION}.tar.gz" | sha256sum --check \
+    && tar -zxvf "./binutils-${BINUTILS_VERSION}.tar.gz" \
+    && cd "binutils-${BINUTILS_VERSION}" \
+    && ./configure --prefix=/usr/local/binutils --disable-gprofng && make && make install \
+    && cd - \
+    && rm -rf "binutils-${BINUTILS_VERSION}" \
+    && rm -rf "binutils-${BINUTILS_VERSION}.tar.gz"
+
+# Use our updated binutils version
+ENV PATH="/usr/local/binutils/bin:$PATH"
+
 
 RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.3.tar.bz2 \
     && cd /tmp \


### PR DESCRIPTION
This allows us to modify the rpath for some 3rd parties binary artifacts, which we can't build with the correct rpath from the start.