### PR TITLE
Install libseccomp-dev

### DIFF
--- a/linux-glibc-2.17-x64/Dockerfile
+++ b/linux-glibc-2.17-x64/Dockerfile
@@ -37,7 +37,7 @@ RUN apt update -qy && apt install -y \
     pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libpq-dev libz-dev \
     rpm tar gettext autopoint autoconf clang libtool-bin \
     pkg-config flex meson selinux-basics squashfs-tools gpg xz-utils gnupg2 patchelf cpio \
-    linux-headers-generic libc6-dev-i386 jq libsystemd-dev clang-format
+    linux-headers-generic libc6-dev-i386 jq libsystemd-dev clang-format libseccomp-dev
 
 COPY linux-glibc-2.17-x64/config-x86_64-unknown-gnu-linux-glibc2.17 /build/crosstool-ng-${CTNG_VERSION}/.config
 COPY linux-glibc-2.17-x64/config-aarch64-unknown-gnu-linux-glibc2.23 /build/crosstool-ng-${CTNG_VERSION}/.config-aarch64


### PR DESCRIPTION
### What does this PR do?
This PR installs `libseccomp-dev` in the image used to build system-probe. This library is used to build a runtime detection for a kernel bug.

https://github.com/DataDog/datadog-agent/pull/38876

### Motivation

### Possible Drawbacks / Trade-offs

### Additional Notes
