### PR TITLE
CI: don't attempt to release ci-uploader image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -457,11 +457,6 @@ release_system-probe_arm64:
   variables:
     IMAGE: system-probe_arm64
 
-release_datadog-ci-uploader:
-  extends: .release
-  variables:
-    IMAGE: datadog-ci-uploader
-
 release_windows_1809_x64:
   extends: .winrelease
   variables:


### PR DESCRIPTION
It isn't built since #517