### PR TITLE
[windows] Remove Windows Server 1809 container build and release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -436,14 +436,6 @@ push_to_datadog_agent:
     - If ($CI_JOB_STATUS -ne "success") { Write-Host "Build failed."; exit 0 }
     - If ($CI_PIPELINE_SOURCE -ne "schedule") { Write-Host "Image $SRC_IMAGE is available." } else { Write-Host "Scheduled pipeline, image push skipped." }
 
-build_windows_1809_x64:
-  extends: .winbuild
-  tags: ["runner:windows-docker", "windowsversion:1809"]
-  variables:
-    DOCKERFILE: windows/Dockerfile
-    IMAGE: windows_1809_x64
-    DD_TARGET_ARCH: x64
-
 build_windows_ltsc2022_x64:
   extends: .winbuild
   tags: ["runner:windows-docker", "windowsversion:2022"]
@@ -536,8 +528,6 @@ release_windows:
     DOCKERHUB_IMAGE: agent-buildimages-windows_x64
   parallel:
     matrix:
-      - IMAGE: windows_1809_x64
-        DOCKERHUB_TAG_PREFIX: 1809
       - IMAGE: windows_ltsc2022_x64
         DOCKERHUB_TAG_PREFIX: ltsc2022
 

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -1,24 +1,14 @@
 # Use the Microsoft-provided .NET Runtime 4.8 image as the base image
 # because installing it in the image with Chocolatey requires a reboot.
 
-# There is a bug in the February 11, 2020 update that makes commands fail in
-# docker containers (see: https://support.microsoft.com/en-us/help/4542617/you-might-encounter-issues-when-using-windows-server-containers-with-t)
-# To avoid that, there are two solutions:
-# - both the host and the container must have the February 11, 2020 update, or
-# - neither the host and the container must have the February 11, 2020 update.
-# Since our 1809 windows-docker host image does not have this update, we use a base
-# container image that does not have this update either (thus the 20200114 tag).
-# On the contrary, since our 1909 windows-docker host image does have this update,
-# we use a base container image that does have this update.
-# TODO: Once the 1809 windows-docker host image is updated, update the base container image.
-ARG BASE_IMAGE=mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
+ARG BASE_IMAGE=mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022
 
 FROM ${BASE_IMAGE}
 
 SHELL ["powershell", "-Command"]
 
 ARG WINDOWS_VERSION
-ENV WINDOWS_VERSION=${WINDOWS_VERSION:-1809}
+ENV WINDOWS_VERSION=${WINDOWS_VERSION:-2022}
 
 ARG DD_TARGET_ARCH
 ENV TARGET_ARCH=${DD_TARGET_ARCH:-x64}

--- a/windows/README.md
+++ b/windows/README.md
@@ -23,7 +23,7 @@ You need only the script itself and the Dockerfile (and [requirements.txt](requi
   .\dockerfile-to-powershell.py 
        -d .\Dockerfile 
        -p .\dockerfile-to-powershell-generated-sample.ps1
-       -a WINDOWS_VERSION=1809
+       -a WINDOWS_VERSION=2022
        -a DD_TARGET_ARCH=x64 
 ```
 


### PR DESCRIPTION
### What does this PR do?

Remove the Windows Server 1809 container build.

### Motivation

It is flaky, and not used anymore in Datadog repositories.

### Possible Drawbacks / Trade-offs

Since there is only one container now, we could remove the matrix jobs, but I'm keeping them in case they are of use in the future (eg. if we start having ltsc2025 containers).

### Additional Notes

n/a
