### PR TITLE
feat(windows): Restore publication and update notification message

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,19 +51,6 @@ variables:
   - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     when: always
 
-.on_default_branch_push_windows:
-  - if: $CI_PIPELINE_SOURCE == "schedule"
-    when: never
-  - if: $CI_COMMIT_TAG != null
-    when: never
-  - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-    changes:
-      paths:
-        - build-container.ps1
-        - windows/**/*
-      compare_to: $COMPARE_TO_BRANCH
-    when: always
-
 workflow:
   rules:
     - <<: *if_release_or_main_branch

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -164,3 +164,7 @@ build_windows_ltsc2022_x64:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $SRC_IMAGE = "registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}"
     - .\build-container.ps1 -Image $SRC_IMAGE -Tag $IMAGE_VERSION -Buildkit
+    - New-Item -ItemType File -Path "windows.image" -Force # Create a file to indicate that the image is built
+  artifacts:
+    paths: ["./windows.image"]
+    expire_in: 1 hour

--- a/.gitlab/notify.yml
+++ b/.gitlab/notify.yml
@@ -13,10 +13,11 @@ notify-images-available:
   script: |
     COMMIT_URL="$CI_PROJECT_URL/commit/$CI_COMMIT_SHA"
     BRANCH_URL="$CI_PROJECT_URL/tree/$CI_COMMIT_BRANCH"
-    export MESSAGE="Your :docker: images with tag \`$IMAGE_VERSION\` are ready.
+    WINDOWS=$([ -f "windows.image" ] && echo "-w" || echo "")
+    export MESSAGE=":done: Your :docker: images with tag \`$IMAGE_VERSION\` are ready.
     :git: Branch <$BRANCH_URL|$CI_COMMIT_BRANCH> for commit \`$CI_COMMIT_TITLE\` (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>)
     :idea: You can test them in the \`datadog-agent\` repository by running:
-    \`\`\`inv buildimages.update -t $IMAGE_VERSION [--no-test] [-i <image_name>]\`\`\`
+    \`\`\`inv buildimages.update -t $IMAGE_VERSION $WINDOWS [--no-test] [-i <image_name>]\`\`\`
     Or run the \`trigger_tests\` manual job in your \`datadog-agent-buildimages\` <$CI_PIPELINE_URL|pipeline>."
     /usr/local/bin/notify.sh
 
@@ -31,7 +32,7 @@ notify-images-failure:
   script: |
     COMMIT_URL="$CI_PROJECT_URL/commit/$CI_COMMIT_SHA"
     BRANCH_URL="$CI_PROJECT_URL/tree/$CI_COMMIT_BRANCH"
-    export MESSAGE=":warning: Your :docker: images with tag \`$IMAGE_VERSION\` failed to build. :warning:
+    export MESSAGE=":red_circle: Your :docker: images with tag \`$IMAGE_VERSION\` failed to build.
     :git: Branch <$BRANCH_URL|$CI_COMMIT_BRANCH> for commit \`$CI_COMMIT_TITLE\` (<$COMMIT_URL|$CI_COMMIT_SHORT_SHA>)
     More details :arrow_right:"
     /usr/local/bin/notify.sh

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -33,7 +33,7 @@ release:
 release_windows:
   stage: release
   rules:
-    - !reference [.on_default_branch_push_windows]
+    - !reference [.on_default_branch_push]
   trigger:
     project: DataDog/public-images
     branch: main


### PR DESCRIPTION
### What does this PR do?
- Restore publication of windows images on `main`: we cannot use the `compare_to` feature on this branch
- Update the notification to give the correct `buildimages.update` command with or without windows

### Motivation
Since #867 we do not create the windows image anymore. We need to restore this and adapt the update on `datadog-agent` side (see https://github.com/DataDog/datadog-agent/pull/38287)

### Possible Drawbacks / Trade-offs
The build image for windows is always generated but we don't need to update it on `datadog-agent` side (do not merge all the renovate PRs)

### Additional Notes
