### PR TITLE
[deb-arm] Fix software-properties-common install

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
 # Ubuntu 16.04 comes with gcc 5.4 by default, which doesn't work with the race detector starting with Go 1.22
 # NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall
 # it and there's not way to prevent that. So leave it be and use update-alternatives to select 9
-RUN apt install -y software-properties-common \
+RUN apt install -y python3-software-properties=0.96.20.10 software-properties-common=0.96.20.10 \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     && apt-get update \
     && apt-get install -y gcc-9 g++-9 \


### PR DESCRIPTION
`software-properties-common=0.96.20.13` was pushed to the Ubuntu 16.04 repositories on May 31, without its needed dependencies, causing our deb-arm builds to fail (see [upstream issue](https://bugs.launchpad.net/ubuntu/+source/software-properties/+bug/2067662)).

This pins the `software-properties-common` install to `0.96.20.10`, the previous available version.

This fixes the `deb-arm64` build, and partially fixes the `deb-armhf` build (which still fails due to https://github.com/DataDog/datadog-agent-buildimages/pull/601).