### PR TITLE
Clean up dda telemetry

### DIFF
--- a/dev-envs/linux/entrypoint.sh
+++ b/dev-envs/linux/entrypoint.sh
@@ -38,6 +38,9 @@ if ! [[ -f "${startup_indicator}" ]]; then
         git config --global user.email "${GIT_AUTHOR_EMAIL}"
     fi
 
+    # Restore default configuration to account for changes during startup like Git author details
+    dda config restore
+
     # Create the startup indicator file
     touch "${startup_indicator}"
 fi

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -82,6 +82,7 @@ case $DD_TARGET_ARCH in
     cd ..
     rm -rf /tmp/dda-install
     # python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}"
+    python3 -m dda self telemetry disable
     python3 -m dda -v self dep sync -f legacy-build
     exit 0
     ;;
@@ -108,6 +109,7 @@ pip install -i https://pypi.python.org/simple pip==${DD_PIP_VERSION_PY3}
 pip install setuptools==${DD_SETUPTOOLS_VERSION_PY3}
 pip install --no-build-isolation "cython<3.0.0" PyYAML==5.4.1
 pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}"
+dda self telemetry disable
 dda -v self dep sync -f legacy-build
 pip uninstall -y cython # remove cython to prevent further issue with nghttp2
 

--- a/windows/helpers/phase2/install_python.ps1
+++ b/windows/helpers/phase2/install_python.ps1
@@ -46,12 +46,14 @@ Get-Content $packages_file | Where-Object { $_.Trim() -ne '' } | Where-Object { 
 python "$($PSScriptRoot)\get-pip.py" pip==${Env:DD_PIP_VERSION_PY3}
 if($Env:DD_DEV_TARGET -eq "Container") {
     python -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${Env:DDA_VERSION}"
+    python -m dda self telemetry disable
     python -m dda -v self dep sync -f legacy-build
 } else {
     ## When installing for local use, set up the virtual environment first
     python -m venv "$($Env:USERPROFILE)\.ddbuild\agentdev"
     &  "$($Env:USERPROFILE)\.ddbuild\agentdev\scripts\activate.ps1"
     python -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${Env:DDA_VERSION}"
+    python -m dda self telemetry disable
     python -m dda -v self dep sync -f legacy-build
 }
 


### PR DESCRIPTION
### What does this PR do?

- Disable telemetry by default in the raw build images as there is no way to submit telemetry, avoiding the confirmation prompt
- Properly restore config during startup of the Linux developer image to account for changes in the default configuration