### PR TITLE
Remove use of requirements files in btf-gen image

### DIFF
--- a/btf-gen/Dockerfile
+++ b/btf-gen/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG PYTHON_VERSION=3.12.6
+ARG DEVA_VERSION
+ARG DEVA_NO_DYNAMIC_DEPS
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
@@ -34,10 +36,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Python install
 ENV PYENV_ROOT="/.pyenv"
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+ENV DEVA_NO_DYNAMIC_DEPS=$DEVA_NO_DYNAMIC_DEPS
 
 RUN git clone --depth=1 https://github.com/pyenv/pyenv.git ${PYENV_ROOT} && \
      pyenv install ${PYTHON_VERSION} && \
-     pyenv global ${PYTHON_VERSION}
+     pyenv global ${PYTHON_VERSION} && \
+     pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${DEVA_VERSION}" && \
+     deva -v self dep sync -f legacy-build -f legacy-btf-gen && \
+     pyenv rehash
 
 COPY .awsconfig /root/.aws/config
 COPY .curlrc .wgetrc /root/
@@ -52,6 +58,3 @@ RUN git reset --hard 77a72987353fcae8ce330fd87d4c7afb7677a169 && \
     git submodule update --init
 
 RUN make -C src/ V=1 install
-
-COPY requirements ./
-RUN pip install -r btf-gen.txt


### PR DESCRIPTION
### Motivation

Correct an oversight from https://github.com/DataDog/datadog-agent-buildimages/pull/741