### PR TITLE
feat(ci): Use another github action to enable bot signed commits

### DIFF
--- a/.dda/extend/commands/run/update/go/__init__.py
+++ b/.dda/extend/commands/run/update/go/__init__.py
@@ -41,7 +41,7 @@ def _get_expected_sha256(version: str, base_url: str) -> list[tuple[Platform, st
     for os, arch in PLATFORMS:
         ext = _get_archive_extension(os)
         url = f"{base_url}/go{version}.{os}-{arch}.{ext}.sha256"
-        res = httpx.get(url)
+        res = httpx.get(url, follow_redirects=True)
         res.raise_for_status()
 
         # Handle both format "<sha256>" and "<sha256>..<filename>"
@@ -80,7 +80,7 @@ def _check_archive(app: Application, version: str, shas: list[tuple[Platform, st
         app.display(f"[check-archive] Fetching archive at {url}")
         # Using `curl` through `ctx.run` takes way too much time due to the archive being huge
         # use `requests` as a workaround
-        req = httpx.get(url)
+        req = httpx.get(url, follow_redirects=True)
         sha = hashlib.sha256(req.content).hexdigest()
         if sha != expected_sha:
             message = f"The SHA256 of Go on {os}/{arch} should be {expected_sha}, but got {sha}"

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -56,29 +56,15 @@ jobs:
         run: |
           dda run update go "${{ inputs.go_version }}" --check-archive
 
-      - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
-        id: autocommit
-        with:
-          # [push_to_datadog_agent] prefix trigger 'push_to_datadog_agent' gitlab job
-          commit_message: "[push_to_datadog_agent] Update go version to ${{ inputs.go_version }}"
-          branch: ${{ env.BRANCH_NAME }}
-          create_branch: true
-
       - name: Create Pull Request
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        if: ${{ inputs.open_pr && steps.autocommit.outputs.changes_detected }}
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        if: ${{ inputs.open_pr }}
         with:
-          # TODO: if minor update, add changelog to the PR body: https://tip.golang.org/doc/go1.21
-          script: |
-            github.rest.pulls.create({
-              title: `Update Go version to ${{ inputs.go_version }}`,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              head: "${{ env.BRANCH_NAME }}",
-              base: context.ref,
-              draft: ${{ inputs.draft }},
-              body: [
-                '## Update docker images to Go ${{ inputs.go_version }}',
-                'For more information about this version, see the [Go release notes](https://golang.org/doc/devel/release.html#go${{ inputs.go_version }}) and the [Github milestone](https://github.com/golang/go/issues?q=milestone%3AGo${{ inputs.go_version }}+label%3ACherryPickApproved).',
-              ].join('\n')
-            });
+          commit-message: "[push_to_datadog_agent] Update go version to ${{ inputs.go_version }}"
+          branch: ${{ env.BRANCH_NAME }}
+          sign-commits: true
+          title: "Update Go version to ${{ inputs.go_version }}"
+          body: |
+              ## Update docker images to Go ${{ inputs.go_version }}',
+              For more information about this version, see the [Go release notes](https://golang.org/doc/devel/release.html#go${{ inputs.go_version }}) and the [Github milestone](https://github.com/golang/go/issues?q=milestone%3AGo${{ inputs.go_version }}+label%3ACherryPickApproved)
+          draft: ${{ inputs.draft }}

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -65,6 +65,6 @@ jobs:
           sign-commits: true
           title: "Update Go version to ${{ inputs.go_version }}"
           body: |
-              ## Update docker images to Go ${{ inputs.go_version }}',
+              ## Update docker images to Go ${{ inputs.go_version }}
               For more information about this version, see the [Go release notes](https://golang.org/doc/devel/release.html#go${{ inputs.go_version }}) and the [Github milestone](https://github.com/golang/go/issues?q=milestone%3AGo${{ inputs.go_version }}+label%3ACherryPickApproved)
           draft: ${{ inputs.draft }}


### PR DESCRIPTION
### What does this PR do?
Replace usage of `stefanzweifel/git-auto-commit-action` by `peter-evans/create-pull-request`

### Motivation
Enable signed commits for bots
https://datadoghq.atlassian.net/browse/ACIX-856

### Possible Drawbacks / Trade-offs

### Additional Notes
[Tried](https://github.com/DataDog/datadog-agent-buildimages/actions/runs/14760277887/job/41439031850) to test the workflow creation there is probably something else to fix.
After several attempts, managed to create https://github.com/DataDog/datadog-agent-buildimages/pull/827
