### PR TITLE
Set default build dirs for the Linux dev env

### DIFF
--- a/dev-envs/linux/env-vars.sh
+++ b/dev-envs/linux/env-vars.sh
@@ -11,3 +11,7 @@ set-ev COLORTERM "truecolor"
 
 # Allow dynamic dependencies again as they are disabled in build images
 set-ev DDA_NO_DYNAMIC_DEPS "0"
+
+# These are effectively required for builds
+set-ev OMNIBUS_BASE_DIR "/omnibus"
+set-ev OMNIBUS_GIT_CACHE_DIR "/tmp/omnibus-git-cache"


### PR DESCRIPTION
### What does this PR do?

Copies the default values:

- https://github.com/DataDog/datadog-agent/blob/2949d91388a916228e84c68b9cb56cc6b2fe2b7c/.gitlab-ci.yml#L107-L110
- https://github.com/DataDog/datadog-agent/blob/2949d91388a916228e84c68b9cb56cc6b2fe2b7c/.gitlab-ci.yml#L154-L156

### Motivation

Consistency, and the latter must be defined explicitly for builds to pass