### PR TITLE
Change always to on_success to prevent running child pipelines when images are not built

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ variables:
     when: never
   - if: $CI_COMMIT_TAG != null
     when: never
-  - when: always
+  - when: on_success
 
 .on_default_branch_push:
   - if: $CI_PIPELINE_SOURCE == "schedule"
@@ -51,7 +51,7 @@ variables:
   - if: $CI_COMMIT_TAG != null
     when: never
   - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-    when: always
+    when: on_success
 
 workflow:
   rules:


### PR DESCRIPTION
With `always` the jobs are always run even if previous stages failed. On success will run jobs only if previous stages succeeded. It should avoid situations where we run datadog-agent pipeline with images that failed their build.
It will make the behaviour closer to what we have before https://github.com/DataDog/datadog-agent-buildimages/pull/497