### PR TITLE
Update go workflow fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -330,7 +330,7 @@ push_to_datadog_agent:
     - export DDA_VERSION=$(grep DDA_VERSION dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')
     - pip install "dda==${DDA_VERSION}"
     - dda -v self dep sync -f legacy-build
-    - dda inv update-datadog-agent-buildimages --images-id "$IMAGES_ID" --ref "$REF" --branch "$BRANCH" --test-version
+    - dda inv buildimages.update --images-id "$IMAGES_ID" --ref "$REF" --branch "$BRANCH" --test-version
 
 build_windows_ltsc2022_x64:
   stage: build


### PR DESCRIPTION
### What does this PR do?

This PR aims to fix the dda inv command run when the github action workflow to update the go version

### Motivation

### Possible Drawbacks / Trade-offs

### Additional Notes
