### PR TITLE
add libc6-dev-i386 to fix error

### DIFF
--- a/linux-glibc-2.17-x64/Dockerfile
+++ b/linux-glibc-2.17-x64/Dockerfile
@@ -33,7 +33,7 @@ RUN apt update -qy && apt install -y \
     pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libpq-dev libz-dev \
     rpm tar gettext autopoint autoconf clang libtool-bin \
     pkg-config flex meson selinux-basics squashfs-tools gpg xz-utils gnupg2 patchelf cpio \
-    linux-headers-generic
+    linux-headers-generic libc6-dev-i386
 
 COPY linux-glibc-2.17-x64/config-x86_64-unknown-gnu-linux-glibc2.17 /build/crosstool-ng-${CTNG_VERSION}/.config
 COPY linux-glibc-2.17-x64/toolchain.cmake /opt/cmake/x86_64-unknown-linux-gnu.toolchain.cmake


### PR DESCRIPTION
### What does this PR do?

Adds `libc6-dev-i386` package to fix build of CWS `syscall-tester`

### Motivation

error: `/usr/include/x86_64-linux-gnu/gnu/stubs.h:7:11: fatal error: 'gnu/stubs-32.h' file not found`

https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/847449979

### Possible Drawbacks / Trade-offs

### Additional Notes

See https://gcc.gnu.org/wiki/FAQ#gnu_stubs-32.h