### PR TITLE
CI: send image size metrics after each successful build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,10 @@ get_agent_version:
     # For testing purposes
     - docker tag 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA} 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID
     - if [ "$CI_PIPELINE_SOURCE" != "schedule" ]; then docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID; fi
+  after_script:
+    - if [ "${CI_JOB_STATUS}" != 'success' ]; then echo "failed build, not sending metrics"; exit 0; fi
+    - export SIZE=$(docker inspect -f "{{ .Size }}" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA})
+    - ./send-metrics.sh $IMAGE $SIZE $CI_PIPELINE_BRANCH
 
 build_deb_x64:
   extends: [.build, .x64]

--- a/send-metrics.sh
+++ b/send-metrics.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 <image> <size> <branch>"
+    exit 1
+fi
+
+IMAGE=$1
+SIZE=$2
+BRANCH=$3
+
+set -e
+set +x
+
+API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption  --query Parameter.Value --out text)
+
+curl -X POST "https://api.datadoghq.com/api/v2/series" \
+    -H "Accept: application/json" \
+    -H "Content-Type: application/json" \
+    -H "DD-API-KEY: ${API_KEY}" \
+    --silent -S \
+    -d @- << EOF
+{
+    "series":
+    [
+        {
+            "metric": "datadog.buildimages.size",
+            "points": [{"timestamp": $(date '+%s'), "value": ${SIZE} }],
+            "tags": ["image:${IMAGE}", "branch:${BRANCH}"]
+        }
+    ]
+}
+EOF


### PR DESCRIPTION
This PR sends the build images size to datadog, as we haven't been tracking those other than printing the sizes in the logs