### PR TITLE
place python before ruby on PATH to deconflict aws cli

### DIFF
--- a/windows/helpers/phase2/install_ruby.ps1
+++ b/windows/helpers/phase2/install_ruby.ps1
@@ -23,10 +23,12 @@ $out = "$($PSScriptRoot)\rubyinstaller.exe"
 Get-RemoteFile -RemoteFile $rubyexe -LocalFile $out -VerifyHash $Sha256
 
 
+# pass nomodpath to avoid putting ruby at the front of the Machine PATH
+# we'll add it to the end of the User PATH ourselves
 Write-Host -ForegroundColor Green Done downloading Ruby, installing
-Start-Process $out -ArgumentList '/verysilent /dir="c:\tools\ruby" /tasks="assocfiles,noridkinstall,modpath"' -Wait
+Start-Process $out -ArgumentList '/verysilent /dir="c:\tools\ruby" /tasks="assocfiles,noridkinstall,nomodpath"' -Wait
 
-Add-ToPath -NewPath "c:\tools\ruby\bin" -Local
+Add-ToPath -NewPath "c:\tools\ruby\bin" -Local -Global
 Add-EnvironmentVariable -Variable RIDK -Value ((Get-Command ridk).Path) -Global
 Start-Process gem -ArgumentList  'install bundler -v 2.3.24' -Wait
 

--- a/windows/helpers/phase2/install_ruby.ps1
+++ b/windows/helpers/phase2/install_ruby.ps1
@@ -23,8 +23,10 @@ $out = "$($PSScriptRoot)\rubyinstaller.exe"
 Get-RemoteFile -RemoteFile $rubyexe -LocalFile $out -VerifyHash $Sha256
 
 
+# pass nomodpath to avoid putting ruby at the front of the Machine PATH
+# we'll add it to the end of the User PATH ourselves
 Write-Host -ForegroundColor Green Done downloading Ruby, installing
-Start-Process $out -ArgumentList '/verysilent /dir="c:\tools\ruby" /tasks="assocfiles,noridkinstall,modpath"' -Wait
+Start-Process $out -ArgumentList '/verysilent /dir="c:\tools\ruby" /tasks="assocfiles,noridkinstall,nomodpath"' -Wait
 
 Add-ToPath -NewPath "c:\tools\ruby\bin" -Local
 Add-EnvironmentVariable -Variable RIDK -Value ((Get-Command ridk).Path) -Global

--- a/windows/helpers/phase2/install_ruby.ps1
+++ b/windows/helpers/phase2/install_ruby.ps1
@@ -23,10 +23,8 @@ $out = "$($PSScriptRoot)\rubyinstaller.exe"
 Get-RemoteFile -RemoteFile $rubyexe -LocalFile $out -VerifyHash $Sha256
 
 
-# pass nomodpath to avoid putting ruby at the front of the Machine PATH
-# we'll add it to the end of the User PATH ourselves
 Write-Host -ForegroundColor Green Done downloading Ruby, installing
-Start-Process $out -ArgumentList '/verysilent /dir="c:\tools\ruby" /tasks="assocfiles,noridkinstall,nomodpath"' -Wait
+Start-Process $out -ArgumentList '/verysilent /dir="c:\tools\ruby" /tasks="assocfiles,noridkinstall,modpath"' -Wait
 
 Add-ToPath -NewPath "c:\tools\ruby\bin" -Local
 Add-EnvironmentVariable -Variable RIDK -Value ((Get-Command ridk).Path) -Global

--- a/windows/install-all.ps1
+++ b/windows/install-all.ps1
@@ -70,10 +70,12 @@ try {
 
     if ($Phase -eq 0 -or $Phase -eq 2) {
         .\helpers\phase2\install_docker.ps1
+        # install python before ruby so it's in front of ruby on the PATH
+        # they both have an `aws` command, and python's is the one we want
+        .\helpers\phase2\install_python.ps1 -Version $ENV:PYTHON_VERSION -Sha256 $ENV:PYTHON_SHA256
         .\helpers\phase2\install_ruby.ps1 -Version $ENV:RUBY_VERSION -Sha256 $ENV:RUBY_SHA256
         # msys depends on ruby
         .\helpers\phase2\install_msys.ps1 -Version $ENV:MSYS_VERSION -Sha256 $ENV:MSYS_SHA256
-        .\helpers\phase2\install_python.ps1 -Version $ENV:PYTHON_VERSION -Sha256 $ENV:PYTHON_SHA256
         .\helpers\phase2\install_gcloud_sdk.ps1
         .\helpers\phase2\install_embedded_pythons.ps1
     }

--- a/windows/install-all.ps1
+++ b/windows/install-all.ps1
@@ -70,12 +70,10 @@ try {
 
     if ($Phase -eq 0 -or $Phase -eq 2) {
         .\helpers\phase2\install_docker.ps1
-        # install python before ruby so it's in front of ruby on the PATH
-        # they both have an `aws` command, and python's is the one we want
-        .\helpers\phase2\install_python.ps1 -Version $ENV:PYTHON_VERSION -Sha256 $ENV:PYTHON_SHA256
         .\helpers\phase2\install_ruby.ps1 -Version $ENV:RUBY_VERSION -Sha256 $ENV:RUBY_SHA256
         # msys depends on ruby
         .\helpers\phase2\install_msys.ps1 -Version $ENV:MSYS_VERSION -Sha256 $ENV:MSYS_SHA256
+        .\helpers\phase2\install_python.ps1 -Version $ENV:PYTHON_VERSION -Sha256 $ENV:PYTHON_SHA256
         .\helpers\phase2\install_gcloud_sdk.ps1
         .\helpers\phase2\install_embedded_pythons.ps1
     }


### PR DESCRIPTION
Changes
---
Windows only

Install Python before Ruby so it is first on User PATH

Pass `nomodpath` to Ruby installer to prevent it from putting ruby on the Machine PATH

Motivation
---
Effort to remove hardcoded python install path in [Agent omnibus build](https://github.com/DataDog/datadog-agent/blob/ceaa7b1c03c75d77cac46c01374ad74db8a88738/omnibus/config/software/datadog-agent-integrations-py3.rb#L135-L136)