### PR TITLE
fix(glibc): Use a more standard arch name for the config file

### DIFF
--- a/linux-glibc-2.23-arm64/Dockerfile
+++ b/linux-glibc-2.23-arm64/Dockerfile
@@ -37,7 +37,7 @@ RUN apt update -qy && apt install -y \
     linux-headers-generic jq libsystemd-dev clang-format
 
 COPY linux-glibc-2.23-arm64/config-aarch64-unknown-gnu-linux-glibc2.23 /build/crosstool-ng-${CTNG_VERSION}/.config
-COPY linux-glibc-2.23-arm64/config-x86_64-unknown-gnu-linux-glibc2.17 /build/crosstool-ng-${CTNG_VERSION}/.config-x86
+COPY linux-glibc-2.23-arm64/config-x86_64-unknown-gnu-linux-glibc2.17 /build/crosstool-ng-${CTNG_VERSION}/.config-x86_64
 COPY linux-glibc-2.23-arm64/toolchain_aarch64.cmake /opt/cmake/aarch64-unknown-linux-gnu.toolchain.cmake
 COPY linux-glibc-2.23-arm64/cargo-config.toml ${HOME}/.cargo/config.toml
 COPY linux-glibc-2.23-arm64/ctng.patch /root/ctng.patch
@@ -70,7 +70,7 @@ RUN cd /build && \
     ./ct-ng upgradeconfig && ./ct-ng build && \
     mkdir -p /opt/toolchains/ && \
     mv /root/x-tools/aarch64-unknown-linux-gnu/ /opt/toolchains/aarch64 && \
-    mv .config-x86 .config && \
+    mv .config-x86_64 .config && \
     ./ct-ng upgradeconfig && \
     ./ct-ng build && \
     mv /root/x-tools/x86_64-unknown-linux-gnu/ /opt/toolchains/x86_64 && \


### PR DESCRIPTION
### What does this PR do?
Change the name `x86` in `x86_64` to ease the correspondance between the 2 glibc images

### Motivation
Enabler to have both images using the same dockerfile

### Possible Drawbacks / Trade-offs

### Additional Notes
Successful `datadog-agent` pipeline [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/70033894) 
