### PR TITLE
feat(ci): add a new required dependency

### DIFF
--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -2,6 +2,7 @@
 
 -c constraints.txt
 
+codeowners
 docker
 docker-squash
 invoke


### PR DESCRIPTION
In the scope of moving toward standalone ci-uploader we need to run the junit-upload task on the test-infra image which is used by new-e2e tests.
This task [requires codeowners](https://github.com/DataDog/datadog-agent/blob/main/tasks/libs/junit_upload_core.py#L126)