### PR TITLE
Add rpm2cpio & cpio into the x64 docker image

### DIFF
--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update &&  \
       libxmlsec1-dev  \
       libffi-dev  \
       liblzma-dev &&  \
+      rpm2cpio && \
+      cpio && \
     apt-get clean &&  \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -28,8 +28,8 @@ RUN apt-get update &&  \
       libxml2-dev  \
       libxmlsec1-dev  \
       libffi-dev  \
-      liblzma-dev &&  \
-      rpm2cpio && \
+      liblzma-dev \
+      rpm2cpio \
       cpio && \
     apt-get clean &&  \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### What does this PR do?

We need `rpm2cpio` and `cpio` to compute rpm packages size from `docker_x64` images

### Motivation

Needed for the following datadog-agent PR: [#33878](https://github.com/DataDog/datadog-agent/pull/33878)

### Possible Drawbacks / Trade-offs

### Additional Notes
