### PR TITLE
Also use `bind` mounts in Windows Docker builds

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -19,29 +19,15 @@ ARG MSGO_PATCH
 ARG DDA_VERSION
 
 ## WORKDIR should automatically create the directory
-WORKDIR c:/scripts
-COPY ./windows/*.ps1 ./
-COPY ./windows/helpers/*.ps1 c:/scripts/helpers/
-
-COPY go.env c:/
-COPY dda.env c:/
-
-COPY python-packages-versions.txt /
-COPY ./windows/set_cpython_compiler.cmd set_cpython_compiler.cmd
-
-
-COPY ./windows/helpers/phase1/*.ps1 c:/scripts/helpers/phase1/
+WORKDIR /mnt/windows
+RUN --mount=type=bind,dst=/mnt /mnt/windows/set_cpython_compiler.cmd
 SHELL ["powershell", "-Command"]
-RUN .\install-all.ps1 -TargetContainer -Phase 1
-COPY ./windows/helpers/phase2/*.ps1 c:/scripts/helpers/phase2/
-RUN .\install-all.ps1 -TargetContainer -Phase 2
-COPY ./windows/helpers/phase3/*.ps1 c:/scripts/helpers/phase3/
-RUN .\install-all.ps1 -TargetContainer -Phase 3
-COPY ./windows/helpers/phase4/*.ps1 c:/scripts/helpers/phase4/
-RUN .\install-all.ps1 -TargetContainer -Phase 4
-
+RUN --mount=type=bind,dst=/mnt /mnt/windows/install-all.ps1 -TargetContainer -Phase 1
+RUN --mount=type=bind,dst=/mnt /mnt/windows/install-all.ps1 -TargetContainer -Phase 2
+RUN --mount=type=bind,dst=/mnt /mnt/windows/install-all.ps1 -TargetContainer -Phase 3
+RUN --mount=type=bind,dst=/mnt /mnt/windows/install-all.ps1 -TargetContainer -Phase 4
 COPY ./windows/entrypoint.bat /entrypoint.bat
 COPY ./windows/helpers/aws_networking.ps1 /aws_networking.ps1
-RUN .\helpers\update_root_certs.ps1
+RUN --mount=type=bind,dst=/mnt /mnt/windows/helpers/update_root_certs.ps1
 
 ENTRYPOINT ["/entrypoint.bat"]

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -29,5 +29,6 @@ RUN --mount=type=bind,dst=/mnt /mnt/windows/install-all.ps1 -TargetContainer -Ph
 COPY ./windows/entrypoint.bat /entrypoint.bat
 COPY ./windows/helpers/aws_networking.ps1 /aws_networking.ps1
 RUN --mount=type=bind,dst=/mnt /mnt/windows/helpers/update_root_certs.ps1
-
+WORKDIR c:/
+RUN Remove-Item -Recurse -Verbose c:/mnt
 ENTRYPOINT ["/entrypoint.bat"]

--- a/windows/helpers/phase1/install_7zip.ps1
+++ b/windows/helpers/phase1/install_7zip.ps1
@@ -17,12 +17,11 @@ if($isInstalled -and $isCurrent){
 # assuming that exe installer would properly handle upgrade if we ever needed to
 # so not installed is the same as not current
 
-# Script directory is $PSScriptRoot
 $shortenedver = $Version.Replace('.','')
 $sevenzip="https://www.7-zip.org/a/7z$($shortenedver)-x64.exe"
 
 Write-Host -ForegroundColor Green "Installing 7zip $sevenzip"
-$out = "$($PSScriptRoot)\7zip.exe"
+$out = Join-Path ([IO.Path]::GetTempPath()) '7zip.exe'
 Get-RemoteFile -RemoteFile $sevenzip -LocalFile $out -VerifyHash $Sha256
 
 Start-Process $out -ArgumentList '/S' -Wait

--- a/windows/helpers/phase1/install_7zip_standalone.ps1
+++ b/windows/helpers/phase1/install_7zip_standalone.ps1
@@ -15,7 +15,6 @@ if($isInstalled -and $isCurrent){
     return
 }
 
-# Script directory is $PSScriptRoot
 $sevenZipStandalone ="https://github.com/ip7z/7zip/releases/download/$Version/7zr.exe"
 
 Write-Host -ForegroundColor Green "Installing 7zip Standalone $sevenZipStandalone"

--- a/windows/helpers/phase1/install_cmake.ps1
+++ b/windows/helpers/phase1/install_cmake.ps1
@@ -3,8 +3,6 @@ param (
     [Parameter(Mandatory=$true)][string]$Sha256
 )
 
-# Script directory is $PSScriptRoot
-
 $shortenedver = $Version.Replace('.','')
 $splitver = $Version.split(".")
 $majmin = "$($splitver[0])$($splitver[1])" 
@@ -21,7 +19,7 @@ if($isInstalled -and $isCurrent) {
 $cmakeurl = "https://github.com/Kitware/CMake/releases/download/v$($Version)/cmake-$($Version)-windows-x86_64.msi"
 
 Write-Host  -ForegroundColor Green starting with CMake
-$out = "$($PSScriptRoot)\cmake.msi"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'cmake.msi'
 
 Get-RemoteFile -RemoteFile $cmakeurl -LocalFile $out -VerifyHash $Sha256
 

--- a/windows/helpers/phase1/install_codecov.ps1
+++ b/windows/helpers/phase1/install_codecov.ps1
@@ -5,7 +5,7 @@ param (
 
 $CodecovPath = "c:\program files\codecov"
 $CodecovUrl = "https://uploader.codecov.io/$Version/windows/codecov.exe"
-$OutFile = "$($PSScriptRoot)\codecov.exe"
+$OutFile = Join-Path ([IO.Path]::GetTempPath()) 'codecov.exe'
 
 if (Test-Path -Path "$CodecovPath\codecov.exe") {
     Write-Output "$CodecovPath\codecov.exe already exists on the system."

--- a/windows/helpers/phase1/install_dotnetcore.ps1
+++ b/windows/helpers/phase1/install_dotnetcore.ps1
@@ -11,7 +11,7 @@ if(-not $isCurrent){
 }
 Write-Host -ForegroundColor Green "Installing dotnetcore from $($env:DOTNETCORE_URL)"
 
-$out = "$($PSScriptRoot)\dotnetcoresdk.exe"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'dotnetcoresdk.exe'
 
 Get-RemoteFile -RemoteFile $env:DOTNETCORE_URL -LocalFile $out -VerifyHash $env:DOTNETCORE_SHA256
 Write-Host -ForegroundColor Green Downloading $env:DOTNETCORE_URL to $out

--- a/windows/helpers/phase1/install_mingit.ps1
+++ b/windows/helpers/phase1/install_mingit.ps1
@@ -8,12 +8,10 @@ param (
 ## in developer mode
 
 function InstallMinGit() {
-    # Script directory is $PSScriptRoot
-
     $mingit = "https://github.com/git-for-windows/git/releases/download/v$($Version).windows.1/MinGit-$($Version)-64-bit.zip"
 
     Write-Host -ForegroundColor Green Installing MinGit
-    $out = "$($PSScriptRoot)\mingit.zip"
+    $out = Join-Path ([IO.Path]::GetTempPath()) 'mingit.zip'
     Get-RemoteFile -RemoteFile $mingit -LocalFile $out -VerifyHash $Sha256
 
     if(! (test-path "c:\devtools\git")){
@@ -41,7 +39,7 @@ function InstallWinGit() {
         return $false
     }
     Write-Host -ForegroundColor Green "Installing WinGit"
-    $out = "$($PSScriptRoot)\wingit.exe"
+    $out = Join-Path ([IO.Path]::GetTempPath()) 'wingit.exe'
     Get-RemoteFile -RemoteFile $wingit -LocalFile $out -VerifyHash $Sha256
 
     Start-Process $out -ArgumentList "/VERYSILENT" -Wait -NoNewWindow

--- a/windows/helpers/phase1/install_nuget.ps1
+++ b/windows/helpers/phase1/install_nuget.ps1
@@ -16,7 +16,7 @@ if(-not $isInstalled) {
     Remove-Item -Force "c:\nuget\nuget.exe" -ErrorAction SilentlyContinue
 }
 Write-Host -ForegroundColor Green "Downloading nuget"
-$out = "$($PSScriptRoot)\nuget.exe"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'nuget.exe'
 
 Get-RemoteFile -RemoteFile $nugetexe -LocalFile $out -VerifyHash $Sha256
 

--- a/windows/helpers/phase1/install_vstudio.ps1
+++ b/windows/helpers/phase1/install_vstudio.ps1
@@ -53,7 +53,7 @@ if($Env:DD_DEV_TARGET -eq "Container") {
 }
 Write-Host -ForegroundColor Green "Installing Visual Studio from $($Url)"
 
-$out = "$($PSScriptRoot)\vs_buildtools.exe"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'vs_buildtools.exe'
 
 Write-Host -ForegroundColor Green Downloading $Url to $out
 Get-RemoteFile -RemoteFile $Url -LocalFile $out -VerifyHash $Sha256

--- a/windows/helpers/phase1/install_wdk.ps1
+++ b/windows/helpers/phase1/install_wdk.ps1
@@ -14,7 +14,7 @@ if ($isinstalled) {
 }
 
 Write-Host -foregroundcolor green installing wdk
-$out = "$($psscriptroot)\wdksetup.exe"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'wdksetup.exe'
 $sha256 = "59c802a7edf1ecca172ec76a8b07702239ae83ee5ff9d1acb6742b2e224e9227"
 Write-Host -foregroundcolor green downloading $wdk to $out
 
@@ -26,7 +26,7 @@ Write-Host -foregroundcolor green "file size is $((get-item $out).length)"
 
 
 start-process $out -argumentlist '/features + /quiet' -wait
-
+Remove-Item $out
 
 set-installedversionkey -component "wdk" -keyname "downloadfile" -targetvalue $wdk
 Write-Host -foregroundcolor green done with wdk

--- a/windows/helpers/phase1/install_wix.ps1
+++ b/windows/helpers/phase1/install_wix.ps1
@@ -21,7 +21,7 @@ if($isInstalled) {
 
 
 Write-Host  -ForegroundColor Green starting with WiX
-$out = "$($PSScriptRoot)\wix.exe"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'wix.exe'
 
 Get-RemoteFile -RemoteFile $wixzip -LocalFile $out -VerifyHash $Sha256
 

--- a/windows/helpers/phase2/install_embedded_pythons.ps1
+++ b/windows/helpers/phase2/install_embedded_pythons.ps1
@@ -30,7 +30,8 @@ DownloadAndExpandTo -TargetDir $py3Target -SourceURL $py3 -Sha256 "$Env:EMBEDDED
 Add-EnvironmentVariable -Variable "TEST_EMBEDDED_PY3" -Value $py3Target -Global
 
 # Read DD_PIP_VERSION{,_PY3} and DD_SETUPTOOLS_VERSION{,_PY3} to variables
-Get-Content \python-packages-versions.txt | Where-Object { $_.Trim() -ne '' } | Where-Object { $_.Trim() -notlike "#*" } | Foreach-Object{
+$packages_file = Join-Path $PSScriptRoot '..\..\..\python-packages-versions.txt'
+Get-Content $packages_file | Where-Object { $_.Trim() -ne '' } | Where-Object { $_.Trim() -notlike "#*" } | Foreach-Object{
    $var = $_.Split('=')
    Add-EnvironmentVariable -Variable $var[0] -Value $var[1] -Local
 }
@@ -38,6 +39,8 @@ Get-Content \python-packages-versions.txt | Where-Object { $_.Trim() -ne '' } | 
 # Python 3
 $py3getpip = "https://raw.githubusercontent.com/pypa/get-pip/66d8a0f637083e2c3ddffc0cb1e65ce126afb856/public/get-pip.py"
 $py3getpipsha256 = "6fb7b781206356f45ad79efbb19322caa6c2a5ad39092d0d44d0fec94117e118"
-Get-RemoteFile -LocalFile "get-pip.py" -RemoteFile $py3getpip -VerifyHash $py3getpipsha256
-& "$py3Target\python" get-pip.py pip==${Env:DD_PIP_VERSION_PY3}
+$out = Join-Path ([IO.Path]::GetTempPath()) 'get-pip.py'
+Get-RemoteFile -LocalFile $out -RemoteFile $py3getpip -VerifyHash $py3getpipsha256
+& "$py3Target\python" "$out" pip==${Env:DD_PIP_VERSION_PY3}
+Remove-Item $out
 If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/windows/helpers/phase2/install_gcloud_sdk.ps1
+++ b/windows/helpers/phase2/install_gcloud_sdk.ps1
@@ -5,7 +5,7 @@ $ProgressPreference = 'SilentlyContinue'
 Write-Host -ForegroundColor Green Installing Google Cloud SDK
 $version = $ENV:GCLOUD_SDK_VERSION
 $gsdk = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$version-windows-x86_64.zip"
-$out = "$($PSScriptRoot)\gsdk.zip"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'gsdk.zip'
 $sha256 = $ENV:GCLOUD_SDK_SHA256
 
 $isInstalled, $isCurrent = Get-InstallUpgradeStatus -Component "GCloudSDK" -Keyname "version" -TargetValue $version

--- a/windows/helpers/phase2/install_msys.ps1
+++ b/windows/helpers/phase2/install_msys.ps1
@@ -43,7 +43,8 @@ $mirrors = @(
 )
 
 Write-Host  -ForegroundColor Green starting with MSYS
-$out = "$($PSScriptRoot)\msys.tar.xz"
+$outDir = [IO.Path]::GetTempPath()
+$out = Join-Path $outDir 'msys.tar.xz'
 $msyszip = "distrib/x86_64/msys2-base-x86_64-$($Version).tar.xz"
 $downloadSuccessful = $False
 foreach($mirror in $mirrors) {
@@ -60,8 +61,8 @@ if (!$downloadSuccessful) {
 }
 
 # uncompress the tar-xz into a tar
-$msystar = "msys.tar"
-& 7z x $out
+$msystar = Join-Path $outDir 'msys.tar'
+& 7z x -o"$outDir" $out
 start-process 7z -ArgumentList "x -o$($InstallPath) $msystar" -Wait
 
 Remove-Item $out

--- a/windows/helpers/phase2/install_python.ps1
+++ b/windows/helpers/phase2/install_python.ps1
@@ -16,7 +16,7 @@ if($isInstalled -and $isCurrent) {
 ## presumably installer exe knows how to handle upgrades
 
 Write-Host  -ForegroundColor Green starting with Python
-$out = "$($PSScriptRoot)\python.exe"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'python.exe'
 
 Get-RemoteFile -RemoteFile $pyexe -LocalFile $out -VerifyHash $Sha256
 
@@ -31,20 +31,18 @@ Remove-Item $out
 
 $getpipurl = "https://raw.githubusercontent.com/pypa/get-pip/66d8a0f637083e2c3ddffc0cb1e65ce126afb856/public/get-pip.py"
 $getpipsha256 = "6fb7b781206356f45ad79efbb19322caa6c2a5ad39092d0d44d0fec94117e118"
-$target = "$($PSScriptRoot)\get-pip.py"
+$target = Join-Path ([IO.Path]::GetTempPath()) 'get-pip.py'
 
 Get-RemoteFile -RemoteFile $getpipurl -LocalFile $target -VerifyHash $getpipsha256
 
-$packages_file = "\python-packages-versions.txt"
-if($Env:DD_DEV_TARGET -ne "Container") {
-    $packages_file = "$($PSScriptRoot)\..\..\.." + $packages_file
-}
+$packages_file = Join-Path $PSScriptRoot '..\..\..\python-packages-versions.txt'
 Get-Content $packages_file | Where-Object { $_.Trim() -ne '' } | Where-Object { $_.Trim() -notlike "#*" } | Foreach-Object{
     $var = $_.Split('=')
     Add-EnvironmentVariable -Variable $var[0] -Value $var[1] -Local
 }
 
-python "$($PSScriptRoot)\get-pip.py" pip==${Env:DD_PIP_VERSION_PY3}
+python "$target" pip==${Env:DD_PIP_VERSION_PY3}
+Remove-Item $target
 if($Env:DD_DEV_TARGET -ne "Container") {
     ## When installing for local use, set up the virtual environment first
     python -m venv "$($Env:USERPROFILE)\.ddbuild\agentdev"
@@ -53,7 +51,7 @@ if($Env:DD_DEV_TARGET -ne "Container") {
 
 python -m pip install uv==${Env:DD_UV_VERSION}
 
-$repoPath = "$($PSScriptRoot)\datadog-agent-dev"
+$repoPath = Join-Path ([IO.Path]::GetTempPath()) 'datadog-agent-dev'
 if (Test-Path "$repoPath") {
     Remove-Item -Recurse -Force "$repoPath"
 }

--- a/windows/helpers/phase2/install_ruby.ps1
+++ b/windows/helpers/phase2/install_ruby.ps1
@@ -18,7 +18,7 @@ if($isInstalled -and -not $isCurrent) {
 $rubyexe = "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-$($Version)/rubyinstaller-$($Version)-x64.exe"
 
 Write-Host  -ForegroundColor Green starting with Ruby
-$out = "$($PSScriptRoot)\rubyinstaller.exe"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'rubyinstaller.exe'
 
 Get-RemoteFile -RemoteFile $rubyexe -LocalFile $out -VerifyHash $Sha256
 

--- a/windows/helpers/phase3/install_awscli.ps1
+++ b/windows/helpers/phase3/install_awscli.ps1
@@ -6,8 +6,6 @@ param (
     [Parameter(Mandatory=$true)][string]$Version
 )
 
-# Script directory is $PSScriptRoot
-
 $isInstalled, $isCurrent = Get-InstallUpgradeStatus -Component "AWSCLI" -Keyname "version" -TargetValue $Version
 if($isInstalled -and $isCurrent) {
     Write-Host -ForegroundColor Green "AWS CLI v2 up to date"
@@ -19,7 +17,7 @@ $awsCliUrl = "https://awscli.amazonaws.com/AWSCLIV2-${Version}.msi"
 $installPath = "$env:ProgramFiles\Amazon\AWSCLIV2"
 
 Write-Host -ForegroundColor Green "Starting with AWS CLI v2 installation"
-$out = "$($PSScriptRoot)\awscli.msi"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'awscli.msi'
 
 Get-RemoteFile -RemoteFile $awsCliUrl -LocalFile $out -VerifyHash $Sha256
 

--- a/windows/helpers/phase3/install_bazelisk.ps1
+++ b/windows/helpers/phase3/install_bazelisk.ps1
@@ -29,7 +29,7 @@ try {
 Add-ToPath -NewPath $targetDir -Global -Local
 Write-Host -ForegroundColor Green "Installed bazelisk v$Version"
 
-$bazeliskHome = (New-Item -ItemType Directory -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName()))).FullName
+$bazeliskHome = (New-Item -ItemType Directory -Path (Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName()))).FullName
 try {
     $output = & {
         $env:BAZELISK_HOME = "$bazeliskHome"

--- a/windows/helpers/phase3/install_codeql.ps1
+++ b/windows/helpers/phase3/install_codeql.ps1
@@ -12,7 +12,7 @@ if($isInstalled -and -not $isCurrent){
 Write-Host -ForegroundColor Green "Installing CodeQL $ENV:CODEQL_VERSION"
 #             https://github.com/github/codeql-cli-binaries/releases/download/v2.10.3/codeql-win64.zip
 $codeqlzip = "https://github.com/github/codeql-cli-binaries/releases/download/v$ENV:CODEQL_VERSION/codeql-win64.zip"
-$out = "$($PSScriptRoot)\codeql.zip"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'codeql.zip'
 
 Write-Host -ForegroundColor Green "Downloading $codeqlzip to $out"
 

--- a/windows/helpers/phase3/install_go.ps1
+++ b/windows/helpers/phase3/install_go.ps1
@@ -7,8 +7,8 @@ Write-Host -ForegroundColor Green "Installing msgo $ENV:GO_VERSION-$ENV:MSGO_PAT
 $gozip = "https://dl.google.com/go/go$ENV:GO_VERSION.windows-amd64.zip"
 $msgozip="https://aka.ms/golang/release/latest/go$($ENV:GO_VERSION)-$($ENV:MSGO_PATCH).windows-amd64.zip"
 
-$out = "$($PSScriptRoot)\go.zip"
-$msgo_out = "$($PSScriptRoot)\msgo.zip"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'go.zip'
+$msgo_out = Join-Path ([IO.Path]::GetTempPath()) 'msgo.zip'
 
 ##
 ## because we want to allow multiple versions of GO, we need to handle

--- a/windows/helpers/phase3/install_java.ps1
+++ b/windows/helpers/phase3/install_java.ps1
@@ -7,7 +7,7 @@ Write-Host -ForegroundColor Green "Installing Java $ENV:JAVA_VERSION"
 ## https://aka.ms/download-jdk/microsoft-jdk-17.0.8-windows-x64.zip
 $javazip = "https://aka.ms/download-jdk/microsoft-jdk-$($ENV:JAVA_VERSION)-windows-x64.zip"
 
-$out = 'java.zip'
+$out = Join-Path ([IO.Path]::GetTempPath()) 'java.zip'
 
 Write-Host -ForegroundColor Green "Downloading $javazip to $out"
 
@@ -18,7 +18,7 @@ mkdir c:\tmp\java
 
 Write-Host -ForegroundColor Green "Extracting $out to c:\tmp\java"
 
-Start-Process "7z" -ArgumentList 'x -oc:\tmp\java java.zip' -Wait
+Start-Process "7z" -ArgumentList "x -oc:\tmp\java $out" -Wait
 
 Write-Host -ForegroundColor Green "Removing temporary file $out"
 

--- a/windows/helpers/phase3/install_rust.ps1
+++ b/windows/helpers/phase3/install_rust.ps1
@@ -23,13 +23,14 @@ if($isInstalled -and $isCurrent) {
 $source="https://static.rust-lang.org/rustup/archive/$Rustup_Version/x86_64-pc-windows-msvc/rustup-init.exe"
 
 Write-Host -ForegroundColor Green "Installing rust-up"
-$out = "$($PSScriptRoot)\rustup-init.exe"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'rustup-init.exe'
 Get-RemoteFile -RemoteFile $source -LocalFile $out -VerifyHash $Rustup_Sha256
 
 Set-InstalledVersionKey -Component "rust-up" -Keyname "version" -TargetValue $Rustup_Version
 
 Write-Host -ForegroundColor Green "Installing rust"
 & $out -y --default-toolchain $Rust_Version
+Remove-Item $out
 
 Set-InstalledVersionKey -Component "rust" -Keyname "version" -TargetValue $Rust_Version
 

--- a/windows/helpers/phase3/install_winget.ps1
+++ b/windows/helpers/phase3/install_winget.ps1
@@ -15,7 +15,7 @@ if($installed -and -not $isCurrent){
     Remove-Item -Force \winget\wingetcreate.exe -ErrorAction SilentlyContinue
 }
 Write-Host -ForegroundColor Green "Downloading winget"
-$out = "$($PSScriptRoot)\wingetcreate.exe"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'wingetcreate.exe'
 
 Get-RemoteFile -RemoteFile $wingetexe -LocalFile $out -VerifyHash $Sha256
 
@@ -44,7 +44,7 @@ if(-not $isCurrent){
     ## presumably executable knows how to handle upgrade
 }
 Write-Host -ForegroundColor Green "Installing dotnet core 6 from $dotnetcore6url"
-$out = "$($PSScriptRoot)\dotnetcore.exe"
+$out = Join-Path ([IO.Path]::GetTempPath()) 'dotnetcore.exe'
 
 Get-RemoteFile -RemoteFile $dotnetcore6url -LocalFile $out -VerifyHash $dotnetcore6hash
 Write-Host -ForegroundColor Green Downloading $dotnetcore6url to $out


### PR DESCRIPTION
### What does this PR do? / Motivation
It turns out `bind` mounts introduced by #958 in Linux Docker builds also work well in Windows builds.

The present change therefore proposes to leverage the feature here too so as to shrink down layers affected by repeated `COPY`s. (overlays)

Doing so unearthed a few issues: (thanks to `bind` mounts in builds being read/only by design)
- quite a number of temporary files (installers, tarballs) where downloaded/extracted to various depths within installation scripts,
- some of these temporaries were not removed after installation:
  - under `./`: `get-pip.py`, (first occurrence)
  - under `./helpers/phase1`: `wdksetup.exe`,
  - under `./helpers/phase2`: `get-pip.py`, (second occurrence)
  - under `./helpers/phase3`: `rustup-init.exe`.

The present change therefore addresses these as well.

### Additional Notes
- #958
- https://github.com/moby/buildkit/issues/2893
- https://stackoverflow.com/questions/72882140/docker-buildkit-new-mount-command-during-build-and-large-files-in-the-context
- https://www.bestonlinetutorial.com/docker/how-can-you-mount-host-volumes-into-docker-containers-in-a-dockerfile-during-build.html