### PR TITLE
Fix image releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -527,7 +527,7 @@ release_circleci_runner_gcr:
     - !reference [.on_default_branch_push]
   variables:
     IMG_SOURCES: datadog/agent-buildimages-circleci-runner${ECR_TEST_ONLY}:$IMAGE_VERSION
-    IMG_DESTINATIONS: agent-circleci-runner:$IMAGE_VERSION
+    IMG_DESTINATIONS: agent-circleci-runner${ECR_TEST_ONLY}:$IMAGE_VERSION
     IMG_REGISTRIES: gcr-datadoghq
   trigger:
     project: DataDog/public-images

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -536,7 +536,7 @@ release_circleci_runner_gcr:
     # They are not expended recursively and end up provided verbatim to the
     # downstream pipeline which then extends the variable with its own CI
     # variables, which causes invalid image tags to be used
-    IMG_SOURCES: datadog/agent-buildimages-circleci-runner${ECR_TEST_ONLY}:$IMAGE_VERSION
+    IMG_SOURCES: datadog/agent-buildimages-circleci-runner${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: agent-circleci-runner${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
     IMG_REGISTRIES: gcr-datadoghq
   trigger:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -513,8 +513,13 @@ dev_release_circleci_runner_gcr:
   rules:
     - !reference [.on_push]
   variables:
-    IMG_SOURCES: datadog/agent-buildimages-circleci-runner${ECR_TEST_ONLY}:$IMAGE_VERSION
-    IMG_DESTINATIONS: agent-circleci-runner${ECR_TEST_ONLY}:$IMAGE_VERSION
+    # Don't rely on ${IMAGE_VERSION} or any variables that is referencing
+    # other variables here.
+    # They are not expended recursively and end up provided verbatim to the
+    # downstream pipeline which then extends the variable with its own CI
+    # variables, which causes invalid image tags to be used
+    IMG_SOURCES: datadog/agent-buildimages-circleci-runner${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
+    IMG_DESTINATIONS: agent-circleci-runner${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
     IMG_REGISTRIES: gcr-datadoghq
   trigger:
     project: DataDog/public-images
@@ -526,8 +531,13 @@ release_circleci_runner_gcr:
   rules:
     - !reference [.on_default_branch_push]
   variables:
+    # Don't rely on ${IMAGE_VERSION} or any variables that is referencing
+    # other variables here.
+    # They are not expended recursively and end up provided verbatim to the
+    # downstream pipeline which then extends the variable with its own CI
+    # variables, which causes invalid image tags to be used
     IMG_SOURCES: datadog/agent-buildimages-circleci-runner${ECR_TEST_ONLY}:$IMAGE_VERSION
-    IMG_DESTINATIONS: agent-circleci-runner${ECR_TEST_ONLY}:$IMAGE_VERSION
+    IMG_DESTINATIONS: agent-circleci-runner${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
     IMG_REGISTRIES: gcr-datadoghq
   trigger:
     project: DataDog/public-images


### PR DESCRIPTION
A recent refactoring combined with a counter intuitive gitlab behavior was causing our image release jobs to systematically fail.
This PR fixes the variables we provide to `public-images` jobs, which should in turn allow us to publish our circle CI images