### PR TITLE
use build_ddregistry base job for new glibc toolchains

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -252,7 +252,7 @@ build_linux_glibc_2_17_x64:
     IMAGE: linux-glibc-2-17-x64
 
 build_linux_glibc_2_23_arm64:
-  extends: build_ddregistry .arm]
+  extends: [.build_ddregistry, .arm]
   variables:
     DOCKERFILE: linux-glibc-2.23-arm64/Dockerfile
     IMAGE: linux-glibc-2-23-arm64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -246,13 +246,13 @@ build_dd_agent_testing:
     IMAGE: dd-agent-testing
 
 build_linux_glibc_2_17_x64:
-  extends: [.build, .x64]
+  extends: [.build_ddregistry, .x64]
   variables:
     DOCKERFILE: linux-glibc-2.17-x64/Dockerfile
     IMAGE: linux-glibc-2-17-x64
 
 build_linux_glibc_2_23_arm64:
-  extends: [.build, .arm]
+  extends: build_ddregistry .arm]
   variables:
     DOCKERFILE: linux-glibc-2.23-arm64/Dockerfile
     IMAGE: linux-glibc-2-23-arm64


### PR DESCRIPTION
The non test_only ECR was cleaned up due to not being used in a while, which causes failures on main
This feels like a good opportunity to start deploying through registry.ddbuild.io