### PR TITLE
[CI] Add the `contents:write` permission to the `go-update.yml` workflow

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -23,11 +23,6 @@ on:
         type: string
         default: ''
 
-permissions:
-  # Give the default GITHUB_TOKEN write permission to commit and push the
-  # added or changed files to the repository.
-  pull-requests: write
-
 env:
   BRANCH_NAME: ${{ inputs.branch || format('gobot/go-update-{0}', inputs.go_version) }}
 

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -23,7 +23,10 @@ on:
         type: string
         default: ''
 
-permissions: {}
+permissions:
+  # Give the default GITHUB_TOKEN write permission to commit and push the
+  # added or changed files to the repository.
+  contents: write
 
 env:
   BRANCH_NAME: ${{ inputs.branch || format('gobot/go-update-{0}', inputs.go_version) }}

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -26,7 +26,7 @@ on:
 permissions:
   # Give the default GITHUB_TOKEN write permission to commit and push the
   # added or changed files to the repository.
-  contents: write
+  pull-requests: write
 
 env:
   BRANCH_NAME: ${{ inputs.branch || format('gobot/go-update-{0}', inputs.go_version) }}


### PR DESCRIPTION
The `go-update.yml` workflow needs the `contents:write` permission to be able to commit and create a PR on the repository. Else we get this error ([see job](https://github.com/DataDog/datadog-agent-buildimages/actions/runs/10792379054/job/29931896062)):
```
RequestError [HttpError]: GitHub Actions is not permitted to create or approve pull requests.
```
This PR fixes it.
