### PR TITLE
Add ruff to the Python deps

### DIFF
--- a/requirements/circleci.txt
+++ b/requirements/circleci.txt
@@ -7,5 +7,6 @@ flake8-comprehensions
 flake8-unused-arguments
 flake8-use-fstring
 isort
+ruff
 vulture
 wheel

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,6 +19,7 @@ packaging==21.3
 python-gitlab==4.4.0
 reno==3.5.0
 requests==2.31.0
+ruff==0.3.5
 semver==2.10.0
 toml==0.10.2
 # urllib3 major version 2, released on May 4th 2023, breaks botocore used


### PR DESCRIPTION
We plan to replace flake8 + isort + black with [ruff](https://pypi.org/project/ruff/).

I'll open another PR in the agent later to use it, and another one after to drop the old libraries