### PR TITLE
[ABLD-135] Add `bazelisk` to Linux containers

### DIFF
--- a/agent-deploy/Dockerfile
+++ b/agent-deploy/Dockerfile
@@ -177,6 +177,16 @@ ENV GO_VERSION $GO_VERSION
 ENV PATH="$PATH:/usr/local/go/bin"
 ENV PATH="${GOPATH}/bin:${PATH}"
 
+# Install & verify Bazelisk (Go package) as Bazel bootstrapper
+RUN bash <<'EOF'
+    set -euxo pipefail
+    go install github.com/bazelbuild/bazelisk@v1.27.0
+    ln -s bazelisk "$(command -v bazelisk | sed 's/bazelisk$/bazel/')"
+    export BAZELISK_HOME="$(mktemp -d)"
+    trap 'rm -rv -- "$BAZELISK_HOME"' EXIT
+    USE_BAZEL_VERSION=7.6.1 bazel --version | grep -Fq 'bazel 7.6.1'
+EOF
+
 # Install vault: https://github.com/hashicorp/vault/blob/main/CHANGELOG.md https://releases.hashicorp.com/vault
 RUN curl -LO https://releases.hashicorp.com/vault/${VAULT_VERSION}/${VAULT_FILENAME} && \
   echo "${VAULT_CHECKSUM} ${VAULT_FILENAME}" | sha256sum --check && \

--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -84,5 +84,16 @@ RUN go install golang.org/x/tools/gopls@latest && \
     go install github.com/go-delve/delve/cmd/dlv@latest && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest && \
     go install gotest.tools/gotestsum@latest
+
+# Install & verify Bazelisk (Go package) as Bazel bootstrapper
+RUN bash <<'EOF'
+    set -euxo pipefail
+    go install github.com/bazelbuild/bazelisk@v1.27.0
+    ln -s bazelisk "$(command -v bazelisk | sed 's/bazelisk$/bazel/')"
+    export BAZELISK_HOME="$(mktemp -d)"
+    trap 'rm -rv -- "$BAZELISK_HOME"' EXIT
+    USE_BAZEL_VERSION=7.6.1 bazel --version | grep -Fq 'bazel 7.6.1'
+EOF
+
 WORKDIR /home/datadog
 CMD [ "sleep", "infinity" ]

--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -58,6 +58,16 @@ ENV GOPATH /go
 ENV GO_VERSION $GO_VERSION
 ENV PATH="/go/bin:/usr/local/go/bin:${PATH}"
 
+# Install & verify Bazelisk (Go package) as Bazel bootstrapper
+RUN bash <<'EOF'
+    set -euxo pipefail
+    go install github.com/bazelbuild/bazelisk@v1.27.0
+    ln -s bazelisk "$(command -v bazelisk | sed 's/bazelisk$/bazel/')"
+    export BAZELISK_HOME="$(mktemp -d)"
+    trap 'rm -rv -- "$BAZELISK_HOME"' EXIT
+    USE_BAZEL_VERSION=7.6.1 bazel --version | grep -Fq 'bazel 7.6.1'
+EOF
+
 # Install vault: https://github.com/hashicorp/vault/blob/main/CHANGELOG.md https://releases.hashicorp.com/vault
 RUN curl -LO https://releases.hashicorp.com/vault/${VAULT_VERSION}/${VAULT_FILENAME} && \
   echo "${VAULT_CHECKSUM} ${VAULT_FILENAME}" | sha256sum --check && \

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -64,6 +64,16 @@ ENV GOPATH /go
 ENV GO_VERSION $GO_VERSION
 ENV PATH="/go/bin:/usr/local/go/bin:${PATH}"
 
+# Install & verify Bazelisk (Go package) as Bazel bootstrapper
+RUN bash <<'EOF'
+    set -euxo pipefail
+    go install github.com/bazelbuild/bazelisk@v1.27.0
+    ln -s bazelisk "$(command -v bazelisk | sed 's/bazelisk$/bazel/')"
+    export BAZELISK_HOME="$(mktemp -d)"
+    trap 'rm -rv -- "$BAZELISK_HOME"' EXIT
+    USE_BAZEL_VERSION=7.6.1 bazel --version | grep -Fq 'bazel 7.6.1'
+EOF
+
 # Install vault: https://github.com/hashicorp/vault/blob/main/CHANGELOG.md https://releases.hashicorp.com/vault
 RUN curl -LO https://releases.hashicorp.com/vault/${VAULT_VERSION}/${VAULT_FILENAME} && \
   echo "${VAULT_CHECKSUM} ${VAULT_FILENAME}" | sha256sum --check && \

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -145,6 +145,17 @@ COPY setup_go.sh /
 RUN ./setup_go.sh
 ENV PATH="${GOPATH}/bin:${PATH}"
 
+# Install & verify Bazelisk (Go package) as Bazel bootstrapper
+RUN bash <<'EOF'
+    source ~/.bashrc  # the actual Go binary path isn't in above `ENV PATH` (see `/setup_go.sh`)
+    set -euxo pipefail
+    go install github.com/bazelbuild/bazelisk@v1.27.0
+    ln -s bazelisk "$(command -v bazelisk | sed 's/bazelisk$/bazel/')"
+    export BAZELISK_HOME="$(mktemp -d)"
+    trap 'rm -rv -- "$BAZELISK_HOME"' EXIT
+    USE_BAZEL_VERSION=7.6.1 bazel --version | grep -Fq 'bazel 7.6.1'
+EOF
+
 # Rust setup
 RUN curl -sSL -o rustup-init https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${ARCH}-unknown-linux-gnu/rustup-init && \
     echo "${RUSTUP_SHA256}  rustup-init" | sha256sum --check && \

--- a/rpm-arm64/Dockerfile
+++ b/rpm-arm64/Dockerfile
@@ -146,6 +146,16 @@ RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-arm64.t
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV PATH="${GOPATH}/bin:${PATH}"
 
+# Install & verify Bazelisk (Go package) as Bazel bootstrapper
+RUN bash <<'EOF'
+    set -euxo pipefail
+    go install github.com/bazelbuild/bazelisk@v1.27.0
+    ln -s bazelisk "$(command -v bazelisk | sed 's/bazelisk$/bazel/')"
+    export BAZELISK_HOME="$(mktemp -d)"
+    trap 'rm -rv -- "$BAZELISK_HOME"' EXIT
+    USE_BAZEL_VERSION=7.6.1 bazel --version | grep -Fq 'bazel 7.6.1'
+EOF
+
 # Rust is needed to compile the SDS library
 RUN curl -sSL -o rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_ARCH}/rustup-init" \
     && echo "${RUSTUP_SHA256}  rustup-init" | sha256sum --check \

--- a/rpm-x64/Dockerfile
+++ b/rpm-x64/Dockerfile
@@ -172,6 +172,16 @@ RUN curl -sL -o /tmp/golang.tar.gz https://go.dev/dl/go$GO_VERSION.linux-amd64.t
 ENV PATH="/usr/local/go/bin:${PATH}"
 ENV PATH="${GOPATH}/bin:${PATH}"
 
+# Install & verify Bazelisk (Go package) as Bazel bootstrapper
+RUN bash <<'EOF'
+    set -euxo pipefail
+    go install github.com/bazelbuild/bazelisk@v1.27.0
+    ln -s bazelisk "$(command -v bazelisk | sed 's/bazelisk$/bazel/')"
+    export BAZELISK_HOME="$(mktemp -d)"
+    trap 'rm -rv -- "$BAZELISK_HOME"' EXIT
+    USE_BAZEL_VERSION=7.6.1 bazel --version | grep -Fq 'bazel 7.6.1'
+EOF
+
 # Add systemd headers
 COPY ./rpm-headers/systemd /usr/include/systemd
 


### PR DESCRIPTION
### What does this PR do?
As the title implies, this is to install the `bazelisk` command line tool (Go binary, ~9 MiB before compression) meant to bootstrap `bazel`, since the version of `bazel` itself will be branch-pinned for reproducible builds.
    
The present iteration targets Linux containers, with the noticeable exception of the `armhf` variant (ARM hard-float, 32-bit architecture) for which no `bazel` distribution will ever exist. We therefore aim at addressing the need by using cross-compilation instead - through `bazel` on either `x86_64` (aka `amd64`) or `aarch64` (aka `arm64`).
    
Note: the change leverages heredocs in `Dockerfile`s, which came out[^1] in 2021 and is now fully supported by:
- BuildKit v0.10.0+, since August 2022,
- Docker 23.0+, since February 2023. (without a need for passing experimental flags)
    
### Motivation
See [Agent Bazel Migration Plan](https://datadoghq.atlassian.net/wiki/spaces/ABLD/pages/5371789343/Agent+Bazel+Migration+Plan).

### Possible Drawbacks / Trade-offs
We may later envision to switch to the standalone binary distribution of `bazelisk` - at the expense of an increased filesystem footprint though.

### Additional Notes
See also:
- DataDog/ci-platform-machine-images#395
[^1]: https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/