### PR TITLE
send-metrics.sh: fix parameters checks

### DIFF
--- a/send-metrics.sh
+++ b/send-metrics.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 3 ]; then
     echo "usage: $0 <image> <size> <branch>"
     exit 1
 fi


### PR DESCRIPTION
A new parameter was recently added, but the check wasn't updated. This caused all script invocation to not send any metrics :smiling_face_with_tear: 