### PR TITLE
Update CODEOWNERS after Agent Platform split

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,19 +30,19 @@ tasks/update_go.py                  @DataDog/agent-shared-components
 /system-probe_x64/                  @DataDog/ebpf-platform @DataDog/agent-ci-experience
 
 # CircleCI image
-/circleci/                           @DataDog/agent-developer-tools @DataDog/agent-ci-experience
+/circleci/                          @DataDog/agent-developer-tools @DataDog/agent-ci-experience
 
 # Linux test & build images
 /deb-arm/                           @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
 /deb-x64/                           @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
-/rpm-arm64/                           @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
-/rpm-armhf/                           @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
+/rpm-arm64/                         @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
+/rpm-armhf/                         @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
 /rpm-x64/                           @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
-/suse-x64/                           @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
+/suse-x64/                          @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
 
 # Windows test & build images
 /windows/                           @DataDog/windows-agent @DataDog/agent-ci-experience
 
 # Docker images
-/docker-arm64/                           @DataDog/container-integrations @DataDog/agent-ci-experience
-/docker-x64/                           @DataDog/container-integrations @DataDog/agent-ci-experience
+/docker-arm64/                      @DataDog/container-integrations @DataDog/agent-ci-experience
+/docker-x64/                        @DataDog/container-integrations @DataDog/agent-ci-experience

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,22 +9,40 @@
 # Rules are matched bottom-to-top, so one team can own subdirectories
 # and another the rest of the directory.
 
-*                                   @DataDog/agent-platform
+*                                   @DataDog/agent-ci-experience
 
 go.env                              @DataDog/agent-shared-components
 
-.gitlab/kernel-version-testing.yml  @DataDog/ebpf-platform @DataDog/agent-platform
+.gitlab/kernel-version-testing.yml  @DataDog/ebpf-platform @DataDog/agent-ci-experience
 
 .github/workflows/go-update.yml     @DataDog/agent-shared-components
 
 tasks/update_go.py                  @DataDog/agent-shared-components
 
-/entrypoint-sysprobe.sh             @DataDog/ebpf-platform @DataDog/agent-platform
+/entrypoint-sysprobe.sh             @DataDog/ebpf-platform @DataDog/agent-ci-experience
 
-/system-probe_arm64/                @DataDog/ebpf-platform @DataDog/agent-platform
-/system-probe_x64/                  @DataDog/ebpf-platform @DataDog/agent-platform
-/btf-gen/                           @DataDog/ebpf-platform @DataDog/agent-platform
-/kernel-version-testing/            @DataDog/ebpf-platform @DataDog/agent-platform
+/build-container.ps1                @DataDog/windows-agent @DataDog/agent-ci-experience
 
-/windows/                           @DataDog/windows-agent @DataDog/agent-platform
-/build-container.ps1                @DataDog/windows-agent @DataDog/agent-platform
+# eBPF / KMT images
+/btf-gen/                           @DataDog/ebpf-platform @DataDog/agent-ci-experience
+/kernel-version-testing/            @DataDog/ebpf-platform @DataDog/agent-ci-experience
+/system-probe_arm64/                @DataDog/ebpf-platform @DataDog/agent-ci-experience
+/system-probe_x64/                  @DataDog/ebpf-platform @DataDog/agent-ci-experience
+
+# CircleCI image
+/circleci/                           @DataDog/agent-developer-tools @DataDog/agent-ci-experience
+
+# Linux test & build images
+/deb-arm/                           @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
+/deb-x64/                           @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
+/rpm-arm64/                           @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
+/rpm-armhf/                           @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
+/rpm-x64/                           @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
+/suse-x64/                           @DataDog/agent-developer-tools @DataDog/agent-build-and-releases @DataDog/agent-ci-experience
+
+# Windows test & build images
+/windows/                           @DataDog/windows-agent @DataDog/agent-ci-experience
+
+# Docker images
+/docker-arm64/                           @DataDog/container-integrations @DataDog/agent-ci-experience
+/docker-x64/                           @DataDog/container-integrations @DataDog/agent-ci-experience


### PR DESCRIPTION
Rationale: 
- The repository as a whole is owned by CI Experience,
- Individual images are owned by the teams that need their contents.