### PR TITLE
fix(dev-env): Update the image name

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -123,7 +123,7 @@ build_dev_env_linux_x64:
             IMAGE: linux-glibc-2-17-x64
   variables:
     DOCKERFILE: dev-envs/linux/Dockerfile
-    IMAGE: dev-env-$DD_TARGET_ARCH
+    IMAGE: dev-env-linux-$DD_TARGET_ARCH
     BASE_IMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-17-x64$ECR_TEST_ONLY
     BASE_IMAGE_TAG: $IMAGE_VERSION
 
@@ -137,7 +137,7 @@ build_dev_env_linux_arm64:
             IMAGE: linux-glibc-2-23-arm64
   variables:
     DOCKERFILE: dev-envs/linux/Dockerfile
-    IMAGE: dev-env-$DD_TARGET_ARCH
+    IMAGE: dev-env-linux-$DD_TARGET_ARCH
     BASE_IMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-23-arm64$ECR_TEST_ONLY
     BASE_IMAGE_TAG: $IMAGE_VERSION
 


### PR DESCRIPTION
### What does this PR do?
Add the `linux` qualifier to the `dev-env` images

### Motivation
Fix the [failure](https://gitlab.ddbuild.io/DataDog/public-images/-/pipelines/70161222) in releasing

### Possible Drawbacks / Trade-offs

### Additional Notes
