### PR TITLE
Build rpmbuild with parallel lzma support

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -90,7 +90,7 @@ RUN curl -LO https://ftp.gnu.org/gnu/gettext/gettext-${GETTEXT_VERSION}.tar.xz \
     && cd "gettext-${GETTEXT_VERSION}" \
     && ./configure --prefix=/usr && make -j$(nproc) && make install \
     && cd / \
-    && rm -rf "gettext-${GETTEXT_VERSION}"
+    && rm -rf "gettext-${GETTEXT_VERSION}*"
 
 # Git
 RUN curl -OL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -175,7 +175,7 @@ RUN curl -LO https://ftp.gnu.org/gnu/gettext/gettext-${GETTEXT_VERSION}.tar.xz \
     && cd "gettext-${GETTEXT_VERSION}" \
     && ./configure --prefix=/usr && make -j$(nproc) && make install \
     && cd / \
-    && rm -rf "gettext-${GETTEXT_VERSION}"
+    && rm -rf "gettext-${GETTEXT_VERSION}*"
 
 # Now install a recent enough liblzma (5.2+) which supports parallel compression
 RUN git clone -b v${LIBLZMA_VERSION} https://github.com/tukaani-project/xz.git \
@@ -194,7 +194,7 @@ RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/r
     && make -j$(nproc) \
     && make install \
     && ldconfig \
-    && rm -rf /tmp/rpm-4.14.3
+    && rm -rf /tmp/rpm-4.14.3*
 
 # Rebuild RPM database with the new rpm
 RUN mkdir -p /usr/local/var/lib/rpm \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -183,7 +183,6 @@ RUN git clone -b v${LIBLZMA_VERSION} https://github.com/tukaani-project/xz.git \
     && autoreconf -vif \
     && ./configure --prefix=/usr/ \
     && make -j$(nproc) && make install \
-    && cp /usr/lib/liblzma.so* /lib/x86_64-linux-gnu/ \
     && rm -rf /xz
 
 RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.3.tar.bz2 \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -31,6 +31,8 @@ ARG BUNDLER_VERSION=2.4.20
 ARG BINUTILS_VERSION="2.39"
 ARG BINUTILS_SHA256="d12ea6f239f1ffe3533ea11ad6e224ffcb89eb5d01bbea589e9158780fa11f10"
 ARG LIBLZMA_VERSION=5.2.11
+ARG GETTEXT_VERSION=0.19.8
+ARG GETTEXT_SHA256=9c1781328238caa1685d7bc7a2e1dcf1c6c134e86b42ed554066734b621bd12f
 
 # Environment
 ENV GOPATH /go
@@ -165,6 +167,15 @@ RUN curl -sL -O "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.t
 
 # Use our updated binutils version
 ENV PATH="/usr/local/binutils/bin:$PATH"
+
+# xz needs gettext 0.19.6 or newer
+RUN curl -LO https://ftp.gnu.org/gnu/gettext/gettext-${GETTEXT_VERSION}.tar.xz \
+    && echo "${GETTEXT_SHA256}  gettext-${GETTEXT_VERSION}.tar.xz" | sha256sum --check \
+    && tar xf "gettext-${GETTEXT_VERSION}.tar.xz" \
+    && cd "gettext-${GETTEXT_VERSION}" \
+    && ./configure --prefix=/usr && make -j$(nproc) && make install \
+    && cd / \
+    && rm -rf "gettext-${GETTEXT_VERSION}"
 
 # Now install a recent enough liblzma (5.2+) which supports parallel compression
 RUN git clone -b v${LIBLZMA_VERSION} https://github.com/tukaani-project/xz.git \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -181,9 +181,10 @@ RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/r
     && tar -xjf /tmp/rpm-4.14.3.tar.bz2 \
     && cd rpm-4.14.3/ \
     && ./configure --with-posixmutexes --with-external-db --without-lua CPPFLAGS="-I/usr/include/nspr4 -I/usr/include/nss3 -I/usr/include/db4"\
-    && make \
+    && make -j$(nproc) \
     && make install \
-    && ldconfig
+    && ldconfig \
+    && rm -rf /tmp/rpm-4.14.3
 
 # Rebuild RPM database with the new rpm
 RUN mkdir -p /usr/local/var/lib/rpm \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -60,7 +60,7 @@ RUN zypper clean -a && zypper --non-interactive refresh && \
       patch postgresql-devel procps rsync readline-devel rpm-build sqlite3-devel \
       tar xz which zlib-devel java mozilla-nspr-devel mozilla-nss-devel popt-devel \
       libbeecrypt-devel file-magic file-devel libarchive-devel libdb-4_8 libdb-4_8-devel \
-      xz-devel patchelf makeinfo wget && \
+      patchelf makeinfo wget && \
       zypper --non-interactive remove gcc && \
       update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 20 && \
       update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-5 20 && \
@@ -167,7 +167,7 @@ RUN curl -sL -O "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.t
 ENV PATH="/usr/local/binutils/bin:$PATH"
 
 # Now install a recent enough liblzma (5.2+) which supports parallel compression
-RUN git clone -b v${LIBLZMA_VERSION} https://git.tukaani.org/xz.git \
+RUN git clone -b v${LIBLZMA_VERSION} https://github.com/tukaani-project/xz.git \
     && cd xz \
     && autoreconf -vif \
     && ./configure --prefix=/usr/ \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -191,9 +191,6 @@ RUN mkdir -p /usr/local/var/lib/rpm \
     && cp /var/lib/rpm/Packages /usr/local/var/lib/rpm/Packages \
     && /usr/local/bin/rpm --rebuilddb
 
-RUN git config --global user.email "package@datadoghq.com"
-RUN git config --global user.name "Bits"
-
 # Force umask to 0022
 RUN echo "umask 0022" >> /root/.bashrc
 

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -30,6 +30,7 @@ ARG RUSTUP_SHA256="0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e
 ARG BUNDLER_VERSION=2.4.20
 ARG BINUTILS_VERSION="2.39"
 ARG BINUTILS_SHA256="d12ea6f239f1ffe3533ea11ad6e224ffcb89eb5d01bbea589e9158780fa11f10"
+ARG LIBLZMA_VERSION=5.2.11
 
 # Environment
 ENV GOPATH /go
@@ -165,6 +166,14 @@ RUN curl -sL -O "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.t
 # Use our updated binutils version
 ENV PATH="/usr/local/binutils/bin:$PATH"
 
+# Now install a recent enough liblzma (5.2+) which supports parallel compression
+RUN git clone -b v${LIBLZMA_VERSION} https://git.tukaani.org/xz.git \
+    && cd xz \
+    && autoreconf -vif \
+    && ./configure --prefix=/usr/ \
+    && make -j$(nproc) && make install \
+    && cp /usr/lib/liblzma.so* /lib/x86_64-linux-gnu/ \
+    && rm -rf /xz
 
 RUN curl -sL -o /tmp/rpm-4.14.3.tar.bz2 http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.3.tar.bz2 \
     && cd /tmp \


### PR DESCRIPTION
This PR replicates what's done for other distributions by enabling parallel compression for XZ.

This is expected to save around 10 minutes per SUSE job in datadog-agent pipelines, as they currently take ≃15 minutes instead of ≃5 for other distributions: 
![image](https://github.com/DataDog/datadog-agent-buildimages/assets/54693/e68a9e4c-c29e-4ea6-9c6b-afb3e5dd8cea)
