### PR TITLE
Improve slack notify message with commit title and branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -515,6 +515,7 @@ notify-images-available:
   dependencies: []
   script: |
     export MESSAGE="Your :docker: images with tag \`v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}\` are ready.
+    :gitlab: Pipeline <$CI_PIPELINE_URL|$CI_PIPELINE_ID> for $CI_COMMIT_TITLE (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>) :git:
     :idea: You can test them in the datadog-agent repository by running:
     \`\`\`inv pipeline.update-buildimages -i v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA} [--no-test-version] [--branch-name <your_branch>]\`\`\`
     "
@@ -530,6 +531,7 @@ notify-images-failure:
   dependencies: []
   script: |
     export MESSAGE=":warning: Your :docker: images with tag \`v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}\` failed to build. :warning:
+    :gitlab: Pipeline <$CI_PIPELINE_URL|$CI_PIPELINE_ID> for $CI_COMMIT_TITLE (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>) :git:
     More details :arrow_right:"
     /usr/local/bin/notify.sh
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -517,7 +517,7 @@ notify-images-available:
     COMMIT_URL="$CI_PROJECT_URL/commit/$CI_COMMIT_SHA"
     BRANCH_URL="$CI_PROJECT_URL/tree/$CI_COMMIT_BRANCH"
     export MESSAGE="Your :docker: images with tag \`v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}\` are ready.
-    :git: Branch <$BRANCH_URL|$CI_COMMIT_BRANCH> for commit `$CI_COMMIT_TITLE` (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>)
+    :git: Branch <$BRANCH_URL|$CI_COMMIT_BRANCH> for commit \`$CI_COMMIT_TITLE\` (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>)
     :idea: You can test them in the datadog-agent repository by running:
     \`\`\`inv pipeline.update-buildimages -i v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA} [--no-test-version] [--branch-name <your_branch>]\`\`\`
     "
@@ -535,7 +535,7 @@ notify-images-failure:
     COMMIT_URL="$CI_PROJECT_URL/commit/$CI_COMMIT_SHA"
     BRANCH_URL="$CI_PROJECT_URL/tree/$CI_COMMIT_BRANCH"
     export MESSAGE=":warning: Your :docker: images with tag \`v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}\` failed to build. :warning:
-    :git: Branch <$BRANCH_URL|$CI_COMMIT_BRANCH> for commit `$CI_COMMIT_TITLE` (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>)
+    :git: Branch <$BRANCH_URL|$CI_COMMIT_BRANCH> for commit \`$CI_COMMIT_TITLE\` (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>)
     More details :arrow_right:"
     /usr/local/bin/notify.sh
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -514,8 +514,10 @@ notify-images-available:
     - when: on_success
   dependencies: []
   script: |
+    COMMIT_URL="$CI_PROJECT_URL/commit/$CI_COMMIT_SHA"
+    BRANCH_URL="$CI_PROJECT_URL/tree/$CI_COMMIT_BRANCH"
     export MESSAGE="Your :docker: images with tag \`v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}\` are ready.
-    :gitlab: Pipeline <$CI_PIPELINE_URL|$CI_PIPELINE_ID> for $CI_COMMIT_TITLE (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>) :git:
+    :git: Branch <$BRANCH_URL|$CI_COMMIT_BRANCH> for commit `$CI_COMMIT_TITLE` (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>)
     :idea: You can test them in the datadog-agent repository by running:
     \`\`\`inv pipeline.update-buildimages -i v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA} [--no-test-version] [--branch-name <your_branch>]\`\`\`
     "
@@ -530,8 +532,10 @@ notify-images-failure:
     - when: on_failure
   dependencies: []
   script: |
+    COMMIT_URL="$CI_PROJECT_URL/commit/$CI_COMMIT_SHA"
+    BRANCH_URL="$CI_PROJECT_URL/tree/$CI_COMMIT_BRANCH"
     export MESSAGE=":warning: Your :docker: images with tag \`v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}\` failed to build. :warning:
-    :gitlab: Pipeline <$CI_PIPELINE_URL|$CI_PIPELINE_ID> for $CI_COMMIT_TITLE (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>) :git:
+    :git: Branch <$BRANCH_URL|$CI_COMMIT_BRANCH> for commit `$CI_COMMIT_TITLE` (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>)
     More details :arrow_right:"
     /usr/local/bin/notify.sh
 


### PR DESCRIPTION
Improve image slack notification message to include commit title and branch.
Before when you received a notification you couldn't know what commit/branch those images were for.

<table>
<tr>
 <td> Before
 <td> After
<tr>
 <td> 
<img width="681" alt="image" src="https://github.com/DataDog/datadog-agent-buildimages/assets/23154723/a6c62a81-98e3-4a6a-855a-6ae6ec55acd0">
 <td> 
<img width="769" alt="image" src="https://github.com/DataDog/datadog-agent-buildimages/assets/23154723/92c757ac-4eda-4f08-ae2a-5c78e76bbe00">
</table>