### PR TITLE
Bump Python to 3.11.8

### DIFF
--- a/agent-deploy/Dockerfile
+++ b/agent-deploy/Dockerfile
@@ -88,9 +88,9 @@ RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
 # Python 3 deps
 COPY requirements.txt /requirements.txt
 COPY requirements /requirements
-RUN python3 -m pip install pip \
- && python3 -m pip install --upgrade pip \
- && python3 -m pip install -r requirements.txt -r requirements/agent-deploy.txt
+RUN pip3 install pip \
+ && pip3 install --upgrade pip \
+ && pip3 install -r requirements.txt -r requirements/agent-deploy.txt
 
 # External calls configuration
 COPY .awsconfig /root/.aws/config

--- a/agent-deploy/Dockerfile
+++ b/agent-deploy/Dockerfile
@@ -17,6 +17,7 @@ ARG GOLANG_VERSION=1.21.7
 ARG GOLANG_SHASUM=13b76a9b2a26823e53062fa841b07087d48ae2ef2936445dc34c4ae03293702c
 ARG CI_UPLOADER_SHASUM=873976f0f8de1073235cf558ea12c7b922b28e1be22dc1553bf56162beebf09d
 ARG CI_UPLOADER_VERSION=2.30.1
+ARG PYTHON_VERSION=3.11.8
 
 ENV RUBY_VERSION=$RUBY_VERSION_ARG \
     BUNDLER_VERSION=$BUNDLER_VERSION_ARG \
@@ -26,7 +27,7 @@ ENV RUBY_VERSION=$RUBY_VERSION_ARG \
 # Remove the early return on non-interactive shells, which makes sourcing the file not activate conda
 RUN grep -v return /root/.bashrc >> /root/newbashrc && cp /root/newbashrc /root/.bashrc
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     createrepo \
     curl \
@@ -39,10 +40,21 @@ RUN apt-get update && apt-get install -y \
     python-boto \
     python-deltarpm \
     python2.7-dev \
-    python3-distutils \
-    python3-pip \
-    python3.8 \
     shellcheck \
+    make  \
+    zlib1g-dev  \
+    libbz2-dev  \
+    libreadline-dev  \
+    libsqlite3-dev  \
+    wget  \
+    llvm  \
+    libncurses5-dev  \
+    xz-utils  \
+    tk-dev  \
+    libxml2-dev  \
+    libxmlsec1-dev  \
+    libffi-dev  \
+    liblzma-dev \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
@@ -65,12 +77,18 @@ RUN python2 -m pip install \
     boto3==1.14.7 \
     pexpect==3.2
 
+# Python install
+ENV PYENV_ROOT="/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
+RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
+     pyenv install ${PYTHON_VERSION} && \
+     pyenv global ${PYTHON_VERSION}
+
 # Python 3 deps
 COPY requirements.txt /requirements.txt
 COPY requirements /requirements
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 \
- && update-alternatives --config python3 \
- && python3 -m pip install pip \
+RUN python3 -m pip install pip \
  && python3 -m pip install --upgrade pip \
  && python3 -m pip install -r requirements.txt -r requirements/agent-deploy.txt
 

--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION=3.11.8
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
@@ -14,9 +15,29 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     llvm-dev \
     lld \
     ninja-build \
-    python3 \
-    python3-pip \
-    xz-utils
+    software-properties-common \
+    make  \
+    zlib1g-dev  \
+    libbz2-dev  \
+    libreadline-dev  \
+    libsqlite3-dev  \
+    wget  \
+    libncurses5-dev  \
+    xz-utils  \
+    tk-dev  \
+    libxml2-dev  \
+    libxmlsec1-dev  \
+    libffi-dev  \
+    liblzma-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Python install
+ENV PYENV_ROOT="/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
+RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
+     pyenv install ${PYTHON_VERSION} && \
+     pyenv global ${PYTHON_VERSION}
 
 COPY .awsconfig /root/.aws/config
 COPY .curlrc .wgetrc /root/

--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 ARG PYTHON_VERSION=3.11.8
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -6,6 +6,8 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
+ARG PYTHON_VERSION=3.11.8
+
 # Pre-requisites
 # Python 3 dev is required for rtloader
 RUN set -ex \
@@ -28,23 +30,32 @@ RUN set -ex \
     libsystemd-dev \
     make \
     pkg-config \
-    python3 \
-    python3-dev \
-    python3-distutils \
-    python3-pip \
-    python3-setuptools \
-    python3-yaml \
     snmp-mibs-downloader \
     ssh \
-    xz-utils
+    build-essential  \
+    zlib1g-dev  \
+    libbz2-dev  \
+    libreadline-dev  \
+    libsqlite3-dev  \
+    wget  \
+    llvm  \
+    libncurses5-dev  \
+    xz-utils  \
+    tk-dev  \
+    libxml2-dev  \
+    libxmlsec1-dev  \
+    libffi-dev  \
+    liblzma-dev &&  \
+    apt-get clean &&  \
+    rm -rf /var/lib/apt/lists/*
 
 # Golang
-ARG GO_VERSION
-ARG GO_SHA256_LINUX_AMD64
+ARG GO_VERSION=1.21.10
+ARG GO_SHA256_LINUX_AMD64="11"
 ENV GO_VERSION $GO_VERSION
 ENV GOPATH /go
 RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz \
-    && echo "$GO_SHA256_LINUX_AMD64 /tmp/golang.tar.gz" | sha256sum --check \
+#    && echo "$GO_SHA256_LINUX_AMD64 /tmp/golang.tar.gz" | sha256sum --check \
     && tar -C /usr/local -xzf /tmp/golang.tar.gz \
     && rm -f /tmp/golang.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
@@ -69,9 +80,16 @@ RUN ./setup_codecov.sh
 # Other dependencies
 
 # Python
+ENV PYENV_ROOT="/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
 COPY requirements.txt /
 COPY requirements /requirements
-RUN python3 -m pip install -r requirements.txt -r requirements/circleci.txt
+
+RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
+     pyenv install ${PYTHON_VERSION} && \
+     pyenv global ${PYTHON_VERSION} && \
+     pip3 install -r requirements.txt -r requirements/circleci.txt
 
 # External calls configuration
 COPY .awsconfig /root/.aws/config

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -50,8 +50,8 @@ RUN set -ex \
     rm -rf /var/lib/apt/lists/*
 
 # Golang
-ARG GO_VERSION=1.21.10
-ARG GO_SHA256_LINUX_AMD64="11"
+ARG GO_VERSION
+ARG GO_SHA256_LINUX_AMD64
 ENV GO_VERSION $GO_VERSION
 ENV GOPATH /go
 RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz \

--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -55,7 +55,7 @@ ARG GO_SHA256_LINUX_AMD64
 ENV GO_VERSION $GO_VERSION
 ENV GOPATH /go
 RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz \
-#    && echo "$GO_SHA256_LINUX_AMD64 /tmp/golang.tar.gz" | sha256sum --check \
+    && echo "$GO_SHA256_LINUX_AMD64 /tmp/golang.tar.gz" | sha256sum --check \
     && tar -C /usr/local -xzf /tmp/golang.tar.gz \
     && rm -f /tmp/golang.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/dd-agent-testing/Dockerfile
+++ b/dd-agent-testing/Dockerfile
@@ -35,7 +35,7 @@ RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
 # Python
 COPY requirements.txt /
 COPY requirements /requirements
-RUN python3 -m pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 # Ruby
 RUN gem install bundler --version ${BUNDLER_VERSION}

--- a/dd-agent-testing/Dockerfile
+++ b/dd-agent-testing/Dockerfile
@@ -3,6 +3,7 @@ FROM ruby:2.7.5-bullseye
 ENV BUNDLER_VERSION=1.17.3
 ARG CI_UPLOADER_VERSION=2.30.1
 ARG CI_UPLOADER_SHA=873976f0f8de1073235cf558ea12c7b922b28e1be22dc1553bf56162beebf09d
+ARG PYTHON_VERSION=3.11.8
 
 # External calls configuration
 COPY .awsconfig /root/.aws/config
@@ -13,7 +14,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   g++ gawk gcc git jq \
   libc6-dev libffi-dev libssl-dev libgdbm-dev libgmp-dev libncurses5-dev \
   libreadline6-dev libsqlite3-dev libtool libyaml-dev \
-  make openssh-client pkg-config python3 python3-pip rsync sqlite3 zlib1g-dev \
+  make openssh-client pkg-config rsync sqlite3 zlib1g-dev \
   && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ focal main" | \
       tee /etc/apt/sources.list.d/azure-cli.list && \
       curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
@@ -22,6 +23,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   && curl -fsSL https://github.com/DataDog/datadog-ci/releases/download/v${CI_UPLOADER_VERSION}/datadog-ci_linux-x64 --output "/usr/local/bin/datadog-ci" \
   && echo "${CI_UPLOADER_SHA} /usr/local/bin/datadog-ci" | sha256sum --check \
   && chmod +x /usr/local/bin/datadog-ci
+
+# Python install
+ENV PYENV_ROOT="/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
+RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
+     pyenv install ${PYTHON_VERSION} && \
+     pyenv global ${PYTHON_VERSION}
 
 # Python
 COPY requirements.txt /

--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10-py3
+FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
 
 ARG PYTHON_VERSION=3.11.8
 
@@ -34,7 +34,7 @@ RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
 COPY requirements.txt /
 COPY requirements /requirements
 
-RUN python3 -m pip install -r requirements.txt
+RUN pip install -r requirements.txt
 
 # External calls configuration
 COPY .awsconfig /root/.aws/config

--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -1,5 +1,36 @@
 FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10-py3
 
+ARG PYTHON_VERSION=3.11.8
+
+RUN apt-get update &&  \
+    apt-get install -y make  \
+      build-essential  \
+      libssl-dev  \
+      zlib1g-dev  \
+      libbz2-dev  \
+      libreadline-dev  \
+      libsqlite3-dev  \
+      wget  \
+      curl  \
+      llvm  \
+      libncurses5-dev  \
+      xz-utils  \
+      tk-dev  \
+      libxml2-dev  \
+      libxmlsec1-dev  \
+      libffi-dev  \
+      liblzma-dev &&  \
+    apt-get clean &&  \
+    rm -rf /var/lib/apt/lists/*
+
+# Python install
+ENV PYENV_ROOT="/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
+RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
+     pyenv install ${PYTHON_VERSION} && \
+     pyenv global ${PYTHON_VERSION}
+
 COPY requirements.txt /
 COPY requirements /requirements
 

--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -3,7 +3,7 @@ FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
 ARG PYTHON_VERSION=3.11.8
 
 RUN apt-get update &&  \
-    apt-get install -y make  \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y make  \
       build-essential  \
       libssl-dev  \
       zlib1g-dev  \

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10-py3
+FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
 
 ARG PYTHON_VERSION=3.11.8
 
@@ -34,7 +34,7 @@ RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
 COPY requirements.txt /
 COPY requirements /requirements
 
-RUN python3 -m pip install -r requirements.txt
+RUN pip install -r requirements.txt
 
 # External calls configuration
 COPY .awsconfig /root/.aws/config

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -1,5 +1,36 @@
 FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10-py3
 
+ARG PYTHON_VERSION=3.11.8
+
+RUN apt-get update &&  \
+    apt-get install -y make  \
+      build-essential  \
+      libssl-dev  \
+      zlib1g-dev  \
+      libbz2-dev  \
+      libreadline-dev  \
+      libsqlite3-dev  \
+      wget  \
+      curl  \
+      llvm  \
+      libncurses5-dev  \
+      xz-utils  \
+      tk-dev  \
+      libxml2-dev  \
+      libxmlsec1-dev  \
+      libffi-dev  \
+      liblzma-dev &&  \
+    apt-get clean &&  \
+    rm -rf /var/lib/apt/lists/*
+
+# Python install
+ENV PYENV_ROOT="/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
+RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
+     pyenv install ${PYTHON_VERSION} && \
+     pyenv global ${PYTHON_VERSION}
+
 COPY requirements.txt /
 COPY requirements /requirements
 

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -3,7 +3,7 @@ FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
 ARG PYTHON_VERSION=3.11.8
 
 RUN apt-get update &&  \
-    apt-get install -y make  \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y make  \
       build-essential  \
       libssl-dev  \
       zlib1g-dev  \


### PR DESCRIPTION
Bump Python to 3.11.8 in some buildimages that were missed.

We want to be able to use Py3.11 in these images.

I used `pyenv` because it makes it easy and straightforward to install any version from source. It will also be easier to bump in the future without depending on the version from the base image. Feel free to challenge this if you think there's a caveat!