### PR TITLE
chore: Keep gpg2 in the image

### DIFF
--- a/agent-deploy/Dockerfile
+++ b/agent-deploy/Dockerfile
@@ -70,7 +70,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Use gnupg1 instead of gnupg2, our scripts and rpm-s3 are currently not compatible with gnupg2
-RUN rm /usr/bin/gpg && ln -s /usr/bin/gpg1 /usr/bin/gpg
+RUN mv /usr/bin/gpg /usr/bin/gpg2 && ln -s /usr/bin/gpg1 /usr/bin/gpg
 
 # Python 2 deps
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py \


### PR DESCRIPTION
This change allows us to by default use `gpg1` for all `gpg` invocations, but opt into `gpg2` specifically if needed. This allows `agent-release-management` to use `gpg2` for package signing.