### PR TITLE
Do not build developer images on scheduled pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,7 +193,6 @@ lint_dockerfiles:
 .build_dev_env:
   stage: build
   rules:
-    - if: $CI_COMMIT_TAG == null
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,6 +192,10 @@ lint_dockerfiles:
 
 .build_dev_env:
   stage: build
+  rules:
+    - if: $CI_COMMIT_TAG == null
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
   script:
     # Docker Hub login
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
### Motivation

Build images do not get pushed on scheduled pipelines so there is no base image