### PR TITLE
fix(README): Update the link for the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Datadog Agent builders
 
-![Docker Image Version](https://img.shields.io/docker/v/datadog/agent-buildimages-deb_x64)
+![Docker Image Version](https://img.shields.io/docker/v/datadog/agent-buildimages-linux)
 ![GitHub License](https://img.shields.io/github/license/datadog/datadog-agent-buildimages)
 
 This repo contains the Dockerfiles of the images used to build the rpm and deb


### PR DESCRIPTION


### What does this PR do?
The badge for the buildimage version was using deb64 as reference and it doesn't exist anymore. Use the new linux reference instead.

### Motivation
Tech debt

### Possible Drawbacks / Trade-offs

### Additional Notes
