### PR TITLE
btf-gen: clone the correct submodule version

### DIFF
--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -42,9 +42,10 @@ RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
 COPY .awsconfig /root/.aws/config
 COPY .curlrc .wgetrc /root/
 
-RUN git clone --recurse-submodules https://github.com/libbpf/bpftool.git
+RUN git clone https://github.com/libbpf/bpftool.git
 WORKDIR bpftool
-RUN git reset --hard cb3deb23d34abdb33f6bcc5fadeee676e538e2ff
+RUN git reset --hard cb3deb23d34abdb33f6bcc5fadeee676e538e2ff && \
+    git submodule update --init
 COPY btf-gen/Makefile.patch ./
 RUN git apply Makefile.patch
 


### PR DESCRIPTION
The current code clones the submodule as defined in main, only to switch to another version afterward.
This makes the bpftools and libbpf code out of sync, which now becomes apparent as libbpf removed an API that is still used in the pinned commit: https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/559017010