### PR TITLE
bump datadog-api-client to 2.29.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -4,7 +4,7 @@ azure-identity==1.14.1
 azure-mgmt-resource==23.0.1
 boto3==1.28.45
 codeowners==0.6.0
-datadog-api-client==2.16.0
+datadog-api-client==2.29.0
 docker-squash==1.1.0
 docker==5.0.3; python_version < '3.7'
 docker==6.1.3; python_version >= '3.7'


### PR DESCRIPTION
bump datadog-api-client to latest version (2.29.0) to enable support Metrics Origin for Datadog Agent metrics ([BARX-572](https://datadoghq.atlassian.net/browse/BARX-572))

[BARX-572]: https://datadoghq.atlassian.net/browse/BARX-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ