### PR TITLE
chore(codeowners): udapte barx to agent-delivery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,12 +33,12 @@ tasks/update_go.py                  @DataDog/agent-shared-components
 /circleci/                          @DataDog/agent-devx-loops @DataDog/agent-devx-infra
 
 # Linux test & build images
-/deb-arm/                           @DataDog/agent-devx-loops @DataDog/agent-build-and-releases @DataDog/agent-devx-infra
-/deb-x64/                           @DataDog/agent-devx-loops @DataDog/agent-build-and-releases @DataDog/agent-devx-infra
-/rpm-arm64/                         @DataDog/agent-devx-loops @DataDog/agent-build-and-releases @DataDog/agent-devx-infra
-/rpm-armhf/                         @DataDog/agent-devx-loops @DataDog/agent-build-and-releases @DataDog/agent-devx-infra
-/rpm-x64/                           @DataDog/agent-devx-loops @DataDog/agent-build-and-releases @DataDog/agent-devx-infra
-/suse-x64/                          @DataDog/agent-devx-loops @DataDog/agent-build-and-releases @DataDog/agent-devx-infra
+/deb-arm/                           @DataDog/agent-devx-loops @DataDog/agent-delivery @DataDog/agent-devx-infra
+/deb-x64/                           @DataDog/agent-devx-loops @DataDog/agent-delivery @DataDog/agent-devx-infra
+/rpm-arm64/                         @DataDog/agent-devx-loops @DataDog/agent-delivery @DataDog/agent-devx-infra
+/rpm-armhf/                         @DataDog/agent-devx-loops @DataDog/agent-delivery @DataDog/agent-devx-infra
+/rpm-x64/                           @DataDog/agent-devx-loops @DataDog/agent-delivery @DataDog/agent-devx-infra
+/suse-x64/                          @DataDog/agent-devx-loops @DataDog/agent-delivery @DataDog/agent-devx-infra
 
 # Windows test & build images
 /windows/                           @DataDog/windows-agent @DataDog/agent-devx-infra


### PR DESCRIPTION
This PR updates the codeowners to the updated team name Agent Delivery
