### PR TITLE
Set compiler related environment variables in the glibc images

### DIFF
--- a/linux-glibc-2.17-x64/Dockerfile
+++ b/linux-glibc-2.17-x64/Dockerfile
@@ -41,6 +41,9 @@ COPY linux-glibc-2.17-x64/config-aarch64-unknown-gnu-linux-glibc2.23 /build/cros
 COPY linux-glibc-2.17-x64/toolchain_x86-64.cmake /opt/cmake/x86_64-unknown-linux-gnu.toolchain.cmake
 COPY linux-glibc-2.17-x64/cargo-config.toml ${HOME}/.cargo/config.toml
 COPY linux-glibc-2.17-x64/ctng.patch /root/ctng.patch
+ENV DD_CC="x86_64-unknown-linux-gnu-gcc"
+ENV DD_CXX="x86_64-unknown-linux-gnu-g++"
+ENV DD_CMAKE_TOOLCHAIN="/opt/cmake/x86_64-unknown-linux-gnu.toolchain.cmake"
 
 RUN git config --global user.email "package@datadoghq.com"
 RUN git config --global user.name "Bits"

--- a/linux-glibc-2.23-arm64/Dockerfile
+++ b/linux-glibc-2.23-arm64/Dockerfile
@@ -39,6 +39,9 @@ COPY linux-glibc-2.23-arm64/config-x86_64-unknown-gnu-linux-glibc2.17 /build/cro
 COPY linux-glibc-2.23-arm64/toolchain_aarch64.cmake /opt/cmake/aarch64-unknown-linux-gnu.toolchain.cmake
 COPY linux-glibc-2.23-arm64/cargo-config.toml ${HOME}/.cargo/config.toml
 COPY linux-glibc-2.17-x64/ctng.patch /root/ctng.patch
+ENV DD_CC="aarch64-unknown-linux-gnu-gcc"
+ENV DD_CXX="aarch64-unknown-linux-gnu-g++"
+ENV DD_CMAKE_TOOLCHAIN="/opt/cmake/aarch64-unknown-linux-gnu.toolchain.cmake"
 
 RUN git config --global user.email "package@datadoghq.com"
 RUN git config --global user.name "Bits"

--- a/linux-glibc-2.23-arm64/Dockerfile
+++ b/linux-glibc-2.23-arm64/Dockerfile
@@ -38,7 +38,7 @@ COPY linux-glibc-2.23-arm64/config-aarch64-unknown-gnu-linux-glibc2.23 /build/cr
 COPY linux-glibc-2.23-arm64/config-x86_64-unknown-gnu-linux-glibc2.17 /build/crosstool-ng-${CTNG_VERSION}/.config-x86
 COPY linux-glibc-2.23-arm64/toolchain_aarch64.cmake /opt/cmake/aarch64-unknown-linux-gnu.toolchain.cmake
 COPY linux-glibc-2.23-arm64/cargo-config.toml ${HOME}/.cargo/config.toml
-COPY linux-glibc-2.17-x64/ctng.patch /root/ctng.patch
+COPY linux-glibc-2.23-arm64/ctng.patch /root/ctng.patch
 ENV DD_CC="aarch64-unknown-linux-gnu-gcc"
 ENV DD_CXX="aarch64-unknown-linux-gnu-g++"
 ENV DD_CMAKE_TOOLCHAIN="/opt/cmake/aarch64-unknown-linux-gnu.toolchain.cmake"


### PR DESCRIPTION
### What does this PR do?

Sets the variables that our build uses to choose the compiler in the build images themselves. These are currently set in individual jobs (like [this](https://github.com/DataDog/datadog-agent/blob/17d59676586027c4684d69a94ffc5a9e60332abb/.gitlab/package_build/linux.yml#L42-L44)), and mainly come into effect via [some omnibus code](https://github.com/DataDog/omnibus-ruby/blob/7fbd2effc5a4308e48529d2d2dab38bd58b76ace/lib/omnibus/software.rb#L795-L807).

### Motivation

As part of [BARX-953](https://datadoghq.atlassian.net/browse/BARX-953) and to make https://github.com/DataDog/datadog-agent/pull/36423 work without having to dynamically determine the architecture of the system or require the user to provide this information.

This could also let us not need to specify these vars for specific jobs, and to some extent reduce coupling between build images and CI jobs.

### Possible Drawbacks / Trade-offs

None, I think, because these variables are only used by our own build tooling.

### Additional Notes


[BARX-953]: https://datadoghq.atlassian.net/browse/BARX-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ