### PR TITLE
Clean up Linux developer image

### DIFF
--- a/.dda/extend/commands/run/build/__init__.py
+++ b/.dda/extend/commands/run/build/__init__.py
@@ -36,4 +36,4 @@ def cmd(app: Application, *, args: tuple[str, ...]) -> None:
                 build_args.extend(("--build-arg", line))
 
     build_args.extend(args)
-    app.subprocess.exit_with_command(build_args)
+    app.subprocess.exit_with(build_args)

--- a/dev-envs/linux/Dockerfile
+++ b/dev-envs/linux/Dockerfile
@@ -5,9 +5,6 @@ FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
 
 ARG DDA_VERSION=""
 
-# Allow dynamic dependencies again as they are disabled in build images
-ENV DDA_NO_DYNAMIC_DEPS=0
-
 # Set up scripts
 COPY scripts /root/.scripts
 COPY scripts.sh /setup/scripts.sh

--- a/dev-envs/linux/dda.sh
+++ b/dev-envs/linux/dda.sh
@@ -2,8 +2,8 @@
 IFS=$'\n\t'
 set -euxo pipefail
 
-# Re-install dda if DDA_VERSION is set, otherwise link the dda from the conda environment
-if [[ -n "${DDA_VERSION}" ]]; then
+# Re-install dda if INSTALL_DDA is set, otherwise link the dda from the conda environment
+if [[ -n "${INSTALL_DDA:-}" ]]; then
     "${HOME}/.venv/bin/pip" install "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}"
 else
     ln -s "$(/root/miniforge3/condabin/conda run -n ddpy3 which dda)" /usr/local/bin/dda

--- a/dev-envs/linux/env-vars.sh
+++ b/dev-envs/linux/env-vars.sh
@@ -4,6 +4,14 @@ set -euxo pipefail
 
 set-ev DD_SHARED_DIR "${HOME}/.shared"
 set-ev DD_REPOS_DIR "${HOME}/repos"
+
+# Advertise full terminal capabilities
+set-ev TERM "xterm-256color"
+set-ev COLORTERM "truecolor"
+
+# Allow dynamic dependencies again as they are disabled in build images
+set-ev DDA_NO_DYNAMIC_DEPS "0"
+
 # These environment variables are set in docker directives, we want them available when we ssh into the container
 set-ev DD_CC "${DD_CC}"
 set-ev DD_CXX "${DD_CXX}"

--- a/dev-envs/linux/git.sh
+++ b/dev-envs/linux/git.sh
@@ -2,25 +2,6 @@
 IFS=$'\n\t'
 set -euxo pipefail
 
-git_dir="${HOME}/git"
-
-# Temporarily required for the ARM image, see:
-# https://confluence.atlassian.com/bitbucketserverkb/bitbucket-server-repository-import-fails-with-error-remote-https-is-not-a-git-command-1103438202.html
-apt-get update && apt-get install -y libcurl4-openssl-dev
-
-# https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
-install-from-source \
-    --version "2.37.3" \
-    --digest "730ea150a9af30e6301d3ff4169567d5a5c52950e122c1a10d21998f7a7f70d7" \
-    --url "https://github.com/git/git/archive/refs/tags/v{{version}}.tar.gz" \
-    --relative-path "git-{{version}}" \
-    --configure-script "make configure && ./configure --prefix=\"${git_dir}\"" \
-    --install-script "make prefix=\"${git_dir}\" -j \"$(nproc)\" all && make prefix=\"${git_dir}\" install"
-
-# The Agent build defines an older version but we require a newer one for SSH signing so we
-# install at a different path so as to not conflict with the build process
-path-prepend "${git_dir}/bin"
-
 # Set up signing:
 # https://github.blog/open-source/git/highlights-from-git-2-34/#tidbits
 git config --global commit.gpgsign true


### PR DESCRIPTION
### What does this PR do?

- Use the proper subprocess utility for newer versions of `dda` when running the `dda run build` local command
- Properly persist the `dda` environment variable to allow dynamic dependencies
- Remove duplicate Git installation now that the newer base image uses a modern version
- Enable high fidelity color output explicitly by default since the container cannot detect the terminal from which it runs