### PR TITLE
Add semver to Python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ reno
 requests
 toml
 urllib3
+semver

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,6 +18,7 @@ jira==3.5.2
 packaging==21.3
 reno==3.5.0
 requests==2.31.0
+semver==2.10.0
 toml==0.10.2
 # urllib3 major version 2, released on May 4th 2023, breaks botocore used
 # by awscli (removed DEFAULT_CIPHERS list from urllib3.util.ssl_)


### PR DESCRIPTION
`semver` is currently directly required in the `requirements.txt` of `datadog-agent`, so it is by default not installed on buildimages.
I need to use it in a unit test of an invoke task (so I need it to be in the `buildimages` list of requirements).