### PR TITLE
Unzip vault in a dedicated folder

### DIFF
--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -54,10 +54,10 @@ ENV PATH="/go/bin:/usr/local/go/bin:${PATH}"
 
 # Install vault: https://github.com/hashicorp/vault/blob/main/CHANGELOG.md https://releases.hashicorp.com/vault
 RUN curl -LO https://releases.hashicorp.com/vault/$VAULT_VERSION/$VAULT_FILENAME \
-    && echo "${VAULT_CHECKSUM}  ${VAULT_FILENAME}" | sha256sum --check \
-    && unzip $VAULT_FILENAME \
+    && echo "${VAULT_CHECKSUM} ${VAULT_FILENAME}" | sha256sum --check \
+    && unzip $VAULT_FILENAME -d /tmp/vault \
     && rm $VAULT_FILENAME \
-    && mv vault /usr/bin/vault \
+    && mv /tmp/vault/vault /usr/bin/vault \
     && chmod +x /usr/bin/vault
 
 # External calls configuration

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -54,10 +54,10 @@ ENV PATH="/go/bin:/usr/local/go/bin:${PATH}"
 
 # Install vault: https://github.com/hashicorp/vault/blob/main/CHANGELOG.md https://releases.hashicorp.com/vault
 RUN curl -LO https://releases.hashicorp.com/vault/$VAULT_VERSION/$VAULT_FILENAME \
-    && echo "${VAULT_CHECKSUM}  ${VAULT_FILENAME}" | sha256sum --check \
-    && unzip $VAULT_FILENAME \
+    && echo "${VAULT_CHECKSUM} ${VAULT_FILENAME}" | sha256sum --check \
+    && unzip $VAULT_FILENAME -d /tmp/vault \
     && rm $VAULT_FILENAME \
-    && mv vault /usr/bin/vault \
+    && mv /tmp/vault/vault /usr/bin/vault \
     && chmod +x /usr/bin/vault
 
 # External calls configuration


### PR DESCRIPTION
The build jobs for these images fail because we have a LICENSE.txt in `/`, which makes the `unzip` command fail. It seems like we now have vault 1.18.2 in the base image, but I prefer keeping the same version across all our build images. 

https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/725118798

Unziping vault in a dedicated folder is a better approach than doing it in `/` 