### PR TITLE
Fix KUBECTL_VERSION=`Timed out while waiting on cache␤`

### DIFF
--- a/dev-envs/linux/tools.sh
+++ b/dev-envs/linux/tools.sh
@@ -145,12 +145,21 @@ mkdir -p "${HOME}/.config"
 mkdir -p "${DD_REPOS_DIR}"
 gfold -d classic "${DD_REPOS_DIR}" --dry-run > "${HOME}/.config/gfold.toml"
 
+curl_opts=(
+  --fail              # fail on HTTP errors (>=400), prevents saving an error page
+  --silent            # no progress meter or extra output
+  --show-error        # but still show errors (important for debugging)
+  --location          # follow redirects
+  --retry 2           # retry N more times on transient errors
+  --retry-connrefused # also if connection is refused (CDN saturation cases)
+)
+
 # Always use the latest version of kubectl as recommended:
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
-KUBECTL_VERSION="$(curl -sL https://dl.k8s.io/release/stable.txt)"
+KUBECTL_VERSION="$(curl "${curl_opts[@]}" https://dl.k8s.io/release/stable.txt)"
 install-binary \
     --version "${KUBECTL_VERSION}" \
-    --digest "$(curl -sL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${short_arch}/kubectl.sha256")" \
+    --digest "$(curl "${curl_opts[@]}" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${short_arch}/kubectl.sha256")" \
     --url "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${short_arch}/kubectl" \
     --name "kubectl"
 
@@ -172,7 +181,7 @@ go install github.com/go-delve/delve/cmd/dlv@latest
 go install github.com/josharian/impl@latest
 go install github.com/fatih/gomodifytags@latest
 
-GOLANGCI_LINT_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent/main/internal/tools/go.mod | awk -Fv '/golangci-lint/ {print $2}')"
+GOLANGCI_LINT_VERSION="$(curl "${curl_opts[@]}" https://raw.githubusercontent.com/DataDog/datadog-agent/main/internal/tools/go.mod | awk -Fv '/golangci-lint/ {print $2}')"
 install-binary \
     --version "${GOLANGCI_LINT_VERSION}" \
     --digest "4037af8122871f401ed874852a471e54f147ff8ce80f5a304e020503bdb806ef" \


### PR DESCRIPTION
### Motivation
While working on #955, an unrelated job failed and had to be restarted: https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/1083853287

The error was kind of cryptic:
```
/bin/linux/amd64/kubectl' -Lo /tmp/kubectl
127.6 curl: (3) URL rejected: Malformed input to a URL function
ERROR: process "/bin/sh -c /setup/tools.sh" did not complete successfully: exit code: 3
```
There was no exploitable error in the console output, nor in the [full log](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/1083853287/viewer).

Fortunately, one could find a suspicious line in the [raw log](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/1083853287/raw):
```
127.3 + install-binary --version 'Timed out while waiting on cache-iad-kjyo7100113-IAD
' --digest '' --url 'https://dl.k8s.io/release/Timed out while waiting on cache-iad-kjyo7100113-IAD
/bin/linux/amd64/kubectl' --name kubectl
```
💡 `KUBECTL_VERSION` was set to: `Timed out while waiting on cache-iad-kjyo7100113-IAD␤`, because this is what `curl` printed to the standard output stream in its preceding invocation.

### What does this PR do?
The present change aims at fixing it by:
- adding fail-fast flags to `curl` invocations,
- enabling internal retries instead of having to retry the full job.