### PR TITLE
[ASCII-1786][Deb ARM64] Update GCC from 5.4 to 9 to support Go 1.22

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
 # Ubuntu 16.04 comes with gcc 5.4 by default, which doesn't work with the race detector starting with Go 1.22
 # NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall
 # it and there's not way to prevent that. So leave it be and use update-alternatives to select 9
+RUN apt install software-properties-common
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN apt-get update \
     && apt-get install -y gcc-9 g++-9 \

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -58,9 +58,9 @@ RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
 # Ubuntu 16.04 comes with gcc 5.4 by default, which doesn't work with the race detector starting with Go 1.22
 # NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall
 # it and there's not way to prevent that. So leave it be and use update-alternatives to select 9
-RUN apt install -y software-properties-common
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
-RUN apt-get update \
+RUN apt install -y software-properties-common \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && apt-get update \
     && apt-get install -y gcc-9 g++-9 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 0
 

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -55,6 +55,14 @@ RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
     gettext libtool autopoint autoconf libtool-bin \
     selinux-basics default-jre flex wget
 
+# Ubuntu 16.04 comes with gcc 5.4 by default, which doesn't work with the race detector starting with Go 1.22
+# NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall
+# it and there's not way to prevent that. So leave it be and use update-alternatives to select 9
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN apt-get update \
+    && apt-get install -y gcc-9 g++-9 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 0
+
 # Update curl with a statically linked binary
 COPY --from=CURL_GETTER /curl-aarch64 /usr/local/bin/curl-aarch64
 COPY --from=CURL_GETTER /curl-armv7 /usr/local/bin/curl-armv7

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
 # Ubuntu 16.04 comes with gcc 5.4 by default, which doesn't work with the race detector starting with Go 1.22
 # NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall
 # it and there's not way to prevent that. So leave it be and use update-alternatives to select 9
-RUN apt install software-properties-common
+RUN apt install -y software-properties-common
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN apt-get update \
     && apt-get install -y gcc-9 g++-9 \


### PR DESCRIPTION
Update GCC from 5.4 to 9 in the deb arm64 image (same version as in deb x64) to fix linker errors with the race detector of Go 1.22.