### PR TITLE
CODEOWNERS: add agent delivery as co-owners of the glibc images

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,7 @@ dda.env                             @DataDog/agent-devx
 /rpm-arm64/                         @DataDog/agent-devx @DataDog/agent-delivery
 /rpm-armhf/                         @DataDog/agent-devx @DataDog/agent-delivery
 /rpm-x64/                           @DataDog/agent-devx @DataDog/agent-delivery
+/linux-glibc-*/                     @DataDog/agent-devx @DataDog/agent-delivery
 
 # Windows test & build images
 /windows/                           @DataDog/windows-agent @DataDog/agent-devx


### PR DESCRIPTION
### What does this PR do?

Add agent-delivery as glibc images co-owners

### Motivation

These images are definitely build related and it makes sense for us to be aware of changes done there

### Possible Drawbacks / Trade-offs

### Additional Notes
