### PR TITLE
Add 7zr

### DIFF
--- a/windows/helpers/phase1/install_7zip.ps1
+++ b/windows/helpers/phase1/install_7zip.ps1
@@ -11,7 +11,7 @@ $ErrorActionPreference = 'Stop'
 $isInstalled, $isCurrent = Get-InstallUpgradeStatus -Component "sevenzip" -Keyname "version" -TargetValue $Version
 
 if($isInstalled -and $isCurrent){
-    Write-Host "SevenZip already installed and current.  Skipping"
+    Write-Host "SevenZip already installed and current. Skipping"
     return
 }
 # assuming that exe installer would properly handle upgrade if we ever needed to

--- a/windows/helpers/phase1/install_7zip_standalone.ps1
+++ b/windows/helpers/phase1/install_7zip_standalone.ps1
@@ -1,0 +1,27 @@
+param (
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$true)][string]$Sha256
+)
+
+# Enabled TLS12
+$ErrorActionPreference = 'Stop'
+
+## check to see if this version is installed
+
+$isInstalled, $isCurrent = Get-InstallUpgradeStatus -Component "sevenzip_standalone" -Keyname "version" -TargetValue $Version
+
+if($isInstalled -and $isCurrent){
+    Write-Host "SevenZip Standalone already installed and current. Skipping"
+    return
+}
+
+# Script directory is $PSScriptRoot
+$sevenZipStandalone ="https://github.com/ip7z/7zip/releases/download/$Version/7zr.exe"
+
+Write-Host -ForegroundColor Green "Installing 7zip Standalone $sevenZipStandalone"
+Get-RemoteFile -RemoteFile $sevenZipStandalone -LocalFile "c:\program files\7-zip\7zr.exe" -VerifyHash $Sha256
+
+## Write the version key out to the registry
+Set-InstalledVersionKey -Component "sevenzip_standalone" -Keyname "Version" -TargetValue $Version
+
+Write-Host -ForegroundColor Green Done with 7zip Standalone

--- a/windows/helpers/phase4/install_datadog_package.ps1
+++ b/windows/helpers/phase4/install_datadog_package.ps1
@@ -1,0 +1,3 @@
+git clone --depth=1 https://github.com/DataDog/datadog-packages
+cd datadog-packages/cmd/datadog-package
+go build .

--- a/windows/install-all.ps1
+++ b/windows/install-all.ps1
@@ -55,6 +55,7 @@ try {
     if ($Phase -eq 0 -or $Phase -eq 1) {
         .\helpers\phase1\install_net35.ps1
         .\helpers\phase1\install_7zip.ps1 -Version $ENV:SEVENZIP_VERSION -Sha256 $ENV:SEVENZIP_SHA256
+        .\helpers\phase1\install_7zip_standalone.ps1 -Version $ENV:SEVENZIP_STANDALONE_VERSION -Sha256 $ENV:SEVENZIP_STANDALONE_SHA256
         .\helpers\phase1\install_mingit.ps1 -Version $ENV:GIT_VERSION -Sha256 $ENV:GIT_SHA256
         .\helpers\phase1\install_vstudio.ps1
         .\helpers\phase1\install_wdk.ps1

--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -5,6 +5,8 @@ $SoftwareTable = @{
     "WINGIT_SHA256"="b0442f1b8ea40b6f94ef9a611121d2c204f6aa7f29c54315d2ce59876c3d134e";
     "SEVENZIP_VERSION"="19.0.0";
     "SEVENZIP_SHA256"="0f5d4dbbe5e55b7aa31b91e5925ed901fdf46a367491d81381846f05ad54c45e";
+    "SEVENZIP_STANDALONE_VERSION"="24.08";
+    "SEVENZIP_STANDALONE_SHA256"="1B16C41AE39B679384B06F1492B587B650716430FF9C2E079DCA2AD1F62C952D";
 
     ## VisualStudio build tools for containers
     # https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history


### PR DESCRIPTION
This PR adds the standalone 7zip executable (7zr) to the buildimage. This executable is used in the compression and decompression of the embedded Python distribution on Windows.