### PR TITLE
[CI] Install `codecov` cli through pip

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -62,18 +62,6 @@ RUN set -ex \
     && mv $CMAKE_NAME $CMAKE_DEST_DIR \
     && rm $CMAKE_ARCHIVE
 
-# Codecov
-ENV CODECOV_VERSION=0.6.1
-RUN curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import \
-    && curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/linux/codecov \
-    && curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/linux/codecov.SHA256SUM \
-    && curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/linux/codecov.SHA256SUM.sig \
-    && gpgv codecov.SHA256SUM.sig codecov.SHA256SUM \
-    && shasum -a 256 -c codecov.SHA256SUM \
-    && rm codecov.SHA256SUM.sig codecov.SHA256SUM \
-    && mv codecov /usr/local/bin/codecov \
-    && chmod +x /usr/local/bin/codecov
-
 # Other dependencies
 
 # Python


### PR DESCRIPTION
With https://github.com/DataDog/datadog-agent/pull/23680 we're installing codecov cli through `pip`, we don't need the binary install in the image anymore.