### PR TITLE
CI: reintroduce S3_CP_CMD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ variables:
   EXTRA_KCONFIG_VERSION: "0.1"
   ECR_TEST_ONLY: "_test_only"
   IMAGE_VERSION: "v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}"
+  S3_CP_CMD: aws s3 cp $S3_CP_OPTIONS
 
 #
 # Workflow rules


### PR DESCRIPTION
### What does this PR do?

Reintroduce a variable that was removed in a recent cleanup

### Motivation

It is still used by our kernel packages jobs, which causes them to fail: https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/956276097

### Possible Drawbacks / Trade-offs

### Additional Notes
