### PR TITLE
Revert dda version bump in the legacy devcontainer image

### DIFF
--- a/.gitlab/devcontainer.yml
+++ b/.gitlab/devcontainer.yml
@@ -17,7 +17,9 @@ lint_devcontainer:
       - PLATFORM: [amd64, arm64]
   script:
     - GO_VERSION_ARG=$(grep GO_VERSION go.env | sed -e 's/^/--build-arg /' | tr '\n' ' ')
-    - DDA_VERSION_ARG=$(grep DDA_VERSION dda.env | sed -e 's/^/--build-arg /' | tr '\n' ' ')
+    # TODO: remove this once permissions are fixed in the devcontainer image or when we moved to the standard developer image
+    # - DDA_VERSION_ARG=$(grep DDA_VERSION dda.env | sed -e 's/^/--build-arg /' | tr '\n' ' ')
+    - DDA_VERSION_ARG="--build-arg DDA_VERSION=v0.11.0"
     - docker buildx build $GO_VERSION_ARG $DDA_VERSION_ARG --no-cache --platform linux/${PLATFORM} --tag ${DOCKER_TARGET}-${PLATFORM} -f devcontainer/Dockerfile . ${PUSH}
 
 test_devcontainer:


### PR DESCRIPTION
### Motivation

The copying of a binary [introduced](https://github.com/DataDog/datadog-agent-dev/pull/90) in v0.12.2 is causing permission issues due to the way the image creates the user [here](https://github.com/DataDog/datadog-agent-buildimages/blob/6029efe97857306066dac9e5242aa2a20c53525a/devcontainer/Dockerfile#L50).

The next step is to fix the way the user is created or preferably (since it will happen anyway) deprecate the image in favor of the new Linux [developer image](https://github.com/DataDog/datadog-agent-buildimages/tree/6029efe97857306066dac9e5242aa2a20c53525a/dev-envs).