### PR TITLE
Remove DD_C* compiler related variables from glibc build images

### DIFF
--- a/linux-glibc-2.17-x64/Dockerfile
+++ b/linux-glibc-2.17-x64/Dockerfile
@@ -44,9 +44,6 @@ COPY linux-glibc-2.17-x64/config-aarch64-unknown-gnu-linux-glibc2.23 /build/cros
 COPY linux-glibc-2.17-x64/toolchain_x86-64.cmake /opt/cmake/x86_64-unknown-linux-gnu.toolchain.cmake
 COPY linux-glibc-2.17-x64/cargo-config.toml ${HOME}/.cargo/config.toml
 COPY linux-glibc-2.17-x64/ctng.patch /root/ctng.patch
-ENV DD_CC_PATH="/opt/toolchains/x86_64/bin/x86_64-unknown-linux-gnu-gcc"
-ENV DD_CXX_PATH="/opt/toolchains/x86_64/bin/x86_64-unknown-linux-gnu-g++"
-ENV DD_CMAKE_TOOLCHAIN_PATH="/opt/cmake/x86_64-unknown-linux-gnu.toolchain.cmake"
 
 RUN git config --global user.email "package@datadoghq.com"
 RUN git config --global user.name "Bits"

--- a/linux-glibc-2.23-arm64/Dockerfile
+++ b/linux-glibc-2.23-arm64/Dockerfile
@@ -39,9 +39,6 @@ COPY linux-glibc-2.23-arm64/config-x86_64-unknown-gnu-linux-glibc2.17 /build/cro
 COPY linux-glibc-2.23-arm64/toolchain_aarch64.cmake /opt/cmake/aarch64-unknown-linux-gnu.toolchain.cmake
 COPY linux-glibc-2.23-arm64/cargo-config.toml ${HOME}/.cargo/config.toml
 COPY linux-glibc-2.23-arm64/ctng.patch /root/ctng.patch
-ENV DD_CC_PATH="/opt/toolchains/aarch64/bin/aarch64-unknown-linux-gnu-gcc"
-ENV DD_CXX_PATH="/opt/toolchains/aarch64/bin/aarch64-unknown-linux-gnu-g++"
-ENV DD_CMAKE_TOOLCHAIN_PATH="/opt/cmake/aarch64-unknown-linux-gnu.toolchain.cmake"
 
 RUN git config --global user.email "package@datadoghq.com"
 RUN git config --global user.name "Bits"


### PR DESCRIPTION
### What does this PR do?

Follow up to https://github.com/DataDog/datadog-agent/pull/37488, we're removing these variables since they're currently not used and we want to avoid confusion with the same variables without the `_PATH` suffix that are currently meaningful for our build scripts.

As said before, we would indeed like to have these defined here but there's currently blockers for that, and we don't want to proliferate similarly name, similar-purpose variables just to work around it.

