### PR TITLE
fix(release): Push to ecr from the runners and to docker with `public-images`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,12 +13,6 @@ stages:
   - notify
 
 variables:
-  # To release Windows images, we need tools that are not necessarily present on the Windows Gitlab runners
-  # (eg. updated versions of awscli, tools to sign images - if we decide to sign buildimages some day)
-  # Thus, to release buildimages, we do the same thing as what we do in the Agent: we run the Docker publish script in
-  # the buildimage for the highest Windows version supported.
-  # This image must use the same Windows version as the Windows version of the Gitlab runner used in .winrelease
-  WINDOWS_RELEASE_IMAGE: $BUILDENV_REGISTRY/ci/datadog-agent-buildimages/windows_ltsc2022_x64
   SETUP_IMAGE_NAME: $BUILDENV_REGISTRY/ci/datadog-agent-buildimages/deb_x64:v62994096-9c8f38f2 # Image used during setup task, must contains pyinvoke
   S3_CP_CMD: aws s3 cp $S3_CP_OPTIONS
   S3_PERMANENT_ARTIFACTS_URI: s3://dd-ci-persistent-artefacts-build-stable/datadog-agent
@@ -396,36 +390,20 @@ release_windows:
     IMAGE: windows_ltsc2022_x64
     DOCKERHUB_TAG_PREFIX: ltsc2022
   script:
+    - $ErrorActionPreference = "Stop"
+    - Set-PSDebug -Trace 1
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $SRC_IMAGE = "registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:${IMAGE_VERSION}"
-    - mkdir ci-scripts
     - docker pull $SRC_IMAGE
-    - |
-      @"
-      Set-PSDebug -Trace 1
-      `$ErrorActionPreference = "Stop"
-      # ECR Login
-      `$AWS_ECR_PASSWORD = aws ecr get-login-password --region us-east-1
-      docker login --username AWS --password "`$AWS_ECR_PASSWORD" 486234852809.dkr.ecr.us-east-1.amazonaws.com
-      # DockerHub login
-      `$DOCKER_REGISTRY_LOGIN = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text
-      `$DOCKER_REGISTRY_PWD = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text
-      docker login --username "`$DOCKER_REGISTRY_LOGIN" --password "`$DOCKER_REGISTRY_PWD" docker.io
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      docker tag $SRC_IMAGE registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:latest
-      docker push registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:latest
-      If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      If ("${DOCKERHUB_IMAGE}" -ne "") {
-        docker tag $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${IMAGE_VERSION}
-        docker push datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${IMAGE_VERSION}
-        If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-        docker tag $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}
-        docker push datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}
-        If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
-      }
-      "@ | out-file ci-scripts/docker-publish.ps1
-    - cat ci-scripts/docker-publish.ps1
-    - docker run --rm -w C:\mnt -e AWS_NETWORKING=true -e SIGN_WINDOWS_DD_WCS=true -v "$(Get-Location):C:\mnt" -v \\.\pipe\docker_engine:\\.\pipe\docker_engine ${WINDOWS_RELEASE_IMAGE}:${IMAGE_VERSION} powershell -C C:\mnt\ci-scripts\docker-publish.ps1
+    - docker tag $SRC_IMAGE registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:latest
+    - docker push registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:latest
+    - If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+    - docker tag $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${IMAGE_VERSION}
+    - docker push datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${IMAGE_VERSION}
+    - If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+    - docker tag $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}
+    - docker push datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}
+    - If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
   after_script:
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,8))
     - $SRC_IMAGE = "registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:${IMAGE_VERSION}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -359,75 +359,7 @@ build_windows_ltsc2022_x64:
     - If ($CI_JOB_STATUS -ne "success") { Write-Host "Build failed."; exit 0 }
     - If ($CI_PIPELINE_SOURCE -ne "schedule") { Write-Host "Image $SRC_IMAGE is available." } else { Write-Host "Scheduled pipeline, image push skipped." }
 
-.release:
-  stage: release
-  rules:
-    - !reference [.on_default_branch_push]
-  tags: ["arch:amd64"]
-  image: "${CI_IMAGE}"
-  variables:
-    SRC_IMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE:$IMAGE_VERSION
-  script:
-    # Tag as latest in internal registry
-    - crane tag $SRC_IMAGE latest
-    # Copy to public dockerhub registry and also tag as latest
-    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin docker.io
-    - crane copy $SRC_IMAGE datadog/agent-buildimages-$IMAGE:$IMAGE_VERSION
-    - crane tag datadog/agent-buildimages-$IMAGE:$IMAGE_VERSION latest
-
-release_windows:
-  stage: release
-  # rules:
-    # - !reference [.on_default_branch_push]
-  tags: ["windows-v2:2022"]
-  id_tokens:
-    CI_IDENTITY_GITLAB_JWT:
-      aud: https://vault.us1.ddbuild.io
-  variables:
-    CI_IDENTITY_ROLE_NAME_OVERRIDE: windows-ci-tmp-gitlab-id-token-datadog-agent-buildimages-all-refs
-    DOCKERHUB_IMAGE: agent-buildimages-windows_x64
-    IMAGE: windows_ltsc2022_x64_test_only
-    DOCKERHUB_TAG_PREFIX: ltsc2022
-  script:
-    - $ErrorActionPreference = "Stop"
-    - Set-PSDebug -Trace 1
-    - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
-    - $SRC_IMAGE = "registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:${IMAGE_VERSION}"
-    - docker pull $SRC_IMAGE
-    - docker tag $SRC_IMAGE registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:latest
-    - docker push registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:latest
-    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
-    # DockerHub login and push
-    - $DOCKER_REGISTRY_LOGIN = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text
-    - $DOCKER_REGISTRY_PWD = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text
-    - docker login --username "$DOCKER_REGISTRY_LOGIN" --password "$DOCKER_REGISTRY_PWD" docker.io
-    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
-    - docker tag $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${IMAGE_VERSION}
-    - docker push datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${IMAGE_VERSION}
-    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
-    - docker tag $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}
-    - docker push datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}
-    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
-  after_script:
-    - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,8))
-    - $SRC_IMAGE = "registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:${IMAGE_VERSION}"
-    - docker rmi $SRC_IMAGE registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:latest
-    - If ("${DOCKERHUB_IMAGE}" -ne "") { docker rmi datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${IMAGE_VERSION} $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX} }
-
-release_linux:
-  extends: .release
-  parallel:
-    matrix:
-      - IMAGE:
-        - deb_x64
-        - rpm_x64
-        - deb_arm64
-        - rpm_arm64
-        - linux-glibc-2-17-x64
-        - linux-glibc-2-23-arm64
-
-release_dev_env_linux:
+release:
   stage: release
   rules:
     - !reference [.on_default_branch_push]
@@ -438,8 +370,24 @@ release_dev_env_linux:
   variables:
     IMG_REGISTRIES: dockerhub
     IMG_SIGNING: "false"
-    IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-linux:x64,registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-linux:aarch64
-    IMG_DESTINATIONS: agent-dev-env-linux:latest,agent-dev-env-linux:v$IMAGE_VERSION
+  parallel:
+    matrix:
+      - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-linux:x64,registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-linux:aarch64
+        IMG_DESTINATIONS: agent-dev-env-linux:latest,agent-dev-env-linux:v$IMAGE_VERSION
+      - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64
+        IMG_DESTINATIONS: agent-buildimages-deb_x64:latest,agent-buildimages-deb_x64:v$IMAGE_VERSION
+      - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_arm64
+        IMG_DESTINATIONS: agent-buildimages-deb_arm64:latest,agent-buildimages-deb_arm64:v$IMAGE_VERSION
+      - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_x64
+        IMG_DESTINATIONS: agent-buildimages-rpm_x64:latest,agent-buildimages-rpm_x64:v$IMAGE_VERSION
+      - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_arm64
+        IMG_DESTINATIONS: agent-buildimages-rpm_arm64:latest,agent-buildimages-rpm_arm64:v$IMAGE_VERSION
+      - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-17-x64
+        IMG_DESTINATIONS: agent-buildimages-linux-glibc-2-17-x64:latest,agent-buildimages-linux-glibc-2-17-x64:v$IMAGE_VERSION
+      - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-23-arm64
+        IMG_DESTINATIONS: agent-buildimages-linux-glibc-2-23-arm64:latest,agent-buildimages-linux-glibc-2-23-arm64:v$IMAGE_VERSION
+      - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/windows_ltsc2022_x64
+        IMG_DESTINATIONS: agent-buildimages-windows_x64:ltsc2022,agent-buildimages-windows_x64:ltsc2022-v$IMAGE_VERSION
 
 notify-images-available:
   extends: .slack-notifier-base

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -378,16 +378,16 @@ build_windows_ltsc2022_x64:
 
 release_windows:
   stage: release
-  rules:
-    - !reference [.on_default_branch_push]
+  # rules:
+    # - !reference [.on_default_branch_push]
   tags: ["windows-v2:2022"]
   id_tokens:
     CI_IDENTITY_GITLAB_JWT:
       aud: https://vault.us1.ddbuild.io
   variables:
     CI_IDENTITY_ROLE_NAME_OVERRIDE: windows-ci-tmp-gitlab-id-token-datadog-agent-buildimages-all-refs
-    DOCKERHUB_IMAGE: agent-buildimages-windows_x64
-    IMAGE: windows_ltsc2022_x64
+    DOCKERHUB_IMAGE: agent-buildimages-windows_x64_test_only
+    IMAGE: windows_ltsc2022_x64_test_only
     DOCKERHUB_TAG_PREFIX: ltsc2022
   script:
     - $ErrorActionPreference = "Stop"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -361,8 +361,8 @@ build_windows_ltsc2022_x64:
 
 release:
   stage: release
-  rules:
-    - !reference [.on_default_branch_push]
+  # rules:
+    # - !reference [.on_default_branch_push]
   trigger:
     project: DataDog/public-images
     branch: main
@@ -373,21 +373,21 @@ release:
   parallel:
     matrix:
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-linux:x64,registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-linux:aarch64
-        IMG_DESTINATIONS: agent-dev-env-linux:latest,agent-dev-env-linux:v$IMAGE_VERSION
+        IMG_DESTINATIONS: agent-dev-env-linux:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64
-        IMG_DESTINATIONS: agent-buildimages-deb_x64:latest,agent-buildimages-deb_x64:v$IMAGE_VERSION
+        IMG_DESTINATIONS: agent-buildimages-deb_x64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_arm64
-        IMG_DESTINATIONS: agent-buildimages-deb_arm64:latest,agent-buildimages-deb_arm64:v$IMAGE_VERSION
+        IMG_DESTINATIONS: agent-buildimages-deb_arm64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_x64
-        IMG_DESTINATIONS: agent-buildimages-rpm_x64:latest,agent-buildimages-rpm_x64:v$IMAGE_VERSION
+        IMG_DESTINATIONS: agent-buildimages-rpm_x64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_arm64
-        IMG_DESTINATIONS: agent-buildimages-rpm_arm64:latest,agent-buildimages-rpm_arm64:v$IMAGE_VERSION
+        IMG_DESTINATIONS: agent-buildimages-rpm_arm64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-17-x64
-        IMG_DESTINATIONS: agent-buildimages-linux-glibc-2-17-x64:latest,agent-buildimages-linux-glibc-2-17-x64:v$IMAGE_VERSION
+        IMG_DESTINATIONS: agent-buildimages-linux-glibc-2-17-x64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-23-arm64
-        IMG_DESTINATIONS: agent-buildimages-linux-glibc-2-23-arm64:latest,agent-buildimages-linux-glibc-2-23-arm64:v$IMAGE_VERSION
+        IMG_DESTINATIONS: agent-buildimages-linux-glibc-2-23-arm64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/windows_ltsc2022_x64
-        IMG_DESTINATIONS: agent-buildimages-windows_x64:ltsc2022,agent-buildimages-windows_x64:ltsc2022-v$IMAGE_VERSION
+        IMG_DESTINATIONS: agent-buildimages-windows_x64:ltsc2022-v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
 
 notify-images-available:
   extends: .slack-notifier-base

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -361,8 +361,8 @@ build_windows_ltsc2022_x64:
 
 release:
   stage: release
-  # rules:
-    # - !reference [.on_default_branch_push]
+  rules:
+    - !reference [.on_default_branch_push]
   trigger:
     project: DataDog/public-images
     branch: main
@@ -370,24 +370,25 @@ release:
   variables:
     IMG_REGISTRIES: dockerhub
     IMG_SIGNING: "false"
+  # We cannot use the $IMAGE_VERSION variable because there is only one step of variable substitution, see https://forum.gitlab.com/t/inconsistent-variable-behavior-in-multi-project-pipeline/77916
   parallel:
     matrix:
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-linux:x64,registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-linux:aarch64
-        IMG_DESTINATIONS: agent-dev-env-linux:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
+        IMG_DESTINATIONS: agent-dev-env-linux:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-dev-env-linux:latest
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64
-        IMG_DESTINATIONS: agent-buildimages-deb_x64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
+        IMG_DESTINATIONS: agent-buildimages-deb_x64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-buildimages-deb_x64:latest
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_arm64
-        IMG_DESTINATIONS: agent-buildimages-deb_arm64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
+        IMG_DESTINATIONS: agent-buildimages-deb_arm64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-buildimages-deb_arm64:latest
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_x64
-        IMG_DESTINATIONS: agent-buildimages-rpm_x64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
+        IMG_DESTINATIONS: agent-buildimages-rpm_x64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-buildimages-rpm_x64:latest
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_arm64
-        IMG_DESTINATIONS: agent-buildimages-rpm_arm64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
+        IMG_DESTINATIONS: agent-buildimages-rpm_arm64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-buildimages-rpm_arm64:latest
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-17-x64
-        IMG_DESTINATIONS: agent-buildimages-linux-glibc-2-17-x64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
+        IMG_DESTINATIONS: agent-buildimages-linux-glibc-2-17-x64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-buildimages-linux-glibc-2-17-x64:latest
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-23-arm64
-        IMG_DESTINATIONS: agent-buildimages-linux-glibc-2-23-arm64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
+        IMG_DESTINATIONS: agent-buildimages-linux-glibc-2-23-arm64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-buildimages-linux-glibc-2-23-arm64:latest
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/windows_ltsc2022_x64
-        IMG_DESTINATIONS: agent-buildimages-windows_x64:ltsc2022-v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}
+        IMG_DESTINATIONS: agent-buildimages-windows_x64:ltsc2022-v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-buildimages-windows_x64:ltsc2022
 
 notify-images-available:
   extends: .slack-notifier-base

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -386,7 +386,7 @@ release_windows:
       aud: https://vault.us1.ddbuild.io
   variables:
     CI_IDENTITY_ROLE_NAME_OVERRIDE: windows-ci-tmp-gitlab-id-token-datadog-agent-buildimages-all-refs
-    DOCKERHUB_IMAGE: agent-buildimages-windows_x64_test_only
+    DOCKERHUB_IMAGE: agent-buildimages-windows_x64
     IMAGE: windows_ltsc2022_x64_test_only
     DOCKERHUB_TAG_PREFIX: ltsc2022
   script:
@@ -397,13 +397,18 @@ release_windows:
     - docker pull $SRC_IMAGE
     - docker tag $SRC_IMAGE registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:latest
     - docker push registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:latest
-    - If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+    # DockerHub login and push
+    - $DOCKER_REGISTRY_LOGIN = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_login --with-decryption --query "Parameter.Value" --out text
+    - $DOCKER_REGISTRY_PWD = aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.docker_hub_pwd --with-decryption --query "Parameter.Value" --out text
+    - docker login --username "$DOCKER_REGISTRY_LOGIN" --password "$DOCKER_REGISTRY_PWD" docker.io
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - docker tag $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${IMAGE_VERSION}
     - docker push datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}-${IMAGE_VERSION}
-    - If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - docker tag $SRC_IMAGE datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}
     - docker push datadog/${DOCKERHUB_IMAGE}:${DOCKERHUB_TAG_PREFIX}
-    - If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
   after_script:
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,8))
     - $SRC_IMAGE = "registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}:${IMAGE_VERSION}"


### PR DESCRIPTION
### What does this PR do?
- Remove calling the tag and push operations to ECR of the windows release from a container. This push is already done in the build step
- Push to dockerhub using the `public-images` repository
- Use the `trigger:parallel:matrix` to simplify the configuration
- Fixed the tag of the devenv images (see [here](https://gitlab.ddbuild.io/DataDog/public-images/-/jobs/933167359#L362))

### Motivation
Push to registry must be authenticated using the automatic authentication and granted in the runner since https://github.com/DataDog/datadog-agent-buildimages/pull/789.

https://datadoghq.atlassian.net/browse/ACIX-869
https://datadoghq.atlassian.net/browse/ACIX-40
https://datadoghq.atlassian.net/browse/ACIX-573

### Possible Drawbacks / Trade-offs

### Additional Notes
We cannot use the $IMAGE_VERSION variable in the `trigget:parallel:matrix` because there is only one step of variable substitution, see https://forum.gitlab.com/t/inconsistent-variable-behavior-in-multi-project-pipeline/77916.
The correct behaviour was tested in [this pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/pipelines/64895649)' see the publication
