### PR TITLE
[ASCII-983] Github workflow to open go update PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,8 @@
 
 .gitlab/kernel-version-testing.yml  @DataDog/ebpf-platform @DataDog/agent-platform
 
+.github/workflows/go-update.yml     @DataDog/agent-shared-components
+
 tasks/update_go.py                  @DataDog/agent-shared-components
 
 /entrypoint-sysprobe.sh             @DataDog/ebpf-platform @DataDog/agent-platform

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       open_pr:
-        description: 'Whether to a PR'
+        description: 'Whether to open a PR'
         required: false
         type: boolean
         default: true

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -8,7 +8,6 @@ on:
         required: true
         type: string
         default: ''
-  pull_request:
 
 jobs:
   open-go-update-pr:

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -7,11 +7,24 @@ on:
         description: 'Go version'
         required: true
         type: string
+      open_pr:
+        description: 'Whether to a PR'
+        required: false
+        type: boolean
+        default: true
       draft:
         description: 'Open a Draft PR'
         required: false
         type: boolean
         default: false
+      branch:
+        description: 'Git branch to use (defaults to "gobot/go-update-<go_version>")'
+        required: false
+        type: string
+        default: ''
+
+env:
+  BRANCH_NAME: ${{ inputs.branch || format('gobot/go-update-{0})', inputs.go_version) }}
 
 jobs:
   open-go-update-pr:
@@ -43,12 +56,12 @@ jobs:
         id: autocommit
         with:
           commit_message: Update go version to ${{ inputs.go_version }}
-          branch: gobot/go-update-${{ inputs.go_version }}
+          branch: ${{ env.BRANCH_NAME }}
           create_branch: true
 
       - name: Create Pull Request
         uses: actions/github-script@v7
-        if: ${{ steps.autocommit.outputs.changes_detected }}
+        if: ${{ inputs.open_pr && steps.autocommit.outputs.changes_detected }}
         with:
           # TODO: if minor update, add changelog to the PR body: https://tip.golang.org/doc/go1.21
           script: |
@@ -56,7 +69,7 @@ jobs:
               title: `Update Go version to ${{ inputs.go_version }}`,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: "gobot/go-update-${{ inputs.go_version }}",
+              head: ${{ env.BRANCH_NAME }},
               base: context.ref,
               draft: ${{ inputs.draft }},
               body: [

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -24,7 +24,7 @@ on:
         default: ''
 
 env:
-  BRANCH_NAME: ${{ inputs.branch || format('gobot/go-update-{0})', inputs.go_version) }}
+  BRANCH_NAME: ${{ inputs.branch || format('gobot/go-update-{0}', inputs.go_version) }}
 
 jobs:
   open-go-update-pr:

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -1,0 +1,64 @@
+name: Open Go Update PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      go_version:
+        description: 'Go version'
+        required: true
+        type: string
+        default: ''
+  pull_request:
+
+jobs:
+  open-go-update-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push commit and branch
+      pull-requests: write # create PR
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Setup Python and pip
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install -r requirements.txt
+
+      - name: Update Go version
+        run: |
+          inv update-go -v "${{ inputs.go_version }}" --check-archive
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        id: autocommit
+        with:
+          commit_message: Update go version to ${{ inputs.go_version }}
+          branch: gobot/go-update-${{ inputs.go_version }}
+          create_branch: true
+
+      - name: Create Pull Request
+        uses: actions/github-script@v7
+        if: ${{ steps.autocommit.outputs.changes_detected }}
+        with:
+          # TODO: if minor update, add changelog to the PR body:
+          # https://tip.golang.org/doc/go1.21
+          script: |
+            github.rest.pulls.create({
+              title: `Update Go version to ${{ inputs.go_version }}`,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: "gobot/go-update-${{ inputs.go_version }}",
+              base: context.ref,
+              draft: true, // for test purpose, remove before merging
+              body: [
+                '## Update docker images to Go ${{ inputs.go_version }}',
+                'For more information about this version, see the [Go release notes](https://golang.org/doc/devel/release.html#go${{ inputs.go_version }}) and the [Github milestone](https://github.com/golang/go/issues?q=milestone%3AGo${{ inputs.go_version }}+label%3ACherryPickApproved).',
+              ].join('\n')
+            });

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -7,7 +7,11 @@ on:
         description: 'Go version'
         required: true
         type: string
-        default: ''
+      draft:
+        description: 'Open a Draft PR'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   open-go-update-pr:
@@ -46,8 +50,7 @@ jobs:
         uses: actions/github-script@v7
         if: ${{ steps.autocommit.outputs.changes_detected }}
         with:
-          # TODO: if minor update, add changelog to the PR body:
-          # https://tip.golang.org/doc/go1.21
+          # TODO: if minor update, add changelog to the PR body: https://tip.golang.org/doc/go1.21
           script: |
             github.rest.pulls.create({
               title: `Update Go version to ${{ inputs.go_version }}`,
@@ -55,7 +58,7 @@ jobs:
               repo: context.repo.repo,
               head: "gobot/go-update-${{ inputs.go_version }}",
               base: context.ref,
-              draft: true, // for test purpose, remove before merging
+              draft: ${{ inputs.draft }},
               body: [
                 '## Update docker images to Go ${{ inputs.go_version }}',
                 'For more information about this version, see the [Go release notes](https://golang.org/doc/devel/release.html#go${{ inputs.go_version }}) and the [Github milestone](https://github.com/golang/go/issues?q=milestone%3AGo${{ inputs.go_version }}+label%3ACherryPickApproved).',


### PR DESCRIPTION
Add a Github workflow which can be triggered manually to open a PR to update the Go version.

This can be tested using Github CLI:
```
gh workflow -R DataDog/datadog-agent-buildimages run go-update.yml -f go_version=1.21.5 --ref pgimalac/auto-create-pr-go-update
```

Note: this is not supposed to be perfect already, more a POC.
For now it can only be triggered manually, doesn't notify on slack, etc