### PR TITLE
Remove KMT dependencies from buildimages

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -47,7 +47,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         python3-dev \
         default-jre \
         wget \
-        xsltproc \
         xz-utils
 
 ENV GO_VERSION $GO_VERSION
@@ -74,10 +73,3 @@ RUN python3 -m pip install -r requirements.txt
 # External calls configuration
 COPY .awsconfig $HOME/.aws/config
 COPY .curlrc .wgetrc $HOME/
-
-# Install pulumi
-RUN curl -fsSL https://raw.githubusercontent.com/pulumi/get.pulumi.com/f06767e3b26451439c066c94e0a907e6d6ec3d85/dist/install.sh > install-pulumi.sh
-RUN echo "060d39770476f7d11de7c75dc1e1780f6492455555b36f4d3ff18f89752ebfc6  install-pulumi.sh" | sha256sum --check
-RUN bash install-pulumi.sh --version 3.48.0
-ENV PATH "/root/.pulumi/bin:${PATH}"
-ENV PULUMI_CONFIG_PASSPHRASE "1234"

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -48,7 +48,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         python3-dev \
         default-jre \
         wget \
-        xsltproc \
         xz-utils
 
 ENV GO_VERSION $GO_VERSION
@@ -75,10 +74,3 @@ RUN python3 -m pip install -r requirements.txt
 # External calls configuration
 COPY .awsconfig $HOME/.aws/config
 COPY .curlrc .wgetrc $HOME/
-
-# Install pulumi
-RUN curl -fsSL https://raw.githubusercontent.com/pulumi/get.pulumi.com/f06767e3b26451439c066c94e0a907e6d6ec3d85/dist/install.sh > install-pulumi.sh
-RUN echo "060d39770476f7d11de7c75dc1e1780f6492455555b36f4d3ff18f89752ebfc6  install-pulumi.sh" | sha256sum --check
-RUN bash install-pulumi.sh --version 3.48.0
-ENV PATH "/root/.pulumi/bin:${PATH}"
-ENV PULUMI_CONFIG_PASSPHRASE "1234"


### PR DESCRIPTION
The jobs requiring these dependencies are now using the image from https://github.com/DataDog/test-infra-definitions/blob/main/Dockerfile.

Changes validated in the [datadog-agent CI](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/26248396)