### PR TITLE
Force installable artifacts for package builds

### DIFF
--- a/dev-envs/linux/env-vars.sh
+++ b/dev-envs/linux/env-vars.sh
@@ -15,3 +15,4 @@ set-ev DDA_NO_DYNAMIC_DEPS "0"
 # These are effectively required for builds
 set-ev OMNIBUS_BASE_DIR "/omnibus"
 set-ev OMNIBUS_GIT_CACHE_DIR "/tmp/omnibus-git-cache"
+set-ev OMNIBUS_FORCE_PACKAGES "1"


### PR DESCRIPTION
### Motivation

The default is to produce `.xz` artifacts for CI but locally developers would want the actual installers like `.deb`