### PR TITLE
Fail CI job on Windows image creation error

### DIFF
--- a/build-container.ps1
+++ b/build-container.ps1
@@ -48,3 +48,4 @@ $cmd_args += $build_args
 # Build the image
 Write-Host "Building the image using $cmd and $cmd_args"
 & $cmd build $cmd_args
+exit $LASTEXITCODE


### PR DESCRIPTION
### Motivation
While working on #953, I mistakenly assumed my draft changes were fine but they were not. This is because [the CI job did not fail](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/1083683302#L3330) despite encountering [an error](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/1083683302#L3312) while creating the Windows image.

### What does this PR do?
The present change aims at fixing it by propagating the error status. ([works](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/1084675471#L3317))

### Additional Notes
😕 Adding the following lines had no effect:
```
$ErrorActionPreference = 'Stop'
$PSNativeCommandUseErrorActionPreference = $true
```
See also: [ACIX-983](https://datadoghq.atlassian.net/browse/ACIX-983)

[ACIX-983]: https://datadoghq.atlassian.net/browse/ACIX-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ