### PR TITLE
Add ruff to the requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ packaging
 python-gitlab
 reno
 requests
+ruff
 semver
 toml
 urllib3


### PR DESCRIPTION
Forgot to add it in https://github.com/DataDog/datadog-agent-buildimages/pull/568. This way people that `pip install -r requirements.txt` in the agent will have ruff installed directly.