### PR TITLE
deb: revert back to github to fetch xz-utils sources

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -164,7 +164,7 @@ RUN if [ "$DD_TARGET_ARCH" = "armhf" ] ; then \
     else \
     LIB_DEST="aarch64-linux-gnu"; \
     fi && \
-    git clone -b v${LIBLZMA_VERSION} https://git.tukaani.org/xz.git \
+    git clone -b v${LIBLZMA_VERSION} https://github.com/tukaani-project/xz.git \
     && cd xz \
     && autoreconf -vif \
     && ./configure --prefix=/usr/ \

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -106,7 +106,7 @@ RUN git config --global user.email "package@datadoghq.com" && \
 
 
 # Now install a recent enough liblzma (5.2+) which supports parallel compression
-RUN git clone -b v${LIBLZMA_VERSION} https://git.tukaani.org/xz.git \
+RUN git clone -b v${LIBLZMA_VERSION} https://github.com/tukaani-project/xz.git \
     && cd xz \
     && autoreconf -vif \
     && ./configure --prefix=/usr/ \


### PR DESCRIPTION
The mirror on tukaani.org was temporarily disabled. see https://tukaani.org/xz/#_development