### PR TITLE
Properly persist env vars in the Linux dev env

### DIFF
--- a/.dda/extend/commands/run/build/__init__.py
+++ b/.dda/extend/commands/run/build/__init__.py
@@ -25,7 +25,7 @@ def cmd(app: Application, *, args: tuple[str, ...]) -> None:
     """
     from dda.utils.fs import Path
 
-    build_args = ["docker", "build"]
+    build_args = ["build"]
     for entry in Path.cwd().glob("*.env"):
         with entry.open(encoding="utf-8") as f:
             for line in f:
@@ -36,4 +36,4 @@ def cmd(app: Application, *, args: tuple[str, ...]) -> None:
                 build_args.extend(("--build-arg", line))
 
     build_args.extend(args)
-    app.subprocess.exit_with(build_args)
+    app.tools.docker.exit_with(build_args)

--- a/dev-envs/linux/Dockerfile
+++ b/dev-envs/linux/Dockerfile
@@ -80,6 +80,9 @@ RUN /setup/ssh.sh
 # hadolint ignore=DL3059
 RUN rm -rf /setup
 
+# Remove side effects of APT installations
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 

--- a/dev-envs/linux/env-vars.sh
+++ b/dev-envs/linux/env-vars.sh
@@ -11,8 +11,3 @@ set-ev COLORTERM "truecolor"
 
 # Allow dynamic dependencies again as they are disabled in build images
 set-ev DDA_NO_DYNAMIC_DEPS "0"
-
-# These environment variables are set in docker directives, we want them available when we ssh into the container
-set-ev DD_CC_PATH "${DD_CC_PATH}"
-set-ev DD_CXX_PATH "${DD_CXX_PATH}"
-set-ev DD_CMAKE_TOOLCHAIN_PATH "${DD_CMAKE_TOOLCHAIN_PATH}"

--- a/dev-envs/linux/env.sh
+++ b/dev-envs/linux/env.sh
@@ -5,12 +5,3 @@ set -euxo pipefail
 source /setup/shellrc.sh
 
 path-prepend "${HOME}/.scripts"
-
-# Properly add directories to PATH that were only added as Docker directives
-path-append "${HOME}/.cargo/bin"
-path-append "/go/bin"
-path-append "/usr/local/go/bin"
-path-append "/root/miniforge3/condabin"
-path-append "/usr/lib/binutils-2.26/bin"
-path-append "/opt/toolchains/x86_64/bin"
-path-append "/opt/toolchains/aarch64/bin"


### PR DESCRIPTION
### What does this PR do?

Properly make use of the `/etc/environment` file created at start up: https://github.com/DataDog/datadog-agent-buildimages/blob/6db031309aa95409e236b38ede1daa9a4decad6f/dev-envs/linux/entrypoint.sh#L25

### Motivation

Prevent the developer image getting out of sync with the base images e.g. https://github.com/DataDog/datadog-agent-buildimages/pull/838