### PR TITLE
Persist the telemetry API key throughout container lifecycle

### DIFF
--- a/dev-envs/linux/entrypoint.sh
+++ b/dev-envs/linux/entrypoint.sh
@@ -26,6 +26,7 @@ if ! [[ -f "${startup_indicator}" ]]; then
 
     # Enable telemetry if the API key is set
     if [[ -n "${DDA_TELEMETRY_API_KEY:-}" ]]; then
+        set-ev DDA_TELEMETRY_API_KEY "${DDA_TELEMETRY_API_KEY}"
         dda self telemetry enable
     fi
 


### PR DESCRIPTION
### Motivation

Avoid having to pass the key during other user actions