### PR TITLE
feat(deb_x64): Install protocol buffer

### DIFF
--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -36,6 +36,9 @@ ARG CI_UPLOADER_SHA=4e56d449e6396ae4c7356f07fc5372a28999aacb012d4343a3b8a9389123
 ARG VAULT_VERSION=1.17.2
 ARG VAULT_CHECKSUM=a0c0449e640c8be5dcf7b7b093d5884f6a85406dbb86bbad0ea06becad5aaab8
 ARG VAULT_FILENAME="vault_${VAULT_VERSION}_linux_amd64.zip"
+ARG PROTOBUF_VERSION=29.3
+ARG PROTOBUF_CHECKSUM=3e866620c5be27664f3d2fa2d656b5f3e09b5152b42f1bedbf427b333e90021a
+ARG PROTOBUF_FILENAME="protoc-${PROTOBUF_VERSION}-linux-x86_64.zip"
 
 # Environment
 ENV GOPATH /go
@@ -224,6 +227,16 @@ RUN curl -LO https://releases.hashicorp.com/vault/${VAULT_VERSION}/${VAULT_FILEN
   echo "${VAULT_CHECKSUM} ${VAULT_FILENAME}" | sha256sum --check && \
   unzip -o ${VAULT_FILENAME} -d /usr/bin vault && \
   rm ${VAULT_FILENAME}
+
+
+# Install protobuf
+RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/${PROTOBUF_FILENAME} \
+    && echo "${PROTOBUF_CHECKSUM}  ${PROTOBUF_FILENAME}" | sha256sum --check \
+    && unzip -o ${PROTOBUF_FILENAME} -d protoc3 \
+    && mv protoc3/bin/* /usr/bin/ \
+    && mv protoc3/include/* /usr/include/ \
+    && rm -rf protoc3 \
+    && rm ${PROTOBUF_FILENAME}
 
 # create the agent build folder within $GOPATH
 RUN mkdir -p /go/src/github.com/DataDog/datadog-agent


### PR DESCRIPTION
### What does this PR do?
Install protocol buffer on the `dev_x64` image to test the generation of `.proto` files on the `datadog-agent` repository

### Motivation
https://datadoghq.atlassian.net/browse/ACIX-511
Tested on https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/53472414

### Possible Drawbacks / Trade-offs

### Additional Notes
