### PR TITLE
upgrade system-probe images to bullseye for gcc 9

### DIFF
--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG GO_VERSION
@@ -6,8 +6,6 @@ ARG GO_SHA256_LINUX_ARM64
 ARG DD_TARGET_ARCH=aarch64
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-# We need up-to-date kernel headers to be able to use newly available eBPF helpers in programs.
-RUN echo "deb https://archive.debian.org/debian buster-backports main" | tee -a /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
         bison \
@@ -22,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         libedit-dev \
         libelf-dev \
         libfl-dev \
-        libstdc++-8-dev \
+        libstdc++-9-dev \
         libtinfo-dev \
         libtinfo5 \
         libxml2-dev \
@@ -30,13 +28,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         $(apt-cache search --names-only linux-headers-5.* | \
           cut -d " " -f 1 | \
           grep "\-common$" | \
-          sed -rn 's/(.*deb10\.)([0-9]+)-common/\2 \0 \1\2-arm64/p' | \
-          sort -gr | \
+          sort -Vr | \
           head -n 1 | \
           cut -f 2-3 -d " ") \
         linux-libc-dev \
         make \
-        ninja-build/buster-backports \
+        ninja-build \
         openssh-client \
         patch \
         pkg-config \

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         libzip-dev \
         $(apt-cache search --names-only linux-headers-5.* | \
           cut -d " " -f 1 | \
-          grep "\-arm64$" | \
+          grep "[0-9]-arm64$" | \
           sort -Vr | \
           head -n 1 | \
           cut -f 2-3 -d " ") \

--- a/system-probe_arm64/Dockerfile
+++ b/system-probe_arm64/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         libzip-dev \
         $(apt-cache search --names-only linux-headers-5.* | \
           cut -d " " -f 1 | \
-          grep "\-common$" | \
+          grep "\-arm64$" | \
           sort -Vr | \
           head -n 1 | \
           cut -f 2-3 -d " ") \

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         libzip-dev \
         $(apt-cache search --names-only linux-headers-5.* | \
           cut -d " " -f 1 | \
-          grep "\-amd64$" | \
+          grep "[0-9]-amd64$" | \
           sort -Vr | \
           head -n 1 | \
           cut -f 2-3 -d " ") \

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG GO_VERSION
@@ -8,9 +8,6 @@ ARG CI_UPLOADER_VERSION=2.30.1
 ARG CI_UPLOADER_SHA=873976f0f8de1073235cf558ea12c7b922b28e1be22dc1553bf56162beebf09d
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-
-# We need up-to-date kernel headers to be able to use newly available eBPF helpers in programs.
-RUN echo "deb https://archive.debian.org/debian/ buster-backports main" | tee -a /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends \
         bison \
@@ -26,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         libedit-dev \
         libelf-dev \
         libfl-dev \
-        libstdc++-8-dev \
+        libstdc++-9-dev \
         libtinfo-dev \
         libtinfo5 \
         libxml2-dev \
@@ -34,13 +31,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         $(apt-cache search --names-only linux-headers-5.* | \
           cut -d " " -f 1 | \
           grep "\-common$" | \
-          sed -rn 's/(.*deb10\.)([0-9]+)-common/\2 \0 \1\2-amd64/p' | \
-          sort -gr | \
+          sort -Vr | \
           head -n 1 | \
           cut -f 2-3 -d " ") \
         linux-libc-dev \
         make \
-        ninja-build/buster-backports \
+        ninja-build \
         openssh-client \
         patch \
         pkg-config \

--- a/system-probe_x64/Dockerfile
+++ b/system-probe_x64/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && ap
         libzip-dev \
         $(apt-cache search --names-only linux-headers-5.* | \
           cut -d " " -f 1 | \
-          grep "\-common$" | \
+          grep "\-amd64$" | \
           sort -Vr | \
           head -n 1 | \
           cut -f 2-3 -d " ") \


### PR DESCRIPTION
Go 1.22 needs gcc 9 to build the race detector and gcc 9 is not available in `buster`, so we are upgrading to `bullseye`. This has been tested in the agent repo and did not cause any test failures.