### PR TITLE
Add `types-requests` to the Python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,9 @@ requests
 ruff
 semver
 toml
+types-pyyaml
+types-requests
 types-tabulate
 types-toml
-types-pyyaml
 urllib3
 vulture

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -22,9 +22,10 @@ semver==2.10.0
 setuptools==42.0.2
 toml==0.10.2
 # mypy
+types-pyyaml==6.0.12.20240311
+types-requests==2.30.0
 types-tabulate==0.9.0.20240106
 types-toml==0.10.8.20240310
-types-pyyaml==6.0.12.20240311
 # urllib3 major version 2, released on May 4th 2023, breaks botocore used
 # by awscli (removed DEFAULT_CIPHERS list from urllib3.util.ssl_)
 urllib3==1.26.15


### PR DESCRIPTION
Missed in https://github.com/DataDog/datadog-agent-buildimages/pull/611

I get: 

```
tasks/unit_tests.py:1:1: error: Library stubs not installed for "requests"  [import-untyped]
```

https://datadoghq.atlassian.net/browse/ADXT-357