### PR TITLE
fix(test): Prevent skipping and use correct image version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,6 @@ stages:
   - setup
   - build
   - availability_message
-  - trigger_build_kernels
   - test
   - dev_envs
   - devcontainer
@@ -325,7 +324,7 @@ build_gitlab_agent_deploy:
     IMAGE: gitlab_agent_deploy
 
 trigger_build_kernels:
-  stage: trigger_build_kernels
+  stage: test
   needs:
     ["build_kernel_version_testing_x64", "build_kernel_version_testing_arm64"]
   rules:

--- a/.gitlab/kernel_version_testing.yml
+++ b/.gitlab/kernel_version_testing.yml
@@ -4,6 +4,7 @@ stages:
 
 
 variables:
+  IMAGE_VERSION: "v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   LINUX_SRC_DIR: /tmp/kernel-src
   S3_DD_AGENT_OMNIBUS_KERNEL_VERSION_TESTING_URI: s3://dd-agent-omnibus/kernel-version-testing
 
@@ -48,7 +49,7 @@ variables:
 
 build_kernels_x64:
   extends: .build_kernels
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/kernel-version-testing_x64${ECR_TEST_ONLY}:v$PARENT_PIPELINE_ID
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/kernel-version-testing_x64${ECR_TEST_ONLY}:$IMAGE_VERSION
   tags: [ "runner:main" ]
   variables:
     ARCH: x86
@@ -59,7 +60,7 @@ build_kernels_x64:
 
 build_kernels_arm64:
   extends: .build_kernels
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/kernel-version-testing_arm64${ECR_TEST_ONLY}:v$PARENT_PIPELINE_ID
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/kernel-version-testing_arm64${ECR_TEST_ONLY}:$IMAGE_VERSION
   tags: [ "runner:docker-arm", "platform:arm64" ]
   variables:
     ARCH: arm64


### PR DESCRIPTION
### What does this PR do?
- Put the `trigger_build_kernels` and `trigger_tests` in the same stage
- Pass the correct image version to the `trigger_build_kernels` part

### Motivation
- Because of the "default" dependency mechanism of gitlab, the `trigger_tests` was skipped if the `trigger_build_kernels` was not run or failed
![image](https://github.com/user-attachments/assets/0196c2ff-0bf7-440b-8041-ecc724a9fba5)
![image](https://github.com/user-attachments/assets/d53bd4c9-b2cb-4137-b0dc-273b84a0c5d2)

- The `trigger_build_kernels` was [failing](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/772239490) because the image version was missing the commit sha
```
ERROR: Job failed: failed to pull image "registry.ddbuild.io/ci/datadog-agent-buildimages/kernel-version-testing_x64_test_only:v53412678" with specified policies
```

### Tests
- Now the `trigger_build_kernels` are [running](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/pipelines/53449342)
- The `trigger_test` is no more skipped
### Possible Drawbacks / Trade-offs

### Additional Notes
