### PR TITLE
Fix developer image build trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,6 +193,7 @@ lint_dockerfiles:
 .build_dev_env:
   stage: build
   rules:
+    - if: $CI_COMMIT_TAG == null
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
   script:


### PR DESCRIPTION
### Motivation

Reverting the suggestion [here](https://github.com/DataDog/datadog-agent-buildimages/pull/808#discussion_r2049249094) because the image has not been built since