### PR TITLE
feat(security): Pin github-actions and enable automatic dependency update

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,8 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: pip
+    directory: /
     labels:
       - dependencies
       - python
@@ -11,3 +12,9 @@ updates:
       # pyyaml 6 is incompatible with awscli
       # see https://github.com/DataDog/datadog-agent-buildimages/pull/207
       - dependency-name: pyyaml
+  - package-ecosystem: github-actions
+    directory: /
+    labels:
+      - dependencies
+    schedule:
+      interval: monthly

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -37,12 +37,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref }}
 
       - name: Setup Python and pip
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: 3.x
 
@@ -56,7 +56,7 @@ jobs:
         run: |
           inv update-go -v "${{ inputs.go_version }}" --check-archive
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5.1.0
         id: autocommit
         with:
           # [push_to_datadog_agent] prefix trigger 'push_to_datadog_agent' gitlab job
@@ -65,7 +65,7 @@ jobs:
           create_branch: true
 
       - name: Create Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         if: ${{ inputs.open_pr && steps.autocommit.outputs.changes_detected }}
         with:
           # TODO: if minor update, add changelog to the PR body: https://tip.golang.org/doc/go1.21

--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -18,7 +18,7 @@ jobs:
           - SLACK_AGENT_CI_EXPERIENCE_REVIEWS_ID
           - SLACK_AGENT_DEVELOPER_TOOLS_REVIEWS_ID
     steps:
-      - uses: DataDog/slapr@master
+      - uses: DataDog/slapr@09a47ae5bb58e2983f1616cdb33bcef8e2dae521 # master
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           SLACK_CHANNEL_ID: "${{ secrets[matrix.channel_variables] }}"


### PR DESCRIPTION

### What does this PR do?
- Pin github-actions
- enable automatic dependency update

### Motivation
[Security](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/3034155880/Guide+How+to+Secure+Your+GitHub+Repositories#Secure-GitHub-Actions%2FWorkflows)

### Possible Drawbacks / Trade-offs

### Additional Notes
On top of that, the authorized actions are now listed in the repo configuration (only github, verified and listed actions are possible)
