### PR TITLE
fix(dev-env): Remove the github.copilot extension from cursor installation

### DIFF
--- a/dev-envs/linux/vscode.sh
+++ b/dev-envs/linux/vscode.sh
@@ -103,6 +103,11 @@ function install_vscode() {
     mkdir -p "${extensions_dir}"
     ln -s "${extensions_dir}" "${root_dir}/extensions"
 
+    # Ugly hack to remove github.copilot extension when we install cursor
+    if [[ "${root_dir_name}" == ".cursor-server" ]]; then
+        sed -i '/github.copilot/d' /setup/default-vscode-extensions.txt
+    fi
+
     install-vscode-extensions /setup/default-vscode-extensions.txt "${binary_name}-server"
 }
 


### PR DESCRIPTION
### What does this PR do?
Remove the github.copilot extension from cursor installation

### Motivation
Fix the [currently failing job](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/987869309)
```
#38 53.68 Extension 'github.copilot' not found.
#38 53.68 Make sure you use the full extension ID, including the publisher, e.g.: anysphere.csharp
...
E0618 15:21:44.548236     204 v2.go:104] EOF
Dockerfile:72
--------------------
  70 |     COPY default-vscode-extensions.txt /setup/default-vscode-extensions.txt
  71 |     COPY vscode.sh /setup/vscode.sh
  72 | >>> RUN /setup/vscode.sh
  73 |     
  74 |     # Set up OpenSSH server
--------------------
ERROR: failed to solve: process "/bin/sh -c /setup/vscode.sh" did not complete successfully: exit code: 123
```

### Possible Drawbacks / Trade-offs
I kept the `default-vscode-extensions.txt` as is, I could have put the `github.copilot` aside. I suppose we don't need this extension in cursor anyway.

### Additional Notes
