### PR TITLE
circleci: install clang format from the usual ubuntu repos

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -11,6 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN set -ex \
     && apt-get update && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
+    clang-format \
     curl \
     default-jre \
     doxygen \
@@ -74,13 +75,6 @@ RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyr
     && chmod +x /usr/local/bin/codecov
 
 # Other dependencies
-RUN set -ex \
-    # clang-format
-    && echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list \
-    && curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-    && apt-get update \
-    && apt-get -t llvm-toolchain-focal install -y --no-install-recommends \
-    clang-format
 
 # Python
 COPY requirements.txt /


### PR DESCRIPTION
This repo contains version which are much more bleeding edge than the one we use for the agent build.
As new option appear, we are hitting a situation where the circleci version wants to apply a change that the deb-x86 images want to revert This leads to a situation where we can't have a green CI. An alternative solution would be to find the setting that causes the change and attempt to set it to a value which makes both versions happy, but there's no guaranty of this being possible.