### PR TITLE
Revert "Add libsystemd-dev needed to build the agent in the devenv"

### DIFF
--- a/dev-envs/linux/Dockerfile
+++ b/dev-envs/linux/Dockerfile
@@ -13,10 +13,6 @@ COPY scripts /root/.scripts
 COPY scripts.sh /setup/scripts.sh
 RUN /setup/scripts.sh
 
-# Set up build dependencies
-COPY build-deps.sh /setup/build-deps.sh
-RUN /setup/build-deps.sh
-
 # We set up shells first so that config can be modified as part of subsequent steps.
 # Shells require scripts to set environment variables and add to PATH. These same
 # scripts require the shells to be set up, leaving us with a cyclical dependency.

--- a/dev-envs/linux/build-deps.sh
+++ b/dev-envs/linux/build-deps.sh
@@ -1,5 +1,0 @@
-#!/bin/bash -l
-set -euxo pipefail
-
-apt-get update && apt-get install -y libsystemd-dev
-


### PR DESCRIPTION
Reverts DataDog/datadog-agent-buildimages#805

The base images are now able to build themselves and the developer images are now always in sync with them:

- https://github.com/DataDog/datadog-agent-buildimages/pull/810
- https://github.com/DataDog/datadog-agent-buildimages/pull/807