### PR TITLE
Add shellcheck to the main Linux image

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -65,7 +65,7 @@ RUN apt update -qy && apt install -y \
     pkg-config libssl-dev libcurl4-openssl-dev libexpat-dev libpq-dev libz-dev \
     rpm tar gettext autopoint autoconf clang libtool-bin \
     pkg-config flex meson selinux-basics squashfs-tools gpg xz-utils gnupg2 patchelf cpio \
-    linux-headers-generic jq libsystemd-dev clang-format libseccomp-dev \
+    linux-headers-generic jq libsystemd-dev clang-format libseccomp-dev shellcheck \
     ${ADDITIONAL_PACKAGE}
 
 # Git configuration


### PR DESCRIPTION
### Motivation

Having this preinstalled on the build and developer images will require one less step during runtime in CI, and one less thing engineers have to set up locally.

Only the main Linux image is being updated as the others are soon going away.