### PR TITLE
[Docker-x64] Install Go

### DIFF
--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -1,6 +1,8 @@
 FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
 
 ARG PYTHON_VERSION=3.12.6
+ARG GO_VERSION
+ARG GO_SHA256_LINUX_ARM64
 ARG CI_UPLOADER_VERSION=2.38.1
 ARG CI_UPLOADER_SHA=90ee346ea639e2d70a45b70e2d1491e5749099665df06a2e6d80ddc9fd90fe0c
 ARG VAULT_VERSION=1.17.2
@@ -40,6 +42,15 @@ COPY requirements.txt /
 COPY requirements /requirements
 
 RUN pip install -r requirements.txt
+
+# Install Go
+RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-arm64.tar.gz \
+  && echo "$GO_SHA256_LINUX_ARM64  /tmp/golang.tar.gz" | sha256sum --check \
+  && tar -C /usr/local -xzf /tmp/golang.tar.gz \
+  && rm -f /tmp/golang.tar.gz
+ENV GOPATH /go
+ENV GO_VERSION $GO_VERSION
+ENV PATH="/go/bin:/usr/local/go/bin:${PATH}"
 
 # Install vault: https://github.com/hashicorp/vault/blob/main/CHANGELOG.md https://releases.hashicorp.com/vault
 RUN curl -LO https://releases.hashicorp.com/vault/$VAULT_VERSION/$VAULT_FILENAME \

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -9,7 +9,6 @@ ARG VAULT_VERSION=1.17.2
 ARG VAULT_CHECKSUM=a0c0449e640c8be5dcf7b7b093d5884f6a85406dbb86bbad0ea06becad5aaab8
 ARG VAULT_FILENAME="vault_${VAULT_VERSION}_linux_amd64.zip"
 
-
 RUN apt-get update &&  \
     DEBIAN_FRONTEND=noninteractive apt-get install -y make  \
       build-essential  \

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -1,11 +1,17 @@
 FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
 
 ARG PYTHON_VERSION=3.12.6
+ARG GO_VERSION
+ARG GO_SHA256_LINUX_AMD64
 ARG CI_UPLOADER_VERSION=2.38.1
 ARG CI_UPLOADER_SHA=4e56d449e6396ae4c7356f07fc5372a28999aacb012d4343a3b8a9389123aa38
 ARG VAULT_VERSION=1.17.2
 ARG VAULT_CHECKSUM=a0c0449e640c8be5dcf7b7b093d5884f6a85406dbb86bbad0ea06becad5aaab8
 ARG VAULT_FILENAME="vault_${VAULT_VERSION}_linux_amd64.zip"
+
+# Environment
+ENV GOPATH /go
+ENV GO_VERSION $GO_VERSION
 
 RUN apt-get update &&  \
     DEBIAN_FRONTEND=noninteractive apt-get install -y make  \
@@ -40,6 +46,16 @@ COPY requirements.txt /
 COPY requirements /requirements
 
 RUN pip install -r requirements.txt
+
+# Install Go
+RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz \
+  && echo "$GO_SHA256_LINUX_AMD64  /tmp/golang.tar.gz" | sha256sum --check \
+  && tar -C /usr/local -xzf /tmp/golang.tar.gz \
+  && rm -f /tmp/golang.tar.gz
+ENV GOPATH /go
+ENV GO_VERSION $GO_VERSION
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV PATH="${GOPATH}/bin:${PATH}"
 
 # Install vault: https://github.com/hashicorp/vault/blob/main/CHANGELOG.md https://releases.hashicorp.com/vault
 RUN curl -LO https://releases.hashicorp.com/vault/$VAULT_VERSION/$VAULT_FILENAME \

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -9,9 +9,6 @@ ARG VAULT_VERSION=1.17.2
 ARG VAULT_CHECKSUM=a0c0449e640c8be5dcf7b7b093d5884f6a85406dbb86bbad0ea06becad5aaab8
 ARG VAULT_FILENAME="vault_${VAULT_VERSION}_linux_amd64.zip"
 
-# Environment
-ENV GOPATH /go
-ENV GO_VERSION $GO_VERSION
 
 RUN apt-get update &&  \
     DEBIAN_FRONTEND=noninteractive apt-get install -y make  \

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -51,8 +51,7 @@ RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.t
   && rm -f /tmp/golang.tar.gz
 ENV GOPATH /go
 ENV GO_VERSION $GO_VERSION
-ENV PATH="/usr/local/go/bin:${PATH}"
-ENV PATH="${GOPATH}/bin:${PATH}"
+ENV PATH="/go/bin:/usr/local/go/bin:${PATH}"
 
 # Install vault: https://github.com/hashicorp/vault/blob/main/CHANGELOG.md https://releases.hashicorp.com/vault
 RUN curl -LO https://releases.hashicorp.com/vault/$VAULT_VERSION/$VAULT_FILENAME \


### PR DESCRIPTION
This PR installs Go on the docker-x64 build image. 

It is needed for the integration tests to run fine (see https://github.com/DataDog/datadog-agent/pull/30856)