### PR TITLE
[devcontainer] fix python installation configuration

### DIFF
--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -8,18 +8,19 @@ ENV DATADOG_AGENT_EMBEDDED_PATH=/opt/datadog-agent/embedded
 
 RUN apt-get update && apt-get upgrade -y && \
     # Common + Agent (Core/Trace/Process) dependencies
-    apt-get install -y wget build-essential apt-transport-https libsystemd-dev cmake sudo vim git curl procps ruby ruby-dev autoconf automake libtool libtool-bin gettext autopoint checkpolicy policycoreutils policycoreutils-python-utils bison pkg-config docker.io docker-buildx docker-compose-v2 ninja-build \
-    # Python setup
-    python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv python3-pip \
+    apt-get install -y wget software-properties-common build-essential apt-transport-https libsystemd-dev cmake sudo vim git curl procps ruby ruby-dev autoconf automake libtool libtool-bin gettext autopoint checkpolicy policycoreutils policycoreutils-python-utils bison pkg-config docker.io docker-buildx docker-compose-v2 ninja-build \
     # Network feature tests
     openjdk-11-jre-headless \
     # System-probe dependencies
-    clang llvm bpfcc-tools libbpfcc-dev libelf-dev linux-headers-generic && \
+    clang llvm bpfcc-tools libbpfcc-dev libelf-dev linux-headers-generic &&\
+    # Python setup
+    add-apt-repository -y 'ppa:deadsnakes/ppa' &&\
+    apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv python3-pip &&\
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists
 
 # Setup python3.11 as default
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 110 && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 100
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 100 && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 110
 
 # Create user
 RUN useradd -g 20 -u 503 -m datadog -s /bin/bash -G sudo,root && \

--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update && apt-get upgrade -y && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists
 
 # Setup python3.11 as default
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 2 && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2
 
 # Create user
 RUN useradd -g 20 -u 503 -m datadog -s /bin/bash -G sudo,root && \

--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update && apt-get upgrade -y && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists
 
 # Setup python3.11 as default
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 100 && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 110
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 2 && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
 
 # Create user
 RUN useradd -g 20 -u 503 -m datadog -s /bin/bash -G sudo,root && \


### PR DESCRIPTION
After some testing python3.10 was still the default because the python3.11 was failing silently when not found

add the missing `ppa:deadsnakes/ppa` apt repo
increase the priority for python3.11