### PR TITLE
deb-x64: install jq

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -58,7 +58,8 @@ RUN echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf.d/20datadog
 RUN apt-get update && apt-get install -y fakeroot procps bzip2 \
   build-essential pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libpq-dev libz-dev \
   libsystemd-journal-dev rpm tar gettext libtool autopoint autoconf pkg-config flex \
-  selinux-basics libtool software-properties-common default-jre texinfo pxz wget binutils-2.26
+  selinux-basics libtool software-properties-common default-jre texinfo pxz wget binutils-2.26 \
+  jq
 
 # Ubuntu 14.04 comes with gcc 4.8 by default, which has a tough time compiling newer Go versions
 # NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall


### PR DESCRIPTION
We want to attempt a fix for the flakyness in OCI packaging jobs that involves URL encoding the CI_JOB_TOKEN we use, and we'd rather use `jq` that doing so in plain bash