### PR TITLE
(datadog-agent-buildimages) Update windows-agent team name to windows-products

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@ dda.env                             @DataDog/agent-devx
 
 /entrypoint-sysprobe.sh             @DataDog/ebpf-platform @DataDog/agent-devx
 
-/build-container.ps1                @DataDog/windows-agent @DataDog/agent-devx
+/build-container.ps1                @DataDog/windows-products @DataDog/agent-devx
 
 # eBPF / KMT images
 /btf-gen/                           @DataDog/ebpf-platform @DataDog/agent-devx
@@ -37,7 +37,7 @@ dda.env                             @DataDog/agent-devx
 /linux-glibc-*/                     @DataDog/agent-devx @DataDog/agent-build
 
 # Windows test & build images
-/windows/                           @DataDog/windows-agent @DataDog/agent-devx
+/windows/                           @DataDog/windows-products @DataDog/agent-devx
 
 # Docker images
 /docker-arm64/                      @DataDog/agent-build @DataDog/agent-devx


### PR DESCRIPTION
### What does this PR do?

This PR renames the windows-agent team to windows-products in the CODEOWNERS file.

### Motivation

Team renamed from Windows Agent to Windows Products

### Possible Drawbacks / Trade-offs

### Additional Notes
