### PR TITLE
Fix developer image build

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -235,6 +235,5 @@ RUN echo "umask 0022" >> /root/.bashrc
 # Entrypoint - only for local usage, Kubernetes-based Gitlab runners overwrite this
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh
-RUN echo foo
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -235,5 +235,6 @@ RUN echo "umask 0022" >> /root/.bashrc
 # Entrypoint - only for local usage, Kubernetes-based Gitlab runners overwrite this
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh
+RUN echo foo
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dev-envs/linux/utils.sh
+++ b/dev-envs/linux/utils.sh
@@ -94,7 +94,7 @@ if [[ $arch == "x86_64" ]]; then
         --name "ambr" \
         --name "ambs"
 else
-    cargo install amber@${AMBR_VERSION}
+    cargo install --locked amber@${AMBR_VERSION}
 fi
 
 PROCS_VERSION="0.14.6"
@@ -119,7 +119,7 @@ if [[ $arch == "x86_64" ]]; then
         --url "https://github.com/KSXGitHub/parallel-disk-usage/releases/download/{{version}}/pdu-${arch}-unknown-linux-musl" \
         --name "pdu"
 else
-    cargo install parallel-disk-usage@${PDU_VERSION} --locked
+    cargo install --locked parallel-disk-usage@${PDU_VERSION}
 fi
 
 install-binary \

--- a/dev-envs/linux/utils.sh
+++ b/dev-envs/linux/utils.sh
@@ -111,15 +111,15 @@ procs --gen-config > "${HOME}/.procs.toml"
 # Necessary for working in our containers
 sed -i 's/show_self_parents = false/show_self_parents = true/' "${HOME}/.procs.toml"
 
-PDU_VERSION="0.9.3"
+PDU_VERSION="0.11.0"
 if [[ $arch == "x86_64" ]]; then
     install-binary \
         --version "${PDU_VERSION}" \
-        --digest "55346371fbffe0e095af335f20dba5c47289562c9fb2f3b0ecf2b3a6125ef158" \
+        --digest "7da2abd0c438e0317271b34e4122d1d5818b124e3d70867309d4a92bfb34ac69" \
         --url "https://github.com/KSXGitHub/parallel-disk-usage/releases/download/{{version}}/pdu-${arch}-unknown-linux-musl" \
         --name "pdu"
 else
-    cargo install parallel-disk-usage@${PDU_VERSION}
+    cargo install parallel-disk-usage@${PDU_VERSION} --locked
 fi
 
 install-binary \


### PR DESCRIPTION
### Motivation

Builds started [failing](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/822872324#L4926) due to a transitive dependency of a utility [using features](https://github.com/KSXGitHub/rounded-div/commit/7daf6e9f498661eea9d9181f151bb3d136bc29ac) that require a newer version of Rust. This properly uses the lock file of Rust applications when performing a manual installation in the case of no binaries for a particular platform/architecture combination.