### PR TITLE
fix(winrelease): Remove last occurrences of SRC_TAG

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -471,8 +471,8 @@ build_windows_ltsc2022_x64:
       docker push 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:latest
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       If ("${DOCKERHUB_IMAGE}" -ne "") {
-        docker tag $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${SRC_TAG}
-        docker push datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${SRC_TAG}
+        docker tag $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${IMAGE_VERSION}
+        docker push datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${IMAGE_VERSION}
         If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
         docker tag $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}
         docker push datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}
@@ -480,12 +480,12 @@ build_windows_ltsc2022_x64:
       }
       "@ | out-file ci-scripts/docker-publish.ps1
     - cat ci-scripts/docker-publish.ps1
-    - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS_DD_WCS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine ${WINDOWS_RELEASE_IMAGE}:${SRC_TAG} powershell -C C:\mnt\ci-scripts\docker-publish.ps1
+    - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS_DD_WCS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine ${WINDOWS_RELEASE_IMAGE}:${IMAGE_VERSION} powershell -C C:\mnt\ci-scripts\docker-publish.ps1
   after_script:
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,8))
     - $SRC_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:${IMAGE_VERSION}"
     - docker rmi $SRC_IMAGE 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/${IMAGE}:latest
-    - If ("${DOCKERHUB_IMAGE}" -ne "") { docker rmi datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${SRC_TAG} $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX} }
+    - If ("${DOCKERHUB_IMAGE}" -ne "") { docker rmi datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${IMAGE_VERSION} $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX} }
 
 
 release_linux:


### PR DESCRIPTION
Since the integration of #684 [there were failures](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent-buildimages%22%20%40ci.job.name%3A%22release_windows%3A%20%5Bwindows_1809_x64%2C%201809%5D%22%20%40git.branch%3Amain&agg_m=count&agg_m_source=base&agg_t=count&colorBy=meta%5B%27ci.stage.name%27%5D&colorByAttr=meta%5B%27ci.stage.name%27%5D&currentTab=trace&fromUser=false&graphType=flamegraph&index=cipipeline&spanViewType=metadata&start=1721202690286&end=1728978690286&paused=false) on the `release_windows` jobs.
There were still occurrences of the `SRC_TAG` in the job script whereas this variable was removed. We can see on [this job](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/653854102) the use of [incomplete tags](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/653854102#L341) ending by `1809-`

Validation will be done once the PR is merged, unfortunately
