### PR TITLE
Enable parallel XZ compression for debian packages

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -118,9 +118,9 @@ ENV PATH="${GOPATH}/bin:${PATH}"
 
 # Now install a recent enough liblzma (5.2+) which supports parallel compression
 RUN if [ "$DD_TARGET_ARCH" = "armhf" ] ; then \
-    LIBDIR="arm-linux-gnueabihf"; \
+    LIB_DEST="arm-linux-gnueabihf"; \
     else \
-    LIBDIR="aarch64-linux-gnu"; \
+    LIB_DEST="aarch64-linux-gnu"; \
     fi && \
     curl -LO https://github.com/tukaani-project/xz/releases/download/v${LIBLZMA_VERSION}/xz-${LIBLZMA_VERSION}.tar.xz \
     && echo "${LIBLZMA_SHA256} /xz-5.2.11.tar.xz" | sha256sum --check \
@@ -128,7 +128,7 @@ RUN if [ "$DD_TARGET_ARCH" = "armhf" ] ; then \
     && cd xz-${LIBLZMA_VERSION} \
     && ./configure --prefix=/usr/ \
     && make -j$(nproc) && make install \
-    && cp /usr/lib/liblzma.so* /lib/${LIBDIR}/ \
+    && cp /usr/lib/liblzma.so* /lib/${LIB_DEST}/ \
     && rm -rf /xz-${LIBLZMA_VERSION}
 
 RUN curl -LO https://salsa.debian.org/dpkg-team/dpkg/-/archive/${DPKG_VERSION}/dpkg-${DPKG_VERSION}.tar.bz2 \

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -131,14 +131,20 @@ RUN if [ "$DD_TARGET_ARCH" = "armhf" ] ; then \
     && cp /usr/lib/liblzma.so* /lib/${LIB_DEST}/ \
     && rm -rf /xz-${LIBLZMA_VERSION}
 
-RUN curl -LO https://salsa.debian.org/dpkg-team/dpkg/-/archive/${DPKG_VERSION}/dpkg-${DPKG_VERSION}.tar.bz2 \
+RUN if [ "$DD_TARGET_ARCH" = "armhf" ] ; then \
+    LIB_DEST="arm-linux-gnueabihf"; \
+    EXTRA_CONFIGURE_OPTIONS="--host=arm-linux-gnueabihf --build=arm-linux-gnueabihf"; \
+    else \
+    LIB_DEST="aarch64-linux-gnu"; \
+    fi && \
+    curl -LO https://salsa.debian.org/dpkg-team/dpkg/-/archive/${DPKG_VERSION}/dpkg-${DPKG_VERSION}.tar.bz2 \
     && echo "${DPKG_SHA256}  dpkg-${DPKG_VERSION}.tar.bz2" | sha256sum --check \
     && tar -xf "dpkg-${DPKG_VERSION}.tar.bz2" \
     && cd "dpkg-${DPKG_VERSION}" \
     && echo 1.18.4 > .dist-version \
     && autoreconf -vfi \
     && mkdir build && cd build \
-    && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ../configure --disable-nls --disable-dselect --prefix=/usr --localstatedir=/var \
+    && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ../configure --disable-nls --disable-dselect --prefix=/usr --localstatedir=/var ${EXTRA_CONFIGURE_OPTIONS} \
     && make -j$(nproc) \
     && make install
 

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -29,6 +29,10 @@ ARG GCC_SHA256=ab1974017834430de27fd803ade4389602a7d6ca1362496c57bef384b2a4cb07
 ARG BUNDLER_VERSION=2.4.20
 ARG PATCHELF_VERSION=0.13.1
 ARG PATCHELF_SHA256="f6d5ecdb51ad78e963233cfde15020f9eebc9d9c7c747aaed54ce39c284ad019"
+ARG DPKG_VERSION=1.18.4
+ARG DPKG_SHA256=19f332e26d40ee45c976ff9ef1a3409792c1f303acff714deea3b43bb689dc41
+ARG LIBLZMA_VERSION=5.2.11
+ARG LIBLZMA_SHA256=503b4a9fb405e70e1d3912e418fdffe5de27e713e58925fb67e12d20d03a77bc
 
 # Environment
 ENV GOPATH /go
@@ -111,6 +115,32 @@ RUN if [ "$DD_TARGET_ARCH" = "armhf" ] ; then \
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV PATH="${GOPATH}/bin:${PATH}"
+
+# Now install a recent enough liblzma (5.2+) which supports parallel compression
+RUN if [ "$DD_TARGET_ARCH" = "armhf" ] ; then \
+    LIBDIR="arm-linux-gnueabihf"; \
+    else \
+    LIBDIR="aarch64-linux-gnu"; \
+    fi && \
+    curl -LO https://github.com/tukaani-project/xz/releases/download/v${LIBLZMA_VERSION}/xz-${LIBLZMA_VERSION}.tar.xz \
+    && echo "${LIBLZMA_SHA256} /xz-5.2.11.tar.xz" | sha256sum --check \
+    && tar -xf /xz-${LIBLZMA_VERSION}.tar.xz \
+    && cd xz-${LIBLZMA_VERSION} \
+    && ./configure --prefix=/usr/ \
+    && make -j$(nproc) && make install \
+    && cp /usr/lib/liblzma.so* /lib/${LIBDIR}/ \
+    && rm -rf /xz-${LIBLZMA_VERSION}
+
+RUN curl -LO https://salsa.debian.org/dpkg-team/dpkg/-/archive/${DPKG_VERSION}/dpkg-${DPKG_VERSION}.tar.bz2 \
+    && echo "${DPKG_SHA256}  dpkg-${DPKG_VERSION}.tar.bz2" | sha256sum --check \
+    && tar -xf "dpkg-${DPKG_VERSION}.tar.bz2" \
+    && cd "dpkg-${DPKG_VERSION}" \
+    && echo 1.18.4 > .dist-version \
+    && autoreconf -vfi \
+    && mkdir build && cd build \
+    && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ../configure --disable-nls --disable-dselect --prefix=/usr --localstatedir=/var \
+    && make -j$(nproc) \
+    && make install
 
 # CMake
 RUN if [ "$DD_TARGET_ARCH" = "aarch64" ] ; then set -ex \


### PR DESCRIPTION
This reintroduces the change from #514, and ensures that dpkg will not return aarch64 or similar as its architecture.

When dpkg does so, we end up generating packages named with the arm64 suffix, while they are for armv7.

Relevant extract from the image build logs:

Incorrectly built dpkg:
```
checking dpkg cpu type... arm64
checking dpkg operating system type... linux
checking dpkg architecture name... arm64
```
full logs: https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/407321376
downstream failure in datadog-agent: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/407409532

dpkg built with this PR:
```
checking dpkg cpu type... arm
checking dpkg operating system type... linux
checking dpkg architecture name... armhf
```
full logs: https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/408252288
downstream pipeline job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/408349817