### PR TITLE
feat(github): Force default permissions of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -23,6 +23,8 @@ on:
         type: string
         default: ''
 
+permissions: {}
+
 env:
   BRANCH_NAME: ${{ inputs.branch || format('gobot/go-update-{0}', inputs.go_version) }}
 
@@ -55,7 +57,7 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         id: autocommit
         with:
-          # [push_to_datadog_agent] prefix trigger 'push_to_datadog_agent' gitlab job 
+          # [push_to_datadog_agent] prefix trigger 'push_to_datadog_agent' gitlab job
           commit_message: "[push_to_datadog_agent] Update go version to ${{ inputs.go_version }}"
           branch: ${{ env.BRANCH_NAME }}
           create_branch: true

--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [closed]
 
+permissions: {}
+
 jobs:
   run_slapr_datadog_agent:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[Jira](https://datadoghq.atlassian.net/browse/ACIX-407?atlOrigin=eyJpIjoiMDU2M2QxNTM0NTgzNGUwZTg3NDc1YjIwZmJlMzk4NTciLCJwIjoiaiJ9)

Github token permissions should follow the [least privilege principle](https://datadoghq.atlassian.net/wiki/x/TIVE6Q)
Reset workflow permissions to validate we can enable Read-only default permissions at repository level to provide a strong baseline protection measure

> [!NOTE]
action [launched](https://github.com/DataDog/datadog-agent-buildimages/actions/runs/10270275163) for go update, [PR creation OK](https://github.com/DataDog/datadog-agent-buildimages/pull/636)