### PR TITLE
Add vulture to the main requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ ruff
 semver
 toml
 urllib3
+vulture


### PR DESCRIPTION
We want to move away from the circleci image to run the linters here https://github.com/DataDog/datadog-agent/blob/main/.gitlab/source_test/technical_linters.yml#L3 and use the buildimage instead so we use the same version of Python we have in the Agent.

This is also needed so people can install `vulture` from the agent repo using `pip install -r requirements.txt`, which is not the case at the moment. 

Vulture is used in the `linter.python` task, which is also used in the pre-commit hooks.

The version is pinned in the `constraints.txt` file.