### PR TITLE
feat(datadog-ci): Add `datadog-ci` to local path

### DIFF
--- a/windows/helpers/phase3/install_ci_uploader.ps1
+++ b/windows/helpers/phase3/install_ci_uploader.ps1
@@ -19,6 +19,6 @@ $target = "c:\devtools\datadog-ci\datadog-ci"
 
 New-Item -ItemType Directory -Path $folder
 Get-RemoteFile -LocalFile $target -RemoteFile $source -VerifyHash $Sha256
-Add-ToPath -NewPath "c:\devtools\datadog-ci" -Global
+Add-ToPath -NewPath "c:\devtools\datadog-ci" -Local -Global
 Set-InstalledVersionKey -Component "datadog-ci" -Keyname "version" -TargetValue $Version
 Write-Host -ForegroundColor Green Done with datadog-ci


### PR DESCRIPTION
As [discussed](https://github.com/DataDog/datadog-agent/pull/29458#discussion_r1768451406) in https://github.com/DataDog/datadog-agent/pull/29458, the `-Global` option of `Add-toPath` is not enough.
Let's add it with `-Local` as well