### PR TITLE
install kernel headers in glibc images

### DIFF
--- a/linux-glibc-2.17-x64/Dockerfile
+++ b/linux-glibc-2.17-x64/Dockerfile
@@ -30,7 +30,8 @@ RUN apt update -qy && apt install -y \
     python-is-python3 git cmake curl fakeroot procps bzip2 \
     pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libpq-dev libz-dev \
     rpm tar gettext autopoint autoconf clang libtool-bin \
-    pkg-config flex meson selinux-basics squashfs-tools gpg xz-utils gnupg2 patchelf cpio
+    pkg-config flex meson selinux-basics squashfs-tools gpg xz-utils gnupg2 patchelf cpio \
+    linux-headers-generic
 
 COPY linux-glibc-2.17-x64/config-x86_64-unknown-gnu-linux-glibc2.17 /build/crosstool-ng-${CTNG_VERSION}/.config
 COPY linux-glibc-2.17-x64/toolchain.cmake /opt/cmake/x86_64-unknown-linux-gnu.toolchain.cmake

--- a/linux-glibc-2.23-arm64/Dockerfile
+++ b/linux-glibc-2.23-arm64/Dockerfile
@@ -28,7 +28,8 @@ RUN apt update -qy && apt install -y \
     python-is-python3 git cmake curl fakeroot procps bzip2 \
     pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libpq-dev libz-dev \
     rpm tar gettext autopoint autoconf clang libtool-bin \
-    pkg-config flex meson selinux-basics squashfs-tools gpg xz-utils gnupg2 patchelf cpio
+    pkg-config flex meson selinux-basics squashfs-tools gpg xz-utils gnupg2 patchelf cpio \
+    linux-headers-generic
 
 COPY linux-glibc-2.23-arm64/config-aarch64-unknown-gnu-linux-glibc2.23 /build/crosstool-ng-${CTNG_VERSION}/.config
 COPY linux-glibc-2.23-arm64/toolchain.cmake /opt/cmake/aarch64-unknown-linux-gnu.toolchain.cmake


### PR DESCRIPTION
### What does this PR do?

install kernel headers in glibc images

### Motivation

kernel headers are needed for building eBPF object files

### Possible Drawbacks / Trade-offs

### Additional Notes
