### PR TITLE
Switch from mirrorlist to vault repo on Centos 7

### DIFF
--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -39,6 +39,11 @@ RUN echo "armhfp" > /etc/yum/vars/basearch && \
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-Arm32
 
+# Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 # The last two lines contain dependencies for build of newer rpm
 RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-libs git procps \
     curl-devel expat-devel gettext-devel openssl-devel systemd-devel zlib-devel bzip2 glibc-static tar pkgconfig  \

--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -41,8 +41,8 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 
 # Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
-    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
-    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+    sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
 
 # The last two lines contain dependencies for build of newer rpm
 RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-libs git procps \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -41,8 +41,8 @@ RUN echo $(cat /etc/redhat-release | cut -d'.' -f1 | awk '{print $NF}') > /etc/r
 
 # Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
-    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
-    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+    sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
 
 # The last two lines contain dependencies for build of newer rpm
 RUN yum install -y epel-release && \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -44,8 +44,17 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
     sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
 
+RUN yum -y install epel-release centos-release-scl \
+  && yum-config-manager --enable rhel-server-rhscl-7-rpms
+
+# Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
+# Do it again because the previous command added new repos
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
+
     # The last two lines contain dependencies for build of newer rpm
-RUN yum install -y epel-release && yum -y install \
+RUN yum -y install \
   @development \
   which perl-ExtUtils-MakeMaker perl-parent perl-core \
   pkgconfig \
@@ -53,24 +62,13 @@ RUN yum install -y epel-release && yum -y install \
   glibc-static tar libtool \
   bzip2-devel e2fsprogs-devel file-devel libacl-devel libattr-devel \
   libxml2-devel lzo-devel nss nss-devel popt-devel postgresql-devel sharutils xz-devel java \
-  texinfo wget policycoreutils-python libarchive-devel patchelf
-
-RUN yum -y install centos-release-scl \
-  && yum-config-manager --enable rhel-server-rhscl-7-rpms
-
-# Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
-# Do it again because epel-release adds new repos
-RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
-    sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
-    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
-
-RUN yum -y install devtoolset-11 \
+  texinfo wget policycoreutils-python libarchive-devel patchelf devtoolset-11 \
   && yum clean all \
   && echo 'source /opt/rh/devtoolset-11/enable' >> /root/.bashrc
 
 COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
 
-# We install our own ruby, let's remove the system one. It made rvm fail to build ruby for some reason
+# We install our own ruby, let's remove the system one. It made rvm fail to build ruby for some reason
 RUN yum remove -y ruby
 
 # External calls configuration

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -39,6 +39,11 @@ ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 # persist RHEL major for readable output
 RUN echo $(cat /etc/redhat-release | cut -d'.' -f1 | awk '{print $NF}') > /etc/redhat-release-major
 
+# Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo \
+
 RUN yum install -y epel-release
 
 # Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -55,14 +55,14 @@ RUN yum install -y epel-release && yum -y install \
   libxml2-devel lzo-devel nss nss-devel popt-devel postgresql-devel sharutils xz-devel java \
   texinfo wget policycoreutils-python libarchive-devel patchelf
 
-RUN && yum -y install centos-release-scl \
+RUN yum -y install centos-release-scl \
   && yum-config-manager --enable rhel-server-rhscl-7-rpms
 
 # Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
 # Do it again because epel-release adds new repos
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
-    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo \
+    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
 
 RUN yum -y install devtoolset-11 \
   && yum clean all \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -39,14 +39,15 @@ ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 # persist RHEL major for readable output
 RUN echo $(cat /etc/redhat-release | cut -d'.' -f1 | awk '{print $NF}') > /etc/redhat-release-major
 
+RUN yum install -y epel-release
+
 # Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
     sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
 
 # The last two lines contain dependencies for build of newer rpm
-RUN yum install -y epel-release && \
-  yum -y install \
+RUN yum -y install \
   @development \
   which perl-ExtUtils-MakeMaker perl-parent perl-core \
   pkgconfig \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -47,6 +47,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
 RUN yum install -y epel-release
 
 # Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
+# Do it again because epel-release adds new repos
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
     sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -39,6 +39,11 @@ ENV DD_TARGET_ARCH $DD_TARGET_ARCH
 # persist RHEL major for readable output
 RUN echo $(cat /etc/redhat-release | cut -d'.' -f1 | awk '{print $NF}') > /etc/redhat-release-major
 
+# Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 # The last two lines contain dependencies for build of newer rpm
 RUN yum install -y epel-release && \
   yum -y install \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -44,16 +44,8 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
     sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
 
-RUN yum install -y epel-release
-
-# Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
-# Do it again because epel-release adds new repos
-RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
-    sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
-    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
-
-# The last two lines contain dependencies for build of newer rpm
-RUN yum -y install \
+    # The last two lines contain dependencies for build of newer rpm
+RUN yum install -y epel-release && yum -y install \
   @development \
   which perl-ExtUtils-MakeMaker perl-parent perl-core \
   pkgconfig \
@@ -61,10 +53,18 @@ RUN yum -y install \
   glibc-static tar libtool \
   bzip2-devel e2fsprogs-devel file-devel libacl-devel libattr-devel \
   libxml2-devel lzo-devel nss nss-devel popt-devel postgresql-devel sharutils xz-devel java \
-  texinfo wget policycoreutils-python libarchive-devel patchelf \
-  && yum -y install centos-release-scl \
-  && yum-config-manager --enable rhel-server-rhscl-7-rpms \
-  && yum -y install devtoolset-11 \
+  texinfo wget policycoreutils-python libarchive-devel patchelf
+
+RUN && yum -y install centos-release-scl \
+  && yum-config-manager --enable rhel-server-rhscl-7-rpms
+
+# Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
+# Do it again because epel-release adds new repos
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo \
+
+RUN yum -y install devtoolset-11 \
   && yum clean all \
   && echo 'source /opt/rh/devtoolset-11/enable' >> /root/.bashrc
 

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -42,7 +42,7 @@ RUN echo $(cat /etc/redhat-release | cut -d'.' -f1 | awk '{print $NF}') > /etc/r
 # Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
     sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
-    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo \
+    sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
 
 RUN yum install -y epel-release
 


### PR DESCRIPTION
Centos 7 EOLed on July 1st 2024 and mirrorlist.centos.org is no more. 

We need to switch to vault which is the historical archive

Note: the `btf_gen` job will be fixed in another PR