### PR TITLE
Dev circleci release didn't have the _test_only prefix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -461,7 +461,7 @@ dev_release_circleci_runner_gcr:
   except: [tags, schedules]
   variables:
     IMG_SOURCES: datadog/agent-buildimages-circleci-runner${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
-    IMG_DESTINATIONS: agent-circleci-runner:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
+    IMG_DESTINATIONS: agent-circleci-runner${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
     IMG_REGISTRIES: gcr-datadoghq
   trigger:
     project: DataDog/public-images
@@ -474,7 +474,7 @@ release_circleci_runner_gcr:
   only: [master, main]
   variables:
     IMG_SOURCES: datadog/agent-buildimages-circleci-runner${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
-    IMG_DESTINATIONS: agent-circleci-runner:latest
+    IMG_DESTINATIONS: agent-circleci-runner:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
     IMG_REGISTRIES: gcr-datadoghq
   trigger:
     project: DataDog/public-images


### PR DESCRIPTION
Fix dev circleci release to send their package to `agent-circleci-runner_test_only` and main release to `agent-circleci-runner`, since `latest` is unused we're removing it.