### PR TITLE
Assign ownership for build-related images to agent-build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,18 +29,18 @@ dda.env                             @DataDog/agent-devx
 /kernel-version-testing/            @DataDog/ebpf-platform @DataDog/agent-devx
 
 # Linux test & build images
-/deb-arm/                           @DataDog/agent-devx @DataDog/agent-delivery
-/deb-x64/                           @DataDog/agent-devx @DataDog/agent-delivery
-/rpm-arm64/                         @DataDog/agent-devx @DataDog/agent-delivery
-/rpm-armhf/                         @DataDog/agent-devx @DataDog/agent-delivery
-/rpm-x64/                           @DataDog/agent-devx @DataDog/agent-delivery
-/linux-glibc-*/                     @DataDog/agent-devx @DataDog/agent-delivery
+/deb-arm/                           @DataDog/agent-devx @DataDog/agent-build
+/deb-x64/                           @DataDog/agent-devx @DataDog/agent-build
+/rpm-arm64/                         @DataDog/agent-devx @DataDog/agent-build
+/rpm-armhf/                         @DataDog/agent-devx @DataDog/agent-build
+/rpm-x64/                           @DataDog/agent-devx @DataDog/agent-build
+/linux-glibc-*/                     @DataDog/agent-devx @DataDog/agent-build
 
 # Windows test & build images
 /windows/                           @DataDog/windows-agent @DataDog/agent-devx
 
 # Docker images
-/docker-arm64/                      @DataDog/container-integrations @DataDog/agent-devx
-/docker-x64/                        @DataDog/container-integrations @DataDog/agent-devx
+/docker-arm64/                      @DataDog/agent-build @DataDog/agent-devx
+/docker-x64/                        @DataDog/agent-build @DataDog/agent-devx
 /dev-envs/                          @DataDog/agent-devx
 /devcontainer/                      @DataDog/agent-devx @DataDog/container-platform


### PR DESCRIPTION
### What does this PR do?

Assigns ownership for build-related images to agent-build:
- Images used to build packages and binary artifacts: from agent-delivery to agent-build (makes sense after the team split)
- Images used to build docker images: from container-integrations to agent-build (agreed with the team, and makes sense because agent-build owns docker image builds currently).

### Motivation

### Possible Drawbacks / Trade-offs

### Additional Notes
