### PR TITLE
feat(deb-x64): Add `authanywhere` to call the `pr-commenter` service

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -223,6 +223,9 @@ RUN curl -LO https://releases.hashicorp.com/vault/$VAULT_VERSION/$VAULT_FILENAME
     && mv vault /usr/bin/vault \
     && chmod +x /usr/bin/vault
 
+# Install authanywhere to use the pr-commenter service https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3047457932/Pull+Request+Commenting+Service
+RUN curl -OL "binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-amd64" && mv "authanywhere-linux-amd64" /bin/authanywhere && chmod +x /bin/authanywhere
+
 # create the agent build folder within $GOPATH
 RUN mkdir -p /go/src/github.com/DataDog/datadog-agent
 


### PR DESCRIPTION
The `pr-commenter` is used on 2 places only
- [ebpf-complexity-changes](https://github.com/DataDog/datadog-agent/blob/main/.gitlab/kernel_matrix_testing/common.yml#L338)
- [notify](https://github.com/DataDog/datadog-agent/blob/main/.gitlab/notify/notify.yml#L112)

With `authanywhere` we will be able to use the new [pr-commenter service](https://datadoghq.atlassian.net/wiki/x/jISktQ), preventing use of a dedicated github app