### PR TITLE
CI: don't block the pipeline while waiting for a manual job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,7 +136,10 @@ build_ci_image:
       --push \
       .
   rules:
-    - changes: ["ci/Dockerfile"]
+    - changes:
+        paths:
+          - "ci/Dockerfile"
+        compare_to: 'main'
     - when: manual
       allow_failure: true
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -138,6 +138,7 @@ build_ci_image:
   rules:
     - changes: ["ci/Dockerfile"]
     - when: manual
+      allow_failure: true
 
 build_deb_x64:
   extends: [.build, .x64]


### PR DESCRIPTION
Our pipelines on main are currently all waiting for a manual job to complete before starting the tests. Since the manual job isn't triggered, the tests aren't either, which in turn means that we don't publish our images publicly