### PR TITLE
fix(all): $HOME is not known in docker context, force it to root home

### DIFF
--- a/.curlrc
+++ b/.curlrc
@@ -1,6 +1,6 @@
 --continue-at -
---include
 --location
 --retry 10
 --max-time 120
+--show-error
 --silent

--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -18,6 +18,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     xz-utils
 
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/
+
 RUN git clone --recurse-submodules https://github.com/libbpf/bpftool.git
 WORKDIR bpftool
 RUN git reset --hard cb3deb23d34abdb33f6bcc5fadeee676e538e2ff
@@ -28,6 +31,3 @@ RUN make -C src/ V=1 install
 
 COPY requirements ./
 RUN pip install -r btf-gen.txt
-
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -88,8 +88,8 @@ COPY requirements /requirements
 RUN python3 -m pip install -r requirements.txt -r requirements/circleci.txt
 
 # External calls configuration
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/
 
 # Setup entrypoint
 WORKDIR $GOPATH

--- a/datadog-ci-uploader/Dockerfile
+++ b/datadog-ci-uploader/Dockerfile
@@ -11,8 +11,8 @@ ENV DATADOG_CI_VERSION=2.17.2
 RUN apt update && apt install -y curl git python3 python3-pip
 COPY requirements /
 RUN pip install -r uploader.txt
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/
 
 RUN curl -L https://raw.githubusercontent.com/tj/n/v${N_VERSION}/bin/n -o n \
     && echo "${N_SHA256}  n" | sha256sum --check \

--- a/dd-agent-testing/Dockerfile
+++ b/dd-agent-testing/Dockerfile
@@ -20,8 +20,8 @@ COPY requirements /requirements
 RUN python3 -m pip install -r requirements.txt
 
 # External calls configuration
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/
 
 # Ruby
 RUN gem install bundler --version ${BUNDLER_VERSION}

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -66,8 +66,8 @@ ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
 # External calls configuration
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/
 
 # Patchelf
 RUN curl -L -o patchelf-${PATCHELF_VERSION}.tar.gz https://github.com/NixOS/patchelf/archive/refs/tags/${PATCHELF_VERSION}.tar.gz \

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -140,8 +140,8 @@ ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
 # External calls configuration
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/
 
 # RVM
 COPY ./rvm/gpg-keys /gpg-keys

--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -6,5 +6,5 @@ COPY requirements /requirements
 RUN python3 -m pip install -r requirements.txt
 
 # External calls configuration
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -6,5 +6,5 @@ COPY requirements /requirements
 RUN python3 -m pip install -r requirements.txt
 
 # External calls configuration
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -71,8 +71,8 @@ ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
 # External calls configuration
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/
 
 # Patchelf
 RUN curl -L -o patchelf-${PATCHELF_VERSION}.tar.gz https://github.com/NixOS/patchelf/archive/refs/tags/${PATCHELF_VERSION}.tar.gz \

--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -108,8 +108,8 @@ COPY requirements /requirements
 RUN ./setup_python.sh
 
 # External calls configuration
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/
 
 # Go
 RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-armv6l.tar.gz \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -155,8 +155,8 @@ ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
 # External calls configuration
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/
 
 # RVM
 COPY ./rvm/gpg-keys /gpg-keys

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -108,8 +108,8 @@ ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
 # External calls configuration
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/
 
 # RVM
 COPY ./rvm/gpg-keys /gpg-keys

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -72,5 +72,5 @@ COPY /requirements /requirements
 RUN python3 -m pip install -r requirements.txt
 
 # External calls configuration
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -73,5 +73,5 @@ COPY /requirements /requirements
 RUN python3 -m pip install -r requirements.txt
 
 # External calls configuration
-COPY .awsconfig $HOME/.aws/config
-COPY .curlrc .wgetrc $HOME/
+COPY .awsconfig /root/.aws/config
+COPY .curlrc .wgetrc /root/


### PR DESCRIPTION
This will enable the auto-setup for curl/wget/aws and should increase the datadog-agent ci resilience.
Do not necessarily remove the redundant options from curl commands in scripts and dockerfiles