### PR TITLE
Make `crosstool-ng` toolchains tarball-friendly

### DIFF
--- a/linux/arm64/config-aarch64-unknown-gnu-linux-glibc2.23
+++ b/linux/arm64/config-aarch64-unknown-gnu-linux-glibc2.23
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.26.0.6_12dd994 Configuration
+# crosstool-NG 1.26.0 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
@@ -27,7 +27,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.26.0.6_12dd994"
+CT_VERSION="1.26.0"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -58,7 +58,7 @@ CT_PREFIX_DIR="${CT_PREFIX:-${HOME}/x-tools}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TA
 CT_RM_RF_PREFIX_DIR=y
 CT_REMOVE_DOCS=y
 CT_INSTALL_LICENSES=y
-CT_PREFIX_DIR_RO=y
+# CT_PREFIX_DIR_RO is not set
 CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 # CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES is not set
 

--- a/linux/arm64/config-x86_64-unknown-gnu-linux-glibc2.17
+++ b/linux/arm64/config-x86_64-unknown-gnu-linux-glibc2.17
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.26.0.6_12dd994 Configuration
+# crosstool-NG 1.26.0 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
@@ -27,7 +27,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.26.0.6_12dd994"
+CT_VERSION="1.26.0"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -58,7 +58,7 @@ CT_PREFIX_DIR="${CT_PREFIX:-${HOME}/x-tools}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TA
 CT_RM_RF_PREFIX_DIR=y
 CT_REMOVE_DOCS=y
 CT_INSTALL_LICENSES=y
-CT_PREFIX_DIR_RO=y
+# CT_PREFIX_DIR_RO is not set
 CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 # CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES is not set
 

--- a/linux/x64/config-aarch64-unknown-gnu-linux-glibc2.23
+++ b/linux/x64/config-aarch64-unknown-gnu-linux-glibc2.23
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.26.0.121_5a40a36 Configuration
+# crosstool-NG 1.26.0 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
@@ -27,7 +27,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.26.0.121_5a40a36"
+CT_VERSION="1.26.0"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -58,7 +58,7 @@ CT_PREFIX_DIR="${CT_PREFIX:-${HOME}/x-tools}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TA
 CT_RM_RF_PREFIX_DIR=y
 CT_REMOVE_DOCS=y
 CT_INSTALL_LICENSES=y
-CT_PREFIX_DIR_RO=y
+# CT_PREFIX_DIR_RO is not set
 CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 # CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES is not set
 

--- a/linux/x64/config-x86_64-unknown-gnu-linux-glibc2.17
+++ b/linux/x64/config-x86_64-unknown-gnu-linux-glibc2.17
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.26.0.6_12dd994 Configuration
+# crosstool-NG 1.26.0 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
@@ -27,7 +27,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.26.0.6_12dd994"
+CT_VERSION="1.26.0"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -58,7 +58,7 @@ CT_PREFIX_DIR="${CT_PREFIX:-${HOME}/x-tools}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TA
 CT_RM_RF_PREFIX_DIR=y
 CT_REMOVE_DOCS=y
 CT_INSTALL_LICENSES=y
-CT_PREFIX_DIR_RO=y
+# CT_PREFIX_DIR_RO is not set
 CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 # CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES is not set
 


### PR DESCRIPTION
### Motivation
While `bazel`ifying `crosstool-ng`-based toolchains, we encountered the problem that their archives were not extractible on all GitLab runners:
```
Error in download_and_extract: java.io.IOException: Error extracting
 [...]/datadog_agent_cc_toolchain_x86_64.tar.gz:
 [...]/usr/include/linux/netfilter/xt_connmark.h (Permission denied)
```
Examples:
- darwin/amd64: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1115250752
- darwin/arm64: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1115250399
- windows: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1115251286

The main culprit is that the archives from installed toolchains hold intermediate **directories that are read-only for the user**:
```sh
$ tar tvzf datadog_agent_cc_toolchain_x86_64.tar.gz | head
dr-xr-xr-x root/root         0 2025-08-20 15:03 ./
# ￪ oops
dr-xr-xr-x root/root         0 2025-08-20 14:54 ./etc/
# ￪ oops
-r--r--r-- root/root      3886 2025-08-20 14:54 ./etc/gprofng.rc
dr-xr-xr-x root/root         0 2025-08-20 15:04 ./x86_64-unknown-linux-gnu/
# ￪ oops
dr-xr-xr-x root/root         0 2025-08-20 14:59 ./x86_64-unknown-linux-gnu/sysroot/
# ￪ oops
dr-xr-xr-x root/root         0 2025-08-20 14:59 ./x86_64-unknown-linux-gnu/sysroot/etc/
# ￪ oops
-r--r--r-- root/root      1634 2025-08-20 14:59 ./x86_64-unknown-linux-gnu/sysroot/etc/rpc
dr-xr-xr-x root/root         0 2025-08-20 15:04 ./x86_64-unknown-linux-gnu/sysroot/lib/
# ￪ oops
-r--r--r-- root/root       132 2025-08-20 15:04 ./x86_64-unknown-linux-gnu/sysroot/lib/libgcc_s.so
lrwxrwxrwx root/root         0 2025-08-20 15:04 ./x86_64-unknown-linux-gnu/sysroot/lib/libstdc++.so.6 -> libstdc++.so.6.0.29
```
... which poses problems to non-GNU implementations of `tar` when attempting to extract files to them:
> Moreover, restoring that directory permissions may not permit file creation within it. Thus, restoring directory permissions and
> modification times must be delayed at least until all files have been extracted into that directory. GNU `tar` restores directories using the following approach.

(https://www.gnu.org/software/tar/manual/html_node/Directory-Modification-Times-and-Permissions.html)

### What does this PR do?
As it turns out to be a [configurable feature](https://github.com/crosstool-ng/crosstool-ng/blob/d427a7ca41690f9d50c04049df6b9b1fe35810d7/scripts/crosstool-NG.sh#L750-L752), the present change aims at exercising it to make them more tarball-friendly, i.e. compatible with non-GNU `tar` implementations.

### Additional Notes
How to:
1. download `crosstool-ng`. I used the version in-sync with the present repo: https://github.com/crosstool-ng/crosstool-ng/releases/download/crosstool-ng-1.26.0/crosstool-ng-1.26.0.tar.xz
2. extract it and enter the `crosstool-ng-1.26` directory,
3. [run](https://crosstool-ng.github.io/docs/configuration/) `./ct-ng menuconfig`,
4. `Load` the existing configuration to alter: `[...]/linux/[arm64|x64]/config-[aarch64|x86_64]-unknown-gnu-linux-glibc[2.17|2.23]`
5. enter the `Paths and misc options` menu,
6. untick `Render the toolchain read-only (NEW)`,
7. `Save` and `Exit`.