### PR TITLE
fix(stats): Do not compute stats on scheduled jobs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,9 @@ ${CUSTOM_BUILD_ARGS:-} \
 --output type=docker,dest=./$IMAGE-$IMAGE_VERSION.tar
 
 # Statistics
-crane manifest registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION | jq
-crane config registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION | jq
-export SIZE=$(crane manifest registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION | jq '.config.size + ([.layers[].size] | add)')
-./send-metrics.sh $IMAGE $SIZE $CI_COMMIT_REF_NAME
+if [[ "$CI_PIPELINE_SOURCE" != "schedule" ]]; then
+    crane manifest registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION | jq
+    crane config registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION | jq
+    export SIZE=$(crane manifest registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION | jq '.config.size + ([.layers[].size] | add)')
+    ./send-metrics.sh $IMAGE $SIZE $CI_COMMIT_REF_NAME
+fi


### PR DESCRIPTION
### What does this PR do?
Prevent the execution of the statistics during the schedules pipelines.

### Motivation
The scheduled pipelines do not push the result of the build. As `crane` checks the registry, it results in a [failure](https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/1097929284).

### Possible Drawbacks / Trade-offs

### Additional Notes
