### PR TITLE
fix(devenv): Prevent pulling newest version

### DIFF
--- a/dev-envs/linux/utils.sh
+++ b/dev-envs/linux/utils.sh
@@ -105,7 +105,7 @@ if [[ $arch == "x86_64" ]]; then
         --url "https://github.com/dalance/procs/releases/download/v{{version}}/procs-v{{version}}-${arch}-linux.zip" \
         --name "procs"
 else
-    cargo install procs@${PROCS_VERSION}
+    cargo install --locked procs@${PROCS_VERSION}
 fi
 procs --gen-config > "${HOME}/.procs.toml"
 # Necessary for working in our containers


### PR DESCRIPTION
### What does this PR do?
Prevent pulling package `home v0.5.11` which relies on rustc 1.81

### Motivation
Quick fix for the devenv build of arm64, see original failure [here](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/741500299)

### Possible Drawbacks / Trade-offs
According to the `cargo install` [documentation](https://doc.rust-lang.org/cargo/commands/cargo-install.html), the downside to using --locked is that you will not receive any fixes or updates to any dependency.
As a consequence we might consider bumping the `rustc` version instead

### Additional Notes
