### PR TITLE
Disable check for new dda releases in CI

### DIFF
--- a/dev-envs/linux/dda.sh
+++ b/dev-envs/linux/dda.sh
@@ -10,4 +10,5 @@ else
 fi
 
 dda self telemetry disable
+dda config set update.mode check
 dda self dep sync -f mcp

--- a/setup_python.sh
+++ b/setup_python.sh
@@ -110,6 +110,7 @@ pip install setuptools==${DD_SETUPTOOLS_VERSION_PY3}
 pip install --no-build-isolation "cython<3.0.0" PyYAML==5.4.1
 pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}"
 dda self telemetry disable
+dda config set update.mode off
 dda -v self dep sync -f legacy-build
 pip uninstall -y cython # remove cython to prevent further issue with nghttp2
 

--- a/windows/helpers/phase2/install_python.ps1
+++ b/windows/helpers/phase2/install_python.ps1
@@ -44,18 +44,15 @@ Get-Content $packages_file | Where-Object { $_.Trim() -ne '' } | Where-Object { 
 }
 
 python "$($PSScriptRoot)\get-pip.py" pip==${Env:DD_PIP_VERSION_PY3}
-if($Env:DD_DEV_TARGET -eq "Container") {
-    python -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${Env:DDA_VERSION}"
-    python -m dda self telemetry disable
-    python -m dda -v self dep sync -f legacy-build
-} else {
+if($Env:DD_DEV_TARGET -ne "Container") {
     ## When installing for local use, set up the virtual environment first
     python -m venv "$($Env:USERPROFILE)\.ddbuild\agentdev"
     &  "$($Env:USERPROFILE)\.ddbuild\agentdev\scripts\activate.ps1"
-    python -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${Env:DDA_VERSION}"
-    python -m dda self telemetry disable
-    python -m dda -v self dep sync -f legacy-build
 }
+python -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${Env:DDA_VERSION}"
+python -m dda self telemetry disable
+python -m dda config set update.mode off
+python -m dda -v self dep sync -f legacy-build
 
 
 Set-InstalledVersionKey -Component "Python" -Keyname "version" -TargetValue $Version


### PR DESCRIPTION
### Motivation

This is undesirable when capturing output of `dda` commands