### PR TITLE
Correct sources of multi-arch Linux release

### DIFF
--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -1,8 +1,8 @@
 ---
 release:
   stage: release
-  rules:
-    - !reference [.on_default_branch_push]
+  # rules:
+  #   - !reference [.on_default_branch_push]
   trigger:
     project: DataDog/public-images
     branch: main

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -25,7 +25,7 @@ release:
         IMG_DESTINATIONS: agent-buildimages-rpm_x64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-buildimages-rpm_x64:latest
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_arm64:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
         IMG_DESTINATIONS: agent-buildimages-rpm_arm64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-buildimages-rpm_arm64:latest
-      - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-x64:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA},registry.ddbuild.io/ci/datadog-agent-buildimages/linux-arm64:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+      - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-x64:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-x64,registry.ddbuild.io/ci/datadog-agent-buildimages/linux-arm64:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
         IMG_DESTINATIONS: agent-buildimages-linux:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-buildimages-linux:latest
 
 release_windows:


### PR DESCRIPTION
### Motivation

- https://github.com/DataDog/datadog-agent-buildimages/blob/0a03859b4e3b25010f9f9f246c029a9aef02da12/.gitlab/build.yml#L66
- https://github.com/DataDog/datadog-agent-buildimages/blob/0a03859b4e3b25010f9f9f246c029a9aef02da12/.gitlab/build.yml#L94