### PR TITLE
fix(devcontainer): Remove `distutils` from dependencies

### DIFF
--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get upgrade -y && \
     clang llvm bpfcc-tools libbpfcc-dev libelf-dev linux-headers-generic &&\
     # Python setup
     add-apt-repository -y 'ppa:deadsnakes/ppa' &&\
-    apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-distutils python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv &&\
+    apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv &&\
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists
 
 # Setup python3.12 as default


### PR DESCRIPTION
The build of the `devcontainer` image is [failing](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/pipelines?page=1&scope=finished&source=schedule&ref=main) since 07DEC24.
An update was done the 06DEC24 on [ppa:deadsnakes/ppa](https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu/dists/) which removed the `python3.12-distutils` from it.
![image](https://github.com/user-attachments/assets/326c6dc8-606f-4297-938e-861b4f16ada8)

According to [this thread](https://stackoverflow.com/questions/69858963/how-can-one-fully-replace-distutils-which-is-deprecated-in-3-10), `distutils` is fully replaced by `setuptools` from python `3.12` 