### PR TITLE
fix(devenv cache): Split cache by arch

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -50,7 +50,7 @@
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
   script:
-    - CACHE_SOURCE="--cache-from type=registry,ref=registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-$PLATFORM:cache"
+    - CACHE_SOURCE="--cache-from type=registry,ref=registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-$PLATFORM:cache-$DD_TARGET_ARCH"
     # Do not use cache on periodic pipeline where we want to test our dependencies.
     - if [[ "$CI_PIPELINE_SOURCE" == "schedule" ]]; then CACHE_SOURCE="--no-cache"; fi
     - PUSH=""
@@ -59,7 +59,7 @@
     - >-
       docker buildx build --platform $PLATFORM $PUSH --pull
       ${CACHE_SOURCE}
-      --cache-to type=registry,ref=registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-$PLATFORM:cache,mode=max
+      --cache-to type=registry,ref=registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-$PLATFORM:cache-$DD_TARGET_ARCH,mode=max
       --build-arg BASE_IMAGE=$BASE_IMAGE
       --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG
       --tag registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-$PLATFORM:$DD_TARGET_ARCH


### PR DESCRIPTION

### What does this PR do?
The devenv images are currently using the same cache, so they are invalidating it for each other. Creating an arch-based cache label should fix this

### Motivation
Efficiency

### Possible Drawbacks / Trade-offs

### Additional Notes
