### PR TITLE
Backport update to prevent failure in windows signing tool installation

### DIFF
--- a/windows/helpers/phase3/install_winsign.ps1
+++ b/windows/helpers/phase3/install_winsign.ps1
@@ -12,3 +12,4 @@ $codesign_wheel_target = "c:\devtools\$($codesign_base)"
 Get-RemoteFile -RemoteFile $codesign_wheel -LocalFile $codesign_wheel_target -VerifyHash $ENV:WINSIGN_SHA256
 
 python -m pip install $codesign_wheel_target
+If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }


### PR DESCRIPTION
Backport commit from #662 to prevent [failures](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/675804208/raw) in `dd_wcs`