### PR TITLE
Install latest version of blinker, upgrade dda version

### DIFF
--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -74,6 +74,10 @@ RUN useradd -g 20 -u 503 -m datadog -s /bin/bash -G sudo,root && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists
 
 USER datadog
+
+# prevents using system package which emits warning logs on every call
+RUN pip3 install --no-cache-dir blinker==1.9.0
+
 ENV GOPATH=/home/datadog/go \
     GOROOT=/usr/local/go \
     PATH="/home/datadog/.local/bin:/home/datadog/go/bin:/usr/local/go/bin:${PATH}"

--- a/devcontainer/README.md
+++ b/devcontainer/README.md
@@ -29,8 +29,16 @@ docker pull registry.ddbuild.io/ci/datadog-agent-devenv:1-<platform>
 
 Option 2: Build the image locally
 
+Set the DDA version
+
 ```
-DOCKER_BUILDKIT=1 docker build --build-arg="GO_VERSION=1.22.5" -t registry.ddbuild.io/ci/datadog-agent-devenv:1 .
+source .dda.env
+```
+
+build the docker image
+
+```
+DOCKER_BUILDKIT=1 docker build --build-arg="GO_VERSION=1.24.5" --build-arg="DDA_VERSION=${DDA_VERSION}" -t registry.ddbuild.io/ci/datadog-agent-devenv:1 .
 ```
 
 The Go version currently in use in the default image can be found [here](https://github.com/DataDog/datadog-agent-buildimages/blob/main/go.env).


### PR DESCRIPTION
### What does this PR do?

Fixup warnings emitted on every call to the command `dda` by installing latest version of the python package `blinker` in usersapce.

Upgrade dda version.

### Motivation

It's very anoying to have warning printed and taking the output.

### Possible Drawbacks / Trade-offs

None that I see so far.

### Additional Notes

Closes: #942