### PR TITLE
Update codeowners after recent unification effort

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,12 +29,10 @@ dda.env                             @DataDog/agent-devx
 /kernel-version-testing/            @DataDog/ebpf-platform @DataDog/agent-devx
 
 # Linux test & build images
-/deb-arm/                           @DataDog/agent-devx @DataDog/agent-build
-/deb-x64/                           @DataDog/agent-devx @DataDog/agent-build
 /rpm-arm64/                         @DataDog/agent-devx @DataDog/agent-build
 /rpm-armhf/                         @DataDog/agent-devx @DataDog/agent-build
 /rpm-x64/                           @DataDog/agent-devx @DataDog/agent-build
-/linux-glibc-*/                     @DataDog/agent-devx @DataDog/agent-build
+/linux/                             @DataDog/agent-devx @DataDog/agent-build
 
 # Windows test & build images
 /windows/                           @DataDog/windows-products @DataDog/agent-devx


### PR DESCRIPTION
### What does this PR do?

Updates codeowners to reflect some of the recent changes to this repository.

### Motivation

Some recent changes were done without adjusting codeowners to reflect.

- https://github.com/DataDog/datadog-agent-buildimages/pull/902 unified linux-glibc images into one dockerfile and changed naming / location to just `linux`.
- https://github.com/DataDog/datadog-agent-buildimages/pull/941 removed deb-arm and deb-x64 images.

### Possible Drawbacks / Trade-offs

### Additional Notes
