### PR TITLE
Enable parallel XZ compression for deb & rpm packages [APL-2626]

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -79,10 +79,13 @@ RUN apt-get update && apt-get install -y fakeroot procps bzip2 \
 # Ubuntu 14.04 comes with gcc 4.8 by default, which has a tough time compiling newer Go versions
 # NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall
 # it and there's not way to prevent that. So leave it be and use update-alternatives to select 4.9
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && add-apt-repository ppa:mikepurvis/dpkg
 RUN apt-get update \
-    && apt-get install -y gcc-4.9 g++-4.9 \
+    && apt-get install -y gcc-4.9 g++-4.9 dpkg \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 0
+
+RUN apt-get update -q && apt-get install -y dpkg
 
 # Update curl with a statically linked binary
 COPY --from=CURL_GETTER /curl-amd64 /usr/local/bin/curl

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -122,7 +122,7 @@ RUN curl -LO https://salsa.debian.org/dpkg-team/dpkg/-/archive/${DPKG_VERSION}/d
     && echo 1.18.4 > .dist-version \
     && autoreconf -vfi \
     && mkdir build && cd build \
-    && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ../configure --disable-nls --disable-dselect --prefix=/usr \
+    && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ../configure --disable-nls --disable-dselect --prefix=/usr --localstatedir=/var \
     && make -j$(nproc) \
     && make install
 

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -31,6 +31,12 @@ ARG BINUTILS_SHA256="d12ea6f239f1ffe3533ea11ad6e224ffcb89eb5d01bbea589e9158780fa
 ARG GCC_VERSION=10.4.0
 ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
 ARG BUNDLER_VERSION=2.4.20
+ARG DPKG_VERSION=1.18.4
+ARG DPKG_SHA256=19f332e26d40ee45c976ff9ef1a3409792c1f303acff714deea3b43bb689dc41
+ARG GETTEXT_VERSION=0.19.8
+ARG GETTEXT_SHA256=9c1781328238caa1685d7bc7a2e1dcf1c6c134e86b42ed554066734b621bd12f
+ARG LIBLZMA_VERSION=5.2.11
+ARG LIBLZMA_SHA256=503b4a9fb405e70e1d3912e418fdffe5de27e713e58925fb67e12d20d03a77bc
 
 # Environment
 ENV GOPATH /go
@@ -79,17 +85,46 @@ RUN apt-get update && apt-get install -y fakeroot procps bzip2 \
 # Ubuntu 14.04 comes with gcc 4.8 by default, which has a tough time compiling newer Go versions
 # NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall
 # it and there's not way to prevent that. So leave it be and use update-alternatives to select 4.9
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test \
-    && add-apt-repository ppa:mikepurvis/dpkg
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN apt-get update \
-    && apt-get install -y gcc-4.9 g++-4.9 dpkg \
+    && apt-get install -y gcc-4.9 g++-4.9 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 0
-
-RUN apt-get update -q && apt-get install -y dpkg
 
 # Update curl with a statically linked binary
 COPY --from=CURL_GETTER /curl-amd64 /usr/local/bin/curl
 RUN chmod +x /usr/local/bin/curl
+
+# The dpkg version we want to install requires a more recent version of
+# gettext than the one shipped in ubuntu 14.04. Even though we disable i18n,
+# their buildsystem still needs gettext
+RUN curl -LO https://ftp.gnu.org/gnu/gettext/gettext-${GETTEXT_VERSION}.tar.xz \
+    && echo "${GETTEXT_SHA256}  gettext-${GETTEXT_VERSION}.tar.xz" | sha256sum --check \
+    && tar xf "gettext-${GETTEXT_VERSION}.tar.xz" \
+    && cd "gettext-${GETTEXT_VERSION}" \
+    && ./configure --prefix=/usr && make -j$(nproc) && make install \
+    && cd / \
+    && rm -rf "gettext-${GETTEXT_VERSION}"
+
+# Now install a recent enough liblzma (5.2+) which supports parallel compression
+RUN curl -LO https://github.com/tukaani-project/xz/releases/download/v${LIBLZMA_VERSION}/xz-${LIBLZMA_VERSION}.tar.xz \
+    && echo "${LIBLZMA_SHA256} /xz-5.2.11.tar.xz" | sha256sum --check \
+    && tar -xf /xz-${LIBLZMA_VERSION}.tar.xz \
+    && cd xz-${LIBLZMA_VERSION} \
+    && ./configure --prefix=/usr/ \
+    && make -j$(nproc) && make install \
+    && cp /usr/lib/liblzma.so* /lib/x86_64-linux-gnu/ \
+    && rm -rf /xz-${LIBLZMA_VERSION}
+
+RUN curl -LO https://salsa.debian.org/dpkg-team/dpkg/-/archive/${DPKG_VERSION}/dpkg-${DPKG_VERSION}.tar.bz2 \
+    && echo "${DPKG_SHA256}  dpkg-${DPKG_VERSION}.tar.bz2" | sha256sum --check \
+    && tar -xf "dpkg-${DPKG_VERSION}.tar.bz2" \
+    && cd "dpkg-${DPKG_VERSION}" \
+    && echo 1.18.4 > .dist-version \
+    && autoreconf -vfi \
+    && mkdir build && cd build \
+    && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ../configure --disable-nls --disable-dselect --prefix=/usr \
+    && make -j$(nproc) \
+    && make install
 
 # Git
 RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz \

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -97,7 +97,7 @@ RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.
     # --no-same-owner: git tarball has a file with UID 110493 which makes pulling this image fail, because we use docker user namespacing and we can't have >65K UIDs. \
     && tar xzf git-${GIT_VERSION}.tar.gz --no-same-owner \
     && cd git-${GIT_VERSION} \
-    && make prefix=/usr/local all \
+    && make -j$(nproc) prefix=/usr/local all \
     && make prefix=/usr/local install \
     && cd .. \
     && rm -rf git-${GIT_VERSION} git-${GIT_VERSION}.tar.gz
@@ -187,7 +187,7 @@ RUN curl -L -o patchelf-${PATCHELF_VERSION}.tar.gz https://github.com/NixOS/patc
     && cd patchelf-${PATCHELF_VERSION}  \
     && ./bootstrap.sh \
     && ./configure \
-    && make \
+    && make -j$(nproc) \
     && make install \
     && cd - \
     && rm -rf patchelf-${PATCHELF_VERSION} \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -100,7 +100,7 @@ RUN if [[ "$(cat /etc/redhat-release-major)" == 6 ]]; then \
     && tar -xvf /tmp/autoconf-2.69.tar.gz --no-same-owner \
     && cd autoconf-2.69 \
     && ./configure \
-    && make && make install \
+    && make -j$(nproc) && make install \
     && cd / \
     && rm -rf /tmp/autoconf-2.69 /tmp/autoconf-2.69.tar.gz; fi
 
@@ -123,7 +123,7 @@ RUN if [[ "$(cat /etc/redhat-release-major)" == 6 ]]; then \
     && cd rpm-4.15.1 \
     && cat /tmp/rpm-4.15.1-fix-rpmbuild-segfault.patch | patch -p1 \
     && ./configure --without-lua --without-audit \
-    && make \
+    && make -j$(nproc) \
     && make install \
     && cd / \
     && rm -rf /tmp/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp/rpm-4.15.1.tar.bz2 /tmp/rpm-4.15.1; fi
@@ -140,7 +140,7 @@ RUN curl -OL "https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar
     # --no-same-owner: git tarball has a file with UID 110493 which makes pulling this image fail, because we use docker user namespacing and we can't have >65K UIDs. \
     && tar xzf "git-${GIT_VERSION}.tar.gz" --no-same-owner \
     && cd "git-${GIT_VERSION}" \
-    && make prefix=/usr/local all \
+    && make -j$(nproc) prefix=/usr/local all \
     && make prefix=/usr/local install \
     && cd .. \
     && rm -rf "git-${GIT_VERSION}" "git-${GIT_VERSION}.tar.gz"
@@ -178,7 +178,7 @@ RUN curl -sL -O "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.t
     && echo "${BINUTILS_SHA256}  ./binutils-${BINUTILS_VERSION}.tar.gz" | sha256sum --check \
     && tar -zxvf "./binutils-${BINUTILS_VERSION}.tar.gz" \
     && cd "binutils-${BINUTILS_VERSION}" \
-    && ./configure --prefix=/usr/local/binutils --disable-gprofng && make && make install \
+    && ./configure --prefix=/usr/local/binutils --disable-gprofng && make -j$(nproc) && make install \
     && cd - \
     && rm -rf "binutils-${BINUTILS_VERSION}" \
     && rm -rf "binutils-${BINUTILS_VERSION}.tar.gz"

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -112,6 +112,19 @@ RUN if [[ "$(cat /etc/redhat-release-major)" == 6 ]]; then \
     && rpm -Uvh --nodeps /root/rpmbuild/RPMS/x86_64/* \
     && rm -rf /tmp/libarchive-3.1.2-12.el7.src.rpm /root/rpmbuild; fi
 
+# Build liblzma 5.2+ which supports parallel compression
+# We still install xz-devel as the distribution provided package
+# is required when rebuilding libarchive just above
+RUN if [[ "$(cat /etc/redhat-release-major)" == 6 ]]; then \
+    curl -sL -o /tmp/xz-5.2.11.tar.xz https://github.com/tukaani-project/xz/releases/download/v5.2.11/xz-5.2.11.tar.xz \
+    && cd /tmp \
+    && echo "503b4a9fb405e70e1d3912e418fdffe5de27e713e58925fb67e12d20d03a77bc  /tmp/xz-5.2.11.tar.xz" | sha256sum --check \
+    && tar -xf /tmp/xz-5.2.11.tar.xz \
+    && cd xz-5.2.11 \
+    && ./configure --prefix=/usr --libdir=/usr/lib64 --disable-symbol-versions \
+    && make -j$(nproc) && make install \
+    && rm -rf /tmp/xz-5.2.11; fi
+
 # Actually build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp
 # Cannot use HTTPS here: cert name is invalid


### PR DESCRIPTION
This PR provides `dpkg` and `rpmbuild` binary build with `liblzma` 5.2, which supports parallel XZ compression.

~Please note that for ubuntu/debian, this is provided as a PPA as the `dpkg` version we need doesn't build easily on our build image (it would require bumping at least gettext & automake manually), however I understand if that's an issue~