### PR TITLE
Use more reliable GPG key server

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -91,7 +91,7 @@ RUN cd /build && \
 # Build cross-compilation toolchain
 RUN cd /build && \
     wget https://github.com/crosstool-ng/crosstool-ng/releases/download/crosstool-ng-${CTNG_VERSION}/crosstool-ng-${CTNG_VERSION}.tar.xz && \
-    gpg --keyserver pgp.surfnet.nl --recv-keys 1F30EF2E && \
+    gpg --keyserver keyserver.ubuntu.com --recv-keys 1F30EF2E && \
     wget https://github.com/crosstool-ng/crosstool-ng/releases/download/crosstool-ng-${CTNG_VERSION}/crosstool-ng-${CTNG_VERSION}.tar.xz.sig && \
     gpg --verify crosstool-ng-${CTNG_VERSION}.tar.xz.sig && \
     tar xf crosstool-ng-${CTNG_VERSION}.tar.xz && \


### PR DESCRIPTION
### What does this PR do?
The present change proposes to switch to `keyserver.ubuntu.com` (based on [Hockeypuck](https://hockeypuck.io)) because it's:
- well maintained and synchronized,
- already used in the repo: https://github.com/DataDog/datadog-agent-buildimages/blob/018496a52eca3a52fba20a2dbdb00b3a8dad6af2/agent-deploy/Dockerfile#L118

### Motivation
While working on #951, I started [facing](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/1081780433#L3596):
> gpg: keyserver receive failed: No data

At the time of writing, https://pgp.surfnet.nl shows:
```
503 Service Unavailable
No server is available to handle this request.
```

It turns out `pgp.surfnet.nl` had already posed problems in the past:
- 2023: https://github.com/crosstool-ng/crosstool-ng/issues/1945
- 2021: https://unix.stackexchange.com/q/656205
- 2021: https://dev.gnupg.org/T5751

### Additional Notes
`keys.openpgp.org` would also be a fine alternative (based on [hagrid](https://gitlab.com/keys.openpgp.org/hagrid)).