### PR TITLE
Remove ruff and vulture from the circleci image

### DIFF
--- a/requirements/circleci.txt
+++ b/requirements/circleci.txt
@@ -1,5 +1,3 @@
 -c constraints.txt
 
-ruff
-vulture
 wheel


### PR DESCRIPTION
We do not use the circleci image anymore to run Python linters. See:

- https://github.com/DataDog/datadog-agent-buildimages/pull/585
- https://github.com/DataDog/datadog-agent/pull/25526