### PR TITLE
[push_to_datadog_agent] Update go version to 1.23.7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -405,6 +405,7 @@ push_to_datadog_agent:
     BRANCH: buildimages/$CI_COMMIT_BRANCH
     IMAGES_ID: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
   script:
+    - source /root/.bashrc
     - set -o pipefail
     # Get the current go version from the go.env file
     - >

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -396,7 +396,7 @@ push_to_datadog_agent:
       when: never
     - !reference [.on_push]
   tags: ["arch:amd64"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/python:3.12.8
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:v58799063-651eeeea
   variables:
     SSM_GITHUB_APP_KEY: ci.datadog-agent.platform-github-app-key
     GITHUB_INSTALLATION_ID: 45116690
@@ -414,9 +414,9 @@ push_to_datadog_agent:
     # Read the Github app private token from AWS SSM
     - export GITHUB_KEY_B64=$(aws ssm get-parameter --region us-east-1 --name $SSM_GITHUB_APP_KEY --with-decryption --query "Parameter.Value" --out text)
     - export DDA_VERSION=$(grep DDA_VERSION dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')
-    - pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}"
+    - pip install "dda==${DDA_VERSION}"
     - dda -v self dep sync -f legacy-build
-    - inv update-datadog-agent-buildimages --images-id "$IMAGES_ID" --ref "$REF" --branch "$BRANCH" --test-version
+    - dda inv update-datadog-agent-buildimages --images-id "$IMAGES_ID" --ref "$REF" --branch "$BRANCH" --test-version
 
 .winbuild: &winbuild
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -396,7 +396,7 @@ push_to_datadog_agent:
       when: never
     - !reference [.on_push]
   tags: ["arch:amd64"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10-py3
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/python:3.12.8
   variables:
     SSM_GITHUB_APP_KEY: ci.datadog-agent.platform-github-app-key
     GITHUB_INSTALLATION_ID: 45116690


### PR DESCRIPTION
### What does this PR do?
Change the image used during the `push_to_datadog_agent` job

### Motivation
Current image has a too old python version for dda compatibility, see [error job](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/847545279)

### Possible Drawbacks / Trade-offs

### Additional Notes
