### PR TITLE
Add Windows Server 2025 build images

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -172,7 +172,7 @@ build_dev_env_linux_arm64:
     BASE_IMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$ECR_TEST_ONLY
     BASE_IMAGE_TAG: $IMAGE_VERSION-arm64
 
-build_windows_ltsc2022_x64:
+.build_windows_x64:
   stage: build
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
@@ -192,13 +192,24 @@ build_windows_ltsc2022_x64:
   variables:
     CI_IDENTITY_ROLE_NAME_OVERRIDE: windows-ci-tmp-gitlab-id-token-datadog-agent-buildimages-all-refs
     DOCKERFILE: windows/Dockerfile
-    IMAGE: windows_ltsc2022_x64
     DD_TARGET_ARCH: x64
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $SRC_IMAGE = "registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}"
-    - .\build-container.ps1 -Image $SRC_IMAGE -Tag $IMAGE_VERSION -Buildkit
+    - .\build-container.ps1 -Image $SRC_IMAGE -WindowsVersion $WINDOWS_VERSION -Tag $IMAGE_VERSION -Buildkit
     - New-Item -ItemType File -Path "windows.image" -Force # Create a file to indicate that the image is built
   artifacts:
     paths: ["./windows.image"]
     expire_in: 1 day
+
+build_windows_ltsc2022_x64:
+  extends: [.build_windows_x64]
+  variables:
+    IMAGE: windows_ltsc2022_x64
+    WINDOWS_VERSION: 2022
+
+build_windows_ltsc2025_x64:
+  extends: [.build_windows_x64]
+  variables:
+    IMAGE: windows_ltsc2025_x64
+    WINDOWS_VERSION: 2025

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -196,7 +196,7 @@ build_dev_env_linux_arm64:
   script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - $SRC_IMAGE = "registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}"
-    - .\build-container.ps1 -Image $SRC_IMAGE -WindowsVersion $WINDOWS_VERSION -Tag $IMAGE_VERSION -Buildkit
+    - .\build-container.ps1 -Image $SRC_IMAGE -Tag $IMAGE_VERSION -Buildkit
     - New-Item -ItemType File -Path "windows.image" -Force # Create a file to indicate that the image is built
   artifacts:
     paths: ["./windows.image"]
@@ -206,10 +206,8 @@ build_windows_ltsc2022_x64:
   extends: [.build_windows_x64]
   variables:
     IMAGE: windows_ltsc2022_x64
-    WINDOWS_VERSION: 2022
 
 build_windows_ltsc2025_x64:
   extends: [.build_windows_x64]
   variables:
     IMAGE: windows_ltsc2025_x64
-    WINDOWS_VERSION: 2025

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -183,6 +183,7 @@ build_dev_env_linux_arm64:
           - build-container.ps1
           - windows/**/*
           - go.env
+          - .gitlab/build.yml
         compare_to: $COMPARE_TO_BRANCH
   timeout: 2h 30m
   tags: ["windows-v2:2022"]

--- a/build-container.ps1
+++ b/build-container.ps1
@@ -1,8 +1,7 @@
 param(
     [Parameter(Mandatory = $true)][string] $Image,
     [Parameter(Mandatory = $true)][string] $Tag,
-    [Parameter(Mandatory = $false)][switch] $Buildkit = $false,
-    [Parameter(Mandatory = $false)][string] $WindowsVersion = "2022"
+    [Parameter(Mandatory = $false)][switch] $Buildkit = $false
 )
 
 $build_args = @()
@@ -35,8 +34,7 @@ if ($Buildkit) {
 }
 
 # Get build arguments from environment variables
-$base_image = "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc${WindowsVersion}"
-$build_args += -split "${build_opt}BASE_IMAGE=${base_image}" 
+$build_args += -split "${build_opt}BASE_IMAGE=mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022" 
 foreach ($line in $(Get-Content go.env)) {
     if ( -not ($line -like "*LINUX*") ) {
         $build_args += -split "$build_opt$line"

--- a/build-container.ps1
+++ b/build-container.ps1
@@ -1,7 +1,8 @@
 param(
     [Parameter(Mandatory = $true)][string] $Image,
     [Parameter(Mandatory = $true)][string] $Tag,
-    [Parameter(Mandatory = $false)][switch] $Buildkit = $false
+    [Parameter(Mandatory = $false)][switch] $Buildkit = $false,
+    [Parameter(Mandatory = $false)][string] $WindowsVersion = "2022"
 )
 
 $build_args = @()
@@ -34,7 +35,8 @@ if ($Buildkit) {
 }
 
 # Get build arguments from environment variables
-$build_args += -split "${build_opt}BASE_IMAGE=mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022" 
+$base_image = "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc${WindowsVersion}"
+$build_args += -split "${build_opt}BASE_IMAGE=${base_image}" 
 foreach ($line in $(Get-Content go.env)) {
     if ( -not ($line -like "*LINUX*") ) {
         $build_args += -split "$build_opt$line"


### PR DESCRIPTION
### What does this PR do?
This PR adds Windows Server 2025 build images to the CI.
This is a prerequisite for Windows Server 2025 docket agent images.
Much thanks to @julien-lebot for expert help.

### Motivation
Part of https://datadoghq.atlassian.net/browse/WINA-1782
