### PR TITLE
Install rc-employee-configuration to the agent-deploy image

### DIFF
--- a/agent-deploy/Dockerfile
+++ b/agent-deploy/Dockerfile
@@ -24,6 +24,8 @@ ENV RUBY_VERSION=$RUBY_VERSION_ARG \
     AWSCLI_VERSION=$AWSCLI_VERSION_ARG \
     RPM_S3_VERSION=$RPM_S3_VERSION_ARG
 
+COPY agent-deploy/get_github_token.py /get_github_token.py
+
 # Remove the early return on non-interactive shells, which makes sourcing the file not activate conda
 RUN grep -v return /root/.bashrc >> /root/newbashrc && cp /root/newbashrc /root/.bashrc
 
@@ -141,6 +143,18 @@ RUN chmod +x /deploy_scripts/check_apt_pool.sh
 RUN chmod +x /deploy_scripts/fail_deb_is_pkg_already_exists.sh
 RUN /bin/bash -l -c "cd /deploy_scripts/cloudfront-invalidation && \
                      bundle install"
+
+RUN export GITHUB_KEY_B64="$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.platform-github-app-key --with-decryption --query "Parameter.Value" --out text)" && \
+    export GITHUB_APP_ID=682216 && \
+    export GH_TOKEN="$(python3 /get_github_token.py)" && \
+    git config --global credential.helper "!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; };f" && \
+    cd /tmp && \
+    git clone https://github.com/DataDog/rc-employee-configurations && \
+    cd rc-employee-configurations && \
+    go install && \
+    rm -rf /tmp/rc-employee-configurations
+
+ENV PATH="$PATH:/root/go/bin/"
 
 # Entrypoint
 COPY ./agent-deploy/entrypoint.sh /entrypoint.sh

--- a/agent-deploy/get_github_token.py
+++ b/agent-deploy/get_github_token.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import base64
+import os
+import sys
+
+from github import Auth, GithubIntegration
+
+if __name__ == "__main__":
+    if sys.stdout.isatty():
+        print(
+            """Refusing to display auth token to terminal.
+Please run this script within a redirection or command substitution."""
+        )
+        sys.exit(1)
+    if "GITHUB_APP_ID" not in os.environ:
+        sys.exit("Missing mandatory GITHUB_APP_ID environment variable")
+    if "GITHUB_KEY_B64" not in os.environ:
+        sys.exit("Missing mandatory GITHUB_KEY_B64 environment variable")
+    app_id = os.environ.get("GITHUB_APP_ID")
+    app_key_b64 = os.environ.get("GITHUB_KEY_B64")
+    app_key = base64.b64decode(app_key_b64).decode("ascii")
+
+    auth = Auth.AppAuth(app_id, app_key)
+    integration = GithubIntegration(auth=auth)
+    installations = integration.get_installations()
+    if installations.totalCount == 0:
+        sys.exit("Failed to list app installations")
+    install_id = installations[0].id
+    auth_token = integration.get_access_token(install_id)
+    print(auth_token.token)


### PR DESCRIPTION
Install the rc-employee-configuration tool to avoid having to clone & build in each OCI promotion job

BARX-296