### PR TITLE
Install authanywhere

### DIFF
--- a/deb-arm/Dockerfile
+++ b/deb-arm/Dockerfile
@@ -258,6 +258,10 @@ RUN curl -LO https://releases.hashicorp.com/vault/${VAULT_VERSION}/${VAULT_FILEN
 RUN apt-get update \
     && apt-get install -y shellcheck
 
+# Install authanywhere for infra token management
+RUN curl -OL "binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-arm64" -o /bin/authanywhere && \
+    chmod +x /bin/authanywhere
+
 RUN git config --global user.email "package@datadoghq.com"
 RUN git config --global user.name "Bits"
 

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -250,6 +250,10 @@ RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v${PR
 RUN apt-get update \
     && apt-get install -y shellcheck
 
+# Install authanywhere for infra token management
+RUN curl -OL "binaries.ddbuild.io/dd-source/authanywhere/LATEST/authanywhere-linux-amd64" -o /bin/authanywhere && \
+    chmod +x /bin/authanywhere
+
 # create the agent build folder within $GOPATH
 RUN mkdir -p /go/src/github.com/DataDog/datadog-agent
 


### PR DESCRIPTION
### What does this PR do?

This is used to generate tokens to access internal services such as the stack cleaner, it's better to do it in the Dockerfile and not at runtime like it is done currently.

### Motivation

### Possible Drawbacks / Trade-offs

### Additional Notes
