### PR TITLE
install_winsign: detect pip install errors

### DIFF
--- a/windows/helpers/phase3/install_winsign.ps1
+++ b/windows/helpers/phase3/install_winsign.ps1
@@ -12,3 +12,4 @@ $codesign_wheel_target = "c:\devtools\$($codesign_base)"
 Get-RemoteFile -RemoteFile $codesign_wheel -LocalFile $codesign_wheel_target -VerifyHash $ENV:WINSIGN_SHA256
 
 python -m pip install $codesign_wheel_target
+If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }


### PR DESCRIPTION
They currently are not preventing the image from being built to completion which cause errors down the line:
https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/630577303#L3369