### PR TITLE
[ASCII-1786][Deb ARM64] Update GCC from 5.4 to 9 to support Go 1.22

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -44,6 +44,15 @@ RUN apt-get update && apt-get install -y fakeroot curl git procps bzip2 \
     gettext libtool autopoint autoconf libtool-bin \
     selinux-basics default-jre flex wget
 
+# Ubuntu 16.04 comes with gcc 5.4 by default, which doesn't work with the race detector starting with Go 1.22
+# NOTE: we *could* uninstall gcc 4.8, but the "rvm requirements" run later on would reinstall
+# it and there's not way to prevent that. So leave it be and use update-alternatives to select 9
+RUN apt install -y software-properties-common \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && apt-get update \
+    && apt-get install -y gcc-9 g++-9 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 0
+
 # Update curl with a statically linked binary
 COPY --from=CURL_GETTER /curl-aarch64 /usr/local/bin/curl-aarch64
 COPY --from=CURL_GETTER /curl-armv7 /usr/local/bin/curl-armv7


### PR DESCRIPTION
The `tests_deb-arm64-py3` is currently [failing](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/708781836) on the `6.53.x` branch of `datadog-agent` with:
```
/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.8.linux-arm64/pkg/tool/linux_arm64/link: running gcc failed: exit status 1
/tmp/go-link-279306332/000025.o: In function `__sanitizer::DecreaseTotalMmap(unsigned long)':
gotsan.cpp:(.text+0x12fc): undefined reference to `__aarch64_ldadd8_acq_rel'
/tmp/go-link-279306332/000025.o: In function `__sanitizer_acquire_crash_state':
```
The job is [successful](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/708937910) with a recent image. I cherry-pick this commit as it's most probably what is missing in the current `6.53.x` image
