### PR TITLE
fix(ci): use new location of the openssl releases

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
 # Ubuntu 16.04 comes with gcc 5.4 by default, which doesn't work with the race detector starting with Go 1.22
 # NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall
 # it and there's not way to prevent that. So leave it be and use update-alternatives to select 9
-RUN apt install -y python3-software-properties=0.96.20.10 software-properties-common=0.96.20.10 \
+RUN apt install -y software-properties-common \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     && apt-get update \
     && apt-get install -y gcc-9 g++-9 \

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -38,7 +38,7 @@ case $DD_TARGET_ARCH in
     OPENSSL_SHA256="88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313"
     PYTHON_SHA256="d3019a613b9e8761d260d9ebe3bd4df63976de30464e5c0189566e1ae3f61889"
 
-    wget https://ftp.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
+    wget https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz
     echo "$OPENSSL_SHA256 openssl-$OPENSSL_VERSION.tar.gz" | sha256sum --check
     tar xzf openssl-$OPENSSL_VERSION.tar.gz
     pushd openssl-$OPENSSL_VERSION


### PR DESCRIPTION
Openssl announced they would [deprecate their old release distribution locations](https://www.openssl.org/blog/blog/2024/04/30/releases-distribution-changes/index.html) from June, 1st.
As a consequence we cannot use anymore the `ftp://ftp.openssl.org`, see [related issues](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/530526047)