### PR TITLE
upgrade perl's List::Util module (#677)

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -86,7 +86,7 @@ COPY .curlrc .wgetrc /root/
 # The dpkg version we want to install requires a more recent version of
 # gettext than the one shipped in ubuntu 14.04. Even though we disable i18n,
 # their buildsystem still needs gettext
-RUN curl -LO https://ftp.gnu.org/gnu/gettext/gettext-${GETTEXT_VERSION}.tar.xz \
+RUN curl -LO https://mirrors.ibiblio.org/pub/mirrors/gnu/gettext/gettext-${GETTEXT_VERSION}.tar.xz \
     && echo "${GETTEXT_SHA256}  gettext-${GETTEXT_VERSION}.tar.xz" | sha256sum --check \
     && tar xf "gettext-${GETTEXT_VERSION}.tar.xz" \
     && cd "gettext-${GETTEXT_VERSION}" \

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -68,6 +68,10 @@ RUN apt-get update \
     && apt-get install -y gcc-9 g++-9 \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 0
 
+# Upgrade some perl modules since some of our dependencies require some "new" features
+# that were not available in centos 7
+RUN cpanp -i List::Util 1.66
+
 # Ensure we're using the newest binutils
 ENV PATH "/usr/lib/binutils-2.26/bin:$PATH"
 

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -56,6 +56,10 @@ RUN curl -sL -O "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.t
     && rm -rf "binutils-${BINUTILS_VERSION}" \
     && rm -rf "binutils-${BINUTILS_VERSION}.tar.gz"
 
+# Upgrade some perl modules since some of our dependencies require some "new" features
+# that were not available in centos 7
+RUN cpanp -i List::Util 1.66
+
 # Build new rpm
 COPY patches/rpm-4.15.1-fix-rpmbuild-segfault.patch /tmp
 # Cannot use HTTPS here: cert name is invalid

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -47,7 +47,7 @@ RUN yum -y install @development which perl-core perl-ExtUtils-MakeMaker ncurses-
 COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
 
 # Upgrade binutils
-RUN curl -sL -O "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.gz" \
+RUN curl -sL -O "https://mirrors.ibiblio.org/pub/mirrors/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.gz" \
     && echo "${BINUTILS_SHA256}  ./binutils-${BINUTILS_VERSION}.tar.gz" | sha256sum --check \
     && tar -zxvf "./binutils-${BINUTILS_VERSION}.tar.gz" \
     && cd "binutils-${BINUTILS_VERSION}" \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -71,6 +71,10 @@ COPY --from=CERT_GETTER /cacert.pem /etc/pki/tls/certs/ca-bundle.crt
 # We install our own ruby, let's remove the system one. It made rvm fail to build ruby for some reason
 RUN yum remove -y ruby
 
+# Upgrade some perl modules since some of our dependencies require some "new" features
+# that were not available in centos 7
+RUN cpanp -i List::Util 1.66
+
 # External calls configuration
 COPY .awsconfig /root/.aws/config
 COPY .curlrc .wgetrc /root/

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -143,7 +143,7 @@ RUN /bin/bash -l -c "gem install bundler --version $BUNDLER_VERSION --no-documen
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /root/.bashrc
 
 # Upgrade binutils
-RUN curl -sL -O "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.gz" \
+RUN curl -sL -O "https://mirrors.ibiblio.org/pub/mirrors/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.gz" \
     && echo "${BINUTILS_SHA256}  ./binutils-${BINUTILS_VERSION}.tar.gz" | sha256sum --check \
     && tar -zxvf "./binutils-${BINUTILS_VERSION}.tar.gz" \
     && cd "binutils-${BINUTILS_VERSION}" \

--- a/suse-x64/Dockerfile
+++ b/suse-x64/Dockerfile
@@ -147,7 +147,7 @@ RUN curl -sSL -o rustup-init https://static.rust-lang.org/rustup/archive/${RUSTU
 ENV PATH "~/.cargo/bin:${PATH}"
 
 # Upgrade binutils
-RUN curl -sL -O "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.gz" \
+RUN curl -sL -O "https://mirrors.ibiblio.org/pub/mirrors/gnu/binutils/binutils-${BINUTILS_VERSION}.tar.gz" \
     && echo "${BINUTILS_SHA256}  ./binutils-${BINUTILS_VERSION}.tar.gz" | sha256sum --check \
     && tar -zxvf "./binutils-${BINUTILS_VERSION}.tar.gz" \
     && cd "binutils-${BINUTILS_VERSION}" \
@@ -160,7 +160,7 @@ RUN curl -sL -O "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_VERSION}.t
 ENV PATH="/usr/local/binutils/bin:$PATH"
 
 # xz needs gettext 0.19.6 or newer
-RUN curl -LO https://ftp.gnu.org/gnu/gettext/gettext-${GETTEXT_VERSION}.tar.xz \
+RUN curl -LO https://mirrors.ibiblio.org/pub/mirrors/gnu/gettext/gettext-${GETTEXT_VERSION}.tar.xz \
     && echo "${GETTEXT_SHA256}  gettext-${GETTEXT_VERSION}.tar.xz" | sha256sum --check \
     && tar xf "gettext-${GETTEXT_VERSION}.tar.xz" \
     && cd "gettext-${GETTEXT_VERSION}" \


### PR DESCRIPTION
* upgrade perl's List::Util module

OpenSSL's build system requires 1.29+ and we currently ship 1.27

* update List::Util on rpm arm64 as well

* pin a version of list util

This is needed to build OpenSSL 3.3.2