### PR TITLE
upgrade perl's List::Util module

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -68,6 +68,10 @@ RUN apt-get update \
     && apt-get install -y gcc-9 g++-9 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 0
 
+# Upgrade some perl modules since some of our dependencies require some "new" features
+# that were not available in centos 7
+RUN cpanp -i List::Util
+
 # Ensure we're using the newest binutils
 ENV PATH "/usr/lib/binutils-2.26/bin:$PATH"
 

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -71,6 +71,10 @@ COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
 # We install our own ruby, let's remove the system one. It made rvm fail to build ruby for some reason
 RUN yum remove -y ruby
 
+# Upgrade some perl modules since some of our dependencies require some "new" features
+# that were not available in centos 7
+RUN cpanp -i List::Util
+
 # External calls configuration
 COPY .awsconfig /root/.aws/config
 COPY .curlrc .wgetrc /root/


### PR DESCRIPTION
OpenSSL's build system requires 1.29+ and we currently ship 1.27