### PR TITLE
fix Go package binaries by setting GOPATH

### DIFF
--- a/linux-glibc-2.17-x64/Dockerfile
+++ b/linux-glibc-2.17-x64/Dockerfile
@@ -97,8 +97,10 @@ RUN /bin/bash -l -c "gem install bundler --version $BUNDLER_VERSION --no-documen
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /root/.bashrc
 
 # Go
+ENV GOPATH=/go
 COPY setup_go.sh /
 RUN ./setup_go.sh
+ENV PATH="${GOPATH}/bin:${PATH}"
 
 # Rust is needed to compile the SDS library
 RUN curl -sSL -o rustup-init https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init \

--- a/linux-glibc-2.23-arm64/Dockerfile
+++ b/linux-glibc-2.23-arm64/Dockerfile
@@ -87,6 +87,7 @@ RUN /bin/bash -l -c "gem install bundler --version $BUNDLER_VERSION --no-documen
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /root/.bashrc
 
 # Go
+ENV GOPATH=/go
 COPY setup_go.sh /
 RUN ./setup_go.sh
 ENV PATH="${GOPATH}/bin:${PATH}"

--- a/setup_go.sh
+++ b/setup_go.sh
@@ -38,7 +38,7 @@ if [ "\$DD_GO_TOOLCHAIN" = "msgo" ]; then
     export PATH="/usr/local/msgo/bin:\$PATH"
     export GOROOT="/usr/local/msgo"
 else
-   export PATH="/usr/local/go/bin:\$PATH"
-   export GOROOT="/usr/local/go"
+    export PATH="/usr/local/go/bin:\$PATH"
+    export GOROOT="/usr/local/go"
 fi
 EOF


### PR DESCRIPTION
### What does this PR do?

fix Go package binaries by setting GOPATH. I believe not setting `GOPATH` and adding it to the path was causing the below error.

### Motivation

Errors such as `/bin/bash: line 1: golangci-lint: command not found` from `dda inv -e install-tools`

### Possible Drawbacks / Trade-offs

### Additional Notes
