### PR TITLE
Add ddpy3/bin to $PATH in sysprobe images

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -53,6 +53,7 @@ COPY python-packages-versions.txt setup_python.sh requirements.txt requirements-
 COPY requirements /requirements
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
+ENV PATH "${CONDA_PATH}/envs/ddpy3/bin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
 RUN wget -O /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-arm64.tar.gz \

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -60,6 +60,7 @@ COPY python-packages-versions.txt setup_python.sh requirements.txt requirements-
 COPY requirements /requirements
 RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
+ENV PATH "${CONDA_PATH}/envs/ddpy3/bin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
 RUN wget -O /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz \


### PR DESCRIPTION
With #547 it seems that some binaries that our code (CI but also local tests) expected to be in `$PATH` cannot be found anymore. This PR adds the binary folder for the ddpy3 virtualenv to `$PATH` to avoid that problem.

Agent pipeline for validation: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/31522447