### PR TITLE
Add job to automatically push buildimages id to datadog-agent branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -307,6 +307,61 @@ wait_for_tests:
   script:
     - cat output.pipeline
 
+push_to_datadog_agent:
+  stage: setup #FIXME: setup stage so that it runs earlier, change to `test` once it works properly
+  rules:
+    # TODO: refactor this with !reference [.on_push] ?
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - if: $CI_COMMIT_TAG != null
+      when: never
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      when: never
+    - if: $CI_COMMIT_MESSAGE !~ /^\[push\]/
+      # for now only run when the commit message starts with [push]
+      when: never
+    - when: always
+  tags: ["arch:amd64"]
+  image: $SETUP_IMAGE_NAME
+  variables:
+    # Workflow ID can be found in https://api.github.com/repos/DataDog/datadog-agent/actions/workflows
+    WORKFLOW_ID: 80540190
+    SSM_GITHUB_TOKEN: ci.datadog-agent.platform-github-app-key
+    INSTALLATION_ID: 45116690
+    APPLICATION_ID: 682216
+    REF: main
+    BRANCH: buildimages/$CI_COMMIT_BRANCH
+    TEST_VERSION: "true"
+    IMAGES_ID: v26894465-ddbd51cf #FIXME: use an hardcoded value for test purpose, when done replace with "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+  script:
+    - set -o pipefail
+    # Get the current go version from the go.env file
+    - >
+      for line in $(cat go.env); do
+        export $line
+      done
+    # Read the Github app private token from AWS SSM
+    - GITHUB_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name $SSM_GITHUB_TOKEN --with-decryption --query "Parameter.Value" --out text | base64 -d -)
+    # Generate a Github token from the Github app
+    - >
+      GITHUB_TOKEN=$(curl -L
+        -X POST
+        -H "Accept: application/vnd.github+json"
+        -H "Authorization: Bearer $GITHUB_APP_KEY"
+        -H "X-GitHub-Api-Version: 2022-11-28"
+        https://api.github.com/app/installations/$INSTALLATION_ID/access_tokens
+        -d '{"permissions":{"issues":"write","contents":"write"}}' | jq .token)
+    - echo "-> TRIGGER WORKFLOW <-" #FIXME: do not run the workflow trigger script for now
+    # # Trigger the workflow
+    # - >
+    #   curl -L
+    #     -X POST
+    #     -H "Accept: application/vnd.github+json"
+    #     -H "Authorization: Bearer $GITHUB_TOKEN"
+    #     -H "X-GitHub-Api-Version: 2022-11-28"
+    #     https://api.github.com/repos/DataDog/datadog-agent/actions/workflows/$WORKFLOW_ID/dispatches
+    #     -d "{\"ref\":\"$REF\",\"inputs\":{\"branch\":\"$BRANCH\",\"images_id\":\"$IMAGES_ID\", \"test_version\":\"$TEST_VERSION\", \"go_version\":\"$GO_VERSION\"}}"
+
 .winbuild: &winbuild
   stage: build
   rules:


### PR DESCRIPTION
Add a job which, on commit to a branch, triggers a workflow in `datadog-agent` which will update the buildimages ID on a given branch to the ones created by that push event.

This is part of the Go update automation effort, but as the job is change-agnostic it should be usable more broadly.