### PR TITLE
feat(readme): Add a badge with the latest image version published from `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![Docker Image Version](https://img.shields.io/docker/v/datadog/agent-buildimages-deb_x64)
 # Datadog Agent builders
 
 This repo contains the Dockerfiles of the images used to build the rpm and deb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Datadog Agent builders
 
 ![Docker Image Version](https://img.shields.io/docker/v/datadog/agent-buildimages-deb_x64)
+![GitHub License](https://img.shields.io/github/license/datadog/datadog-agent-buildimages)
+
 This repo contains the Dockerfiles of the images used to build the rpm and deb
 packages for the Datadog [Agent][agent].
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Docker Image Version](https://img.shields.io/docker/v/datadog/agent-buildimages-deb_x64)
 # Datadog Agent builders
 
+![Docker Image Version](https://img.shields.io/docker/v/datadog/agent-buildimages-deb_x64)
 This repo contains the Dockerfiles of the images used to build the rpm and deb
 packages for the Datadog [Agent][agent].
 


### PR DESCRIPTION
Check the result [here](https://github.com/DataDog/datadog-agent-buildimages/blob/nschweitzer/badge/README.md)
Add the latest version published easy to see.
Copy of it seems not trivial (you have to click on the image then select)