### PR TITLE
Updated devcontainer stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,13 +5,13 @@ include:
 
 stages:
   - setup
-  - lint
   - build
   - availability_message
   - trigger_build_kernels
   - test
   - after_test
   - release
+  - lint
   - notify
 
 variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,8 +10,8 @@ stages:
   - trigger_build_kernels
   - test
   - after_test
-  - release
   - lint
+  - release
   - notify
 
 variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ stages:
   - trigger_build_kernels
   - test
   - after_test
-  - lint
+  - devcontainer
   - release
   - notify
 

--- a/.gitlab/devcontainer.yml
+++ b/.gitlab/devcontainer.yml
@@ -7,14 +7,14 @@ lint_devcontainer:
   tags: ["arch:amd64"]
 
 .build_devcontainer:
-  tags: [ "arch:amd64" ]
+  tags: ["arch:amd64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.3
   variables:
     DOCKER_TARGET: registry.ddbuild.io/ci/datadog-agent-devenv:1
     PUSH: --push
   parallel:
     matrix:
-      - PLATFORM: [ amd64,arm64 ]
+      - PLATFORM: [amd64, arm64]
   script:
     - GO_VERSION_ARG=$(grep GO_VERSION go.env | sed -e 's/^/--build-arg /' | tr '\n' ' ')
     - docker buildx build $GO_VERSION_ARG --no-cache --platform linux/${PLATFORM} --tag ${DOCKER_TARGET}-${PLATFORM} -f devcontainer/Dockerfile . ${PUSH}

--- a/.gitlab/devcontainer.yml
+++ b/.gitlab/devcontainer.yml
@@ -1,5 +1,5 @@
 lint_devcontainer:
-  stage: lint
+  stage: devcontainer
   needs: []
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/images:v26997867-ebc48a76
   script:
@@ -19,18 +19,18 @@ lint_devcontainer:
     - GO_VERSION_ARG=$(grep GO_VERSION go.env | sed -e 's/^/--build-arg /' | tr '\n' ' ')
     - docker buildx build $GO_VERSION_ARG --no-cache --platform linux/${PLATFORM} --tag ${DOCKER_TARGET}-${PLATFORM} -f devcontainer/Dockerfile . ${PUSH}
 
-test-devcontainer:
+test_devcontainer:
   extends: .build_devcontainer
-  stage: test
-  needs: []
+  stage: devcontainer
+  needs: [lint_devcontainer]
   rules:
     - if: '$CI_COMMIT_BRANCH != "main"'
   variables:
     PUSH: ""
 
-build-devcontainer:
+build_devcontainer:
   extends: .build_devcontainer
-  stage: build
-  needs: []
+  stage: devcontainer
+  needs: [lint_devcontainer]
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'

--- a/.gitlab/devcontainer.yml
+++ b/.gitlab/devcontainer.yml
@@ -22,7 +22,7 @@ lint_devcontainer:
 test-devcontainer:
   extends: .build_devcontainer
   stage: test
-  needs: [lint_devcontainer]
+  needs: []
   rules:
     - if: '$CI_COMMIT_BRANCH != "main"'
   variables:
@@ -31,6 +31,6 @@ test-devcontainer:
 build-devcontainer:
   extends: .build_devcontainer
   stage: build
-  needs: [lint_devcontainer]
+  needs: []
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'


### PR DESCRIPTION
ACIX-419

To avoid blocking the builds, reworked devcontainer stages.
Now it is only one stage after the `build` stage and jobs are executed from the start of the pipeline.