### PR TITLE
Remove flake8, black and isort dependencies

### DIFF
--- a/requirements/circleci.txt
+++ b/requirements/circleci.txt
@@ -1,12 +1,5 @@
 -c constraints.txt
 
-black
-flake8
-flake8-bugbear
-flake8-comprehensions
-flake8-unused-arguments
-flake8-use-fstring
-isort
 ruff
 vulture
 wheel

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,5 +1,4 @@
 awscli==1.29.45
-black==22.10.0
 boto3==1.28.45
 codeowners==0.6.0
 datadog-api-client==2.16.0
@@ -7,13 +6,7 @@ docker-squash==1.1.0
 docker==5.0.3; python_version < '3.7'
 docker==6.1.3; python_version >= '3.7'
 dulwich==0.21.6
-flake8-bugbear==22.10.27
-flake8-comprehensions==3.10.1
-flake8-unused-arguments==0.0.12
-flake8-use-fstring==1.4
-flake8==5.0.4
 invoke==2.2.0
-isort==5.10.1
 jira==3.5.2
 packaging==21.3
 python-gitlab==4.4.0


### PR DESCRIPTION
Remove flake8, black and isort dependencies because [we switched to ruff](https://github.com/DataDog/datadog-agent/pull/24590)

https://datadoghq.atlassian.net/browse/ADXT-186