### PR TITLE
workaround a bug in GCC's contrib script

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -46,7 +46,7 @@ RUN grep -v return /root/.bashrc >> /root/newbashrc && cp /root/newbashrc /root/
 RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
     build-essential pkg-config tar libsystemd-dev libkrb5-dev \
     gettext libtool autopoint autoconf libtool-bin \
-    selinux-basics default-jre flex
+    selinux-basics default-jre flex wget
 
 # Update curl with a statically linked binary
 COPY --from=CURL_GETTER /curl-aarch64 /usr/local/bin/curl-aarch64

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -65,7 +65,7 @@ RUN echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf.d/20datadog
 RUN apt-get update && apt-get install -y fakeroot procps bzip2 \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libpq-dev libz-dev \
   libsystemd-journal-dev rpm tar gettext libtool autopoint autoconf pkg-config flex \
-  selinux-basics libtool software-properties-common default-jre texinfo pxz
+  selinux-basics libtool software-properties-common default-jre texinfo pxz wget
 
 # Ubuntu 14.04 comes with gcc 4.8 by default, which has a tough time compiling newer Go versions
 # NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -35,7 +35,7 @@ RUN yum -y install @development which perl-core perl-ExtUtils-MakeMaker ncurses-
     curl-devel expat-devel gettext-devel openssl-devel systemd-devel zlib-devel bzip2 glibc-static python-devel tar pkgconfig  \
     libtool autoconf policycoreutils-python \
     bzip2-devel e2fsprogs-devel file-devel libacl-devel libarchive-devel libattr-devel \
-    libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel java \
+    libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel java wget \
     && yum clean all
 
 COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -62,7 +62,7 @@ RUN yum -y install \
   glibc-static tar libtool \
   bzip2-devel e2fsprogs-devel file-devel libacl-devel libattr-devel \
   libxml2-devel lzo-devel nss nss-devel popt-devel postgresql-devel sharutils xz-devel java \
-  texinfo \
+  texinfo wget \
   && yum clean all
 
 RUN if [[ $(cat /etc/redhat-release-major) != 6 ]]; then \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -62,7 +62,7 @@ RUN zypper clean -a && zypper --non-interactive refresh && \
       patch postgresql-devel procps rsync readline-devel rpm-build sqlite3-devel \
       tar xz which zlib-devel java mozilla-nspr-devel mozilla-nss-devel popt-devel \
       libbeecrypt-devel file-magic file-devel libarchive-devel libdb-4_8 libdb-4_8-devel \
-      xz-devel patchelf makeinfo
+      xz-devel patchelf makeinfo wget
 
 # Remove all zypper repositories in the image to prevent errors when using zypper.
 # While the repos are available right now, they might go out of order in the future,


### PR DESCRIPTION
GCC's contrib script passes invalid arguments to curl, causing it to attemt to download the output file instead of using it as such. This causes a repetitive failure which our new curlrc exacerbates by insisting on retrying with an exponential backoff, which causes our build jobs to double in duration.
After a long time, curl gives up and uses the intented URL and the download finally succeeds.
The bug is fixed upstream: https://github.com/gcc-mirror/gcc/commit/def4c0b47e0af546d1669743286fee3c3f3159d3 but is only part of 11.x and later releases.