### PR TITLE
Prevent building developer images on schedules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,7 +151,7 @@ lint_dockerfiles:
 .build_dev_env:
   stage: build
   rules:
-    - if: $CI_COMMIT_TAG == null
+    - if: $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE != "schedule"
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
   script:


### PR DESCRIPTION
### Motivation

The developer images are based on the build images but the build images are not published on schedules so there is no base image with which to build