### PR TITLE
Backport #928 to 7.69.x

### DIFF
--- a/.github/chainguard/self.go-update.create-pr.sts.yaml
+++ b/.github/chainguard/self.go-update.create-pr.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-agent-buildimages:ref:refs/heads/main
+
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/datadog-agent-buildimages/\.github/workflows/go-update\.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # push commit and branch
-      pull-requests: write # create PR
+      id-token: write # needed for dd-octo-sts token exchange
 
     steps:
       - name: Checkout code
@@ -45,6 +45,13 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
+
+      - name: Get access token via dd-octo-sts
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-agent-buildimages
+          policy: self.go-update.create-pr
 
       - name: Install dependencies
         run: |
@@ -60,6 +67,7 @@ jobs:
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         if: ${{ inputs.open_pr }}
         with:
+          token: ${{ steps.octo-sts.outputs.token }}
           commit-message: "[push_to_datadog_agent] Update go version to ${{ inputs.go_version }}"
           branch: ${{ env.BRANCH_NAME }}
           sign-commits: true


### PR DESCRIPTION
### What does this PR do?

Backports [this](https://github.com/DataDog/datadog-agent-buildimages/pull/928) in case we need to bump go for CVEs on this branch.

### Motivation

### Possible Drawbacks / Trade-offs

### Additional Notes
