### PR TITLE
chore(devcontainer): add container-platform as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,4 +46,4 @@ tasks/update_go.py                  @DataDog/agent-shared-components
 /docker-arm64/                      @DataDog/container-integrations @DataDog/agent-devx-infra
 /docker-x64/                        @DataDog/container-integrations @DataDog/agent-devx-infra
 /dev-envs/                          @DataDog/agent-devx-loops
-/devcontainer/                      @DataDog/container-platform
+/devcontainer/                      @DataDog/agent-devx-loops @DataDog/container-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,4 +46,4 @@ tasks/update_go.py                  @DataDog/agent-shared-components
 /docker-arm64/                      @DataDog/container-integrations @DataDog/agent-devx-infra
 /docker-x64/                        @DataDog/container-integrations @DataDog/agent-devx-infra
 /dev-envs/                          @DataDog/agent-devx-loops
-/devcontainer/                      @DataDog/agent-devx-loops
+/devcontainer/                      @DataDog/container-platform


### PR DESCRIPTION
### What does this PR do?

Add https://github.com/orgs/DataDog/teams/container-platform as codeowner for the `devcontainer` image.

### Motivation

Container Platform can help on working the `devcontainer` image.

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes

N/A
