### PR TITLE
Prevent building Linux release image on scheduled runs

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -160,7 +160,7 @@ build_kernel_version_testing_arm64:
     IMAGE: kernel-version-testing_arm64
 
 build_multiarch:
-  extends: [.always, .x64]
+  extends: [.no_schedule, .x64]
   stage: build
   needs:
     - job: build_linux_x64


### PR DESCRIPTION
### Motivation

The required images to produce the joint multi-arch image do not get pushed during scheduled pipelines and are therefore unavailable at this stage.

https://github.com/DataDog/datadog-agent-buildimages/blob/a6edab78df2f2ca0bd6fad725b6c1d78129b754c/build.sh#L12-L15