### PR TITLE
glibc images: cmake: default to release builds

### DIFF
--- a/linux-glibc-2.17-x64/toolchain.cmake
+++ b/linux-glibc-2.17-x64/toolchain.cmake
@@ -1,4 +1,4 @@
-set(CMAKE_BUILD_TYPE RelWithDebInfo)
+set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_RANLIB x86_64-unknown-linux-gnu-ranlib)

--- a/linux-glibc-2.23-arm64/toolchain.cmake
+++ b/linux-glibc-2.23-arm64/toolchain.cmake
@@ -1,4 +1,4 @@
-set(CMAKE_BUILD_TYPE RelWithDebInfo)
+set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_SYSTEM_PROCESSOR aarch64)
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_RANLIB aarch64-unknown-linux-gnu-ranlib)


### PR DESCRIPTION
### What does this PR do?

Switch the default cmake build types to release

### Motivation

If we produce artifacts that aren't stripped by omnibus, we don't want to include the debug symbols

### Possible Drawbacks / Trade-offs

### Additional Notes
