### PR TITLE
[ASCII-2595] Remove unused /root/.bashrc modification in setup_go.sh

### DIFF
--- a/setup_go.sh
+++ b/setup_go.sh
@@ -32,3 +32,8 @@ echo "Installing Microsoft Go"
 curl -SL -o /tmp/golang.tar.gz https://aka.ms/golang/release/latest/go${GO_VERSION}-1.linux-${GOARCH}.tar.gz
 echo "$MSGO_SHA256  /tmp/golang.tar.gz" | sha256sum --check
 mkdir /usr/local/msgo && tar --strip-components=1 -C /usr/local/msgo/ -xzf /tmp/golang.tar.gz && rm -f /tmp/golang.tar.gz;
+
+cat << EOF >> /root/.bashrc
+export PATH="/usr/local/go/bin:\$PATH"
+export GOROOT="/usr/local/go"
+EOF


### PR DESCRIPTION

### What does this PR do?

Cleans up `setup_go.sh` as the `/root/.bashrc` content is unused because we ended up managing the toolchain PATH with omnibus in the agent codebase (https://github.com/DataDog/datadog-agent/pull/31004/commits/dada6cbb431637c499d1407f1c43bb5a7b70baaf)

### Motivation

### Possible Drawbacks / Trade-offs

### Additional Notes
