### PR TITLE
feat(vault): Adding in `dd-agent-testing` as well

### DIFF
--- a/dd-agent-testing/Dockerfile
+++ b/dd-agent-testing/Dockerfile
@@ -4,6 +4,9 @@ ENV BUNDLER_VERSION=1.17.3
 ARG CI_UPLOADER_VERSION=2.38.1
 ARG CI_UPLOADER_SHA=4e56d449e6396ae4c7356f07fc5372a28999aacb012d4343a3b8a9389123aa38
 ARG PYTHON_VERSION=3.11.8
+ARG VAULT_VERSION=1.17.2
+ARG VAULT_CHECKSUM=a0c0449e640c8be5dcf7b7b093d5884f6a85406dbb86bbad0ea06becad5aaab8
+ARG VAULT_FILENAME="vault_${VAULT_VERSION}_linux_amd64.zip"
 
 # External calls configuration
 COPY .awsconfig /root/.aws/config
@@ -42,6 +45,14 @@ RUN gem install bundler --version ${BUNDLER_VERSION}
 COPY dd-agent-testing/Gemfile dd-agent-testing/Gemfile.lock ./
 RUN bundle install
 RUN bundle show
+
+# Install vault: https://github.com/hashicorp/vault/blob/main/CHANGELOG.md https://releases.hashicorp.com/vault
+RUN curl -LO https://releases.hashicorp.com/vault/$VAULT_VERSION/$VAULT_FILENAME \
+    && echo "${VAULT_CHECKSUM}  ${VAULT_FILENAME}" | sha256sum --check \
+    && unzip $VAULT_FILENAME \
+    && rm $VAULT_FILENAME \
+    && mv vault /usr/bin/vault \
+    && chmod +x /usr/bin/vault
 
 # create the agent build folder within $GOPATH
 RUN mkdir -p /go/src/github.com/DataDog/datadog-agent


### PR DESCRIPTION
Last (hopefully) change in buildimages. Change tested in [this commit](https://github.com/DataDog/datadog-agent/commit/7909ebbc938c037e545b9d4d3d3cafa99f82b189) on the branch using vault in the `dd-agent-testing` image, jobs are [ok](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/671038283) (compared to previous pipeline execution where we [timeout](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/669612897#L459) in the `after_script`)