### PR TITLE
Add jq to system-probe buildimages

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         g++ \
         gcc \
         git \
+        jq \
         libbpf-dev \
         libedit-dev \
         libelf-dev \

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         gcc \
         gcc-multilib \
         git \
+        jq \
         libbpf-dev \
         libedit-dev \
         libelf-dev \


### PR DESCRIPTION
Jq is required for parsing json from the command line in this PR https://github.com/DataDog/datadog-agent/pull/22091