### PR TITLE
Bump the Python version in agent-deploy and dd-agent-testing

### DIFF
--- a/agent-deploy/Dockerfile
+++ b/agent-deploy/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y \
     python2.7-dev \
     python3-distutils \
     python3-pip \
-    python3.8 \
+    python3.11 \
     shellcheck \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \

--- a/dd-agent-testing/Dockerfile
+++ b/dd-agent-testing/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   g++ gawk gcc git jq \
   libc6-dev libffi-dev libssl-dev libgdbm-dev libgmp-dev libncurses5-dev \
   libreadline6-dev libsqlite3-dev libtool libyaml-dev \
-  make openssh-client pkg-config python3 python3-pip rsync sqlite3 zlib1g-dev \
+  make openssh-client pkg-config python3.11 python3-pip rsync sqlite3 zlib1g-dev \
   && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ focal main" | \
       tee /etc/apt/sources.list.d/azure-cli.list && \
       curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \


### PR DESCRIPTION
We still use Python 3.8 there