### PR TITLE
feat(notify): Use the more recent invoke task name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -577,7 +577,7 @@ notify-images-available:
     export MESSAGE="Your :docker: images with tag \`$IMAGE_VERSION\` are ready.
     :git: Branch <$BRANCH_URL|$CI_COMMIT_BRANCH> for commit \`$CI_COMMIT_TITLE\` (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>)
     :idea: You can test them in the \`datadog-agent\` repository by running:
-    \`\`\`inv pipeline.update-buildimages -i $IMAGE_VERSION [--no-test-version] [--branch-name <your_branch>]\`\`\`
+    \`\`\`inv buildimages.update -i $IMAGE_VERSION [--no-test-version] [--branch-name <your_branch>]\`\`\`
     Or run the \`trigger_tests\` manual job in your <$CI_PIPELINE_URL|pipeline>.
     "
     /usr/local/bin/notify.sh


### PR DESCRIPTION
We have 2 invoke tasks for buildimage update
- inv pipeline.buildimages-update
- inv buildimages.update
The latter one should be used now and we will deprecate the former one