### PR TITLE
[DRAFT] Improve the go version update task with pr creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/settings.json
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ invoke
 packaging
 reno
 requests
+semver==2.10.0
 toml
 urllib3

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -162,7 +162,7 @@ def _update_and_create_pr(gover):
         if local_uncommited_changes_exist(repo):
             raise exceptions.Exit("Uncommited changes exist in datadog-agent-buildimages repo. Exiting.")
         checkout_latest_main(repo)
-        _add_wait_for_tests(f"update-go-{gover}")
+        _add_wait_for_tests(branch)
         _update_images(gover)
         if local_uncommited_changes_exist(repo):
             create_branch_and_push_changes(
@@ -198,7 +198,7 @@ def _update_and_create_pr(gover):
         res = requests.get(f"https://gitlab.ddbuild.io/api/v4/projects/291/jobs/{build_ids[0]}", headers={"PRIVATE-TOKEN": os.environ["GITLAB_ACCESS_TOKEN"]})
         pipeline_id = res.json()["pipeline"]["id"]
         image_tag = f"v{pipeline_id}-{commit_sha[:8]}_test_only"
-        _create_agent_pr(gover, image_tag)
+        _create_agent_pr(branch, gover, image_tag)
 
     create_pr_link = f"https://github.com/DataDog/datadog-agent-buildimages/compare/{branch}?expand=1"
     print(f"Opening link to create an associated PR for the updated buildimages: {create_pr_link}")
@@ -209,7 +209,7 @@ def _update_and_create_pr(gover):
     subprocess.run(["open", create_pr_link])
 
 
-def _create_agent_pr(gover, image_tag):
+def _create_agent_pr(branch, gover, image_tag):
     repo = "datadog-agent"
     with dd_repo_temp_cwd(repo):
         if local_uncommited_changes_exist(repo):
@@ -219,7 +219,7 @@ def _create_agent_pr(gover, image_tag):
         if local_uncommited_changes_exist(repo):
             create_branch_and_push_changes(
                 repo,
-                f"update-go-{gover}",
+                branch,
                 f"Update Go version to {gover} and buildimages to {image_tag} for datadog agent",
             )
         else:

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -1,0 +1,36 @@
+from contextlib import contextmanager
+import os
+import subprocess
+
+def _get_local_path(repo):
+    return os.path.join(os.environ["DATADOG_ROOT"], repo)
+
+def local_uncommited_changes_exist(repo):
+    with dd_repo_temp_cwd(repo):
+        return subprocess.check_output(["git", "status", "--porcelain"]) != b""
+
+@contextmanager
+def dd_repo_temp_cwd(repo=""):
+    current_dir = os.getcwd()
+    try:
+        os.chdir(_get_local_path(repo))
+        yield
+    finally:
+        os.chdir(current_dir)
+
+def checkout_latest_main(repo):
+    with dd_repo_temp_cwd(repo):
+        subprocess.check_call(["git", "checkout", "main"])
+        subprocess.check_call(["git", "pull"])
+
+def create_branch_and_push_changes(
+        repo,
+        branch,
+        commit_msg,
+        commit_args= None,
+        labels= None,
+        ):
+    subprocess.check_call(["git", "checkout", "-b", branch])
+    subprocess.check_call(["git", "add", ".", ":!venv"])
+    subprocess.check_call(["git", "commit", "-am", commit_msg])
+    subprocess.check_call(["git", "push", "origin", branch])

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -21,7 +21,7 @@ def dd_repo_temp_cwd(repo=""):
 def checkout_latest_main(repo):
     with dd_repo_temp_cwd(repo):
         subprocess.check_call(["git", "checkout", "main"])
-        subprocess.check_call(["git", "pull"])
+        subprocess.check_call(["git", "pull", "origin", "main"])
 
 def create_branch_and_push_changes(
         repo,

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -7,7 +7,7 @@ def _get_local_path(repo):
 
 def local_uncommited_changes_exist(repo):
     with dd_repo_temp_cwd(repo):
-        return subprocess.check_output(["git", "status", "--porcelain"]) != b""
+        return subprocess.check_output(["git", "status", "--porcelain"]).strip() != b""
 
 @contextmanager
 def dd_repo_temp_cwd(repo=""):


### PR DESCRIPTION
This is an attempt to script some of the annoying parts re: Go version update detailed in the [RFC](https://docs.google.com/document/d/1X7T3X5_mMRb7pd4zTQ-JluV_5UUxRk-IYOgMoV3S7Ug/edit#heading=h.ixldy9ty2xy5)
* adds `wait_for_test` branch name which will be created in `datadog-agent` after we get the CI_PIPELINE_ID
* runs the current invoke task to update the Dockerfiles
* creates a `datadog-agent-buildimages` PR (to start the CI pipeline)
* gets the CI_PIPELINE_ID from gitlab via it's api to determine the docker image tag the `datadog-agent` CI needs
* runs the `datadog-agent` invoke task with the Go version and image tag from above 
* creates the `datadog-agent` branch with correct CI image tag and Go versions (the `datadog-agent` CI will fail because the images won't be built yet, but that is fine since the `wait_for_test` job will verify the upgrade in the buildimage repo's CI)