### PR TITLE
Properly handle errors in Windows build scripts

### DIFF
--- a/windows/helpers/phase2/install_python.ps1
+++ b/windows/helpers/phase2/install_python.ps1
@@ -3,6 +3,7 @@ param (
     [Parameter(Mandatory=$true)][string]$Sha256
 )
 
+$ErrorActionPreference = 'Stop'
 
 # https://www.python.org/ftp/python/X.Y.Z/python-X.Y.Z-amd64.exe
 $pyexe = "https://www.python.org/ftp/python/$($Version)/python-$($Version)-amd64.exe"
@@ -53,7 +54,9 @@ if($Env:DD_DEV_TARGET -ne "Container") {
 python -m pip install uv==${Env:DD_UV_VERSION}
 
 $repoPath = "$($PSScriptRoot)\datadog-agent-dev"
-Remove-Item -Recurse -Force "$repoPath"
+if (Test-Path "$repoPath") {
+    Remove-Item -Recurse -Force "$repoPath"
+}
 Write-Host -ForegroundColor Green "Cloning dda repository..."
 git clone --depth 1 --branch "$($Env:DDA_VERSION)" https://github.com/DataDog/datadog-agent-dev.git "$repoPath"
 


### PR DESCRIPTION
### Motivation

Most other scripts had that first line to catch all non-zero exit codes from cmdlets

https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/1060604437

Ultimately same error as before but now errors are caught properly (for cmdlets) https://github.com/DataDog/datadog-agent-buildimages/pull/925#issuecomment-3139738873