### PR TITLE
Update vstudio build tools to 16.11.34

### DIFF
--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -5,11 +5,20 @@ $SoftwareTable = @{
     "WINGIT_SHA256"="b0442f1b8ea40b6f94ef9a611121d2c204f6aa7f29c54315d2ce59876c3d134e";
     "SEVENZIP_VERSION"="19.0.0";
     "SEVENZIP_SHA256"="0f5d4dbbe5e55b7aa31b91e5925ed901fdf46a367491d81381846f05ad54c45e";
-    "VS2017BUILDTOOLS_VERSION"="16.8.3.0";
-    "VS2017BUILDTOOLS_SHA256"="ccfb9355f4f753315455542f966025f96de734292d3908c8c3717e9685b709f0";
-    "VS2017BUILDTOOLS_DOWNLOAD_URL"="https://download.visualstudio.microsoft.com/download/pr/9b3476ff-6d0a-4ff8-956d-270147f21cd4/ccfb9355f4f753315455542f966025f96de734292d3908c8c3717e9685b709f0/vs_BuildTools.exe";
+    
+    ## VisualStudio build tools for containers
+    # https://learn.microsoft.com/en-us/visualstudio/releases/2019/history
+    "VS2017BUILDTOOLS_VERSION"="16.11.34";
+    "VS2017BUILDTOOLS_DOWNLOAD_URL"="https://download.visualstudio.microsoft.com/download/pr/30682086-8872-4c7d-b066-0446b278141b/6cc639a464629b62ece2b4b786880bd213ee371d89ffc7717dc08b7f68644f38/vs_BuildTools.exe";
+    
+    # Get-FileHash -Algorithm SHA256 -InputStream ([System.Net.WebClient]::new().OpenRead('https://download.visualstudio.microsoft.com/download/pr/30682086-8872-4c7d-b066-0446b278141b/6cc639a464629b62ece2b4b786880bd213ee371d89ffc7717dc08b7f68644f38/vs_BuildTools.exe'))
+    "VS2017BUILDTOOLS_SHA256"="6CC639A464629B62ECE2B4B786880BD213EE371D89FFC7717DC08B7F68644F38";
+
+    ## VisualStudio IDE
+    # https://learn.microsoft.com/en-us/visualstudio/releases/2019/history
     "VS2019INSTALLER_DOWNLOAD_URL"="https://download.visualstudio.microsoft.com/download/pr/3a7354bc-d2e4-430f-92d0-9abd031b5ee5/d9fc228ea71a98adc7bc5f5d8e8800684c647e955601ed721fcb29f74ace7536/vs_Community.exe";
     "VS2019INSTALLER_SHA256"="d9fc228ea71a98adc7bc5f5d8e8800684c647e955601ed721fcb29f74ace7536";
+    
     "RUBY_VERSION"="2.6.6-1";
     "RUBY_SHA256"="fbdf77a3e1fa36e25cf0af1303ac76f67dec7a6f739a829784a299702cad1492";
     "IBM_MQ_VERSION"="9.2.4.0";


### PR DESCRIPTION
https://github.com/DataDog/datadog-agent-buildimages/pull/540 won't work until we bump the .Net framework version of the NG installer to > 4.5.