### PR TITLE
[windows] fix developer build script

### DIFF
--- a/windows/helpers/phase1/install_codecov.ps1
+++ b/windows/helpers/phase1/install_codecov.ps1
@@ -5,7 +5,7 @@ param (
 
 $CodecovPath = "c:\program files\codecov"
 $CodecovUrl = "https://uploader.codecov.io/$Version/windows/codecov.exe"
-$OutFile = "codecov.exe"
+$OutFile = "$($PSScriptRoot)\codecov.exe"
 
 if (Test-Path -Path "$CodecovPath\codecov.exe") {
     Write-Output "$CodecovPath\codecov.exe already exists on the system."

--- a/windows/install-all.ps1
+++ b/windows/install-all.ps1
@@ -93,6 +93,7 @@ try {
     }
 
     if ($Phase -eq 0 -or $Phase -eq 4) {
+        
     }
 }
 catch {

--- a/windows/modules/DDDeveloper/main.psm1
+++ b/windows/modules/DDDeveloper/main.psm1
@@ -1,6 +1,7 @@
 function Use-BuildEnv {
     param (
-        [Parameter(Mandatory = $false)][string] $GoVer
+        [Parameter(Mandatory = $false)][string] $GoVer,
+        [Parameter(Mandatory = $false)][switch] $NoCacheIntegrationsCore    
     )
 
     # put python in front of `working path`.  Windows 10 includes a dummy python in the path
@@ -65,6 +66,11 @@ function Use-BuildEnv {
     $Env:PATH=$newPathEntries -join ";"
     $Env:BUILDENV="Agent-Build"
 
+    # set the environment variables that default to ussing cached integrations-core
+    if(!$NoCacheIntegrationsCore) {
+        $Env:INTEGRATION_WHEELS_CACHE_BUCKET="dd-agent-omnibus" 
+        $Env:INTEGRATION_WHEELS_SKIP_CACHE_UPLOAD="1"
+    }
     # enable RIDK in this shell
     & $Env:RIDK enable
 


### PR DESCRIPTION
This PR makes two changes
1) changes the `codecov` script to operate properly by using an absolute path for the download.
2) updates the windows powershell environment to, by default, use cached integrations-core