### PR TITLE
[ACIX-1056] Updated slow build timeout

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -51,7 +51,7 @@
 
 .slow_build:
   extends: .build
-  timeout: 1h 10m
+  timeout: 1h 30m
 
 build_linux_x64:
   extends: [.slow_build, .always, .x64]


### PR DESCRIPTION
### What does this PR do?

We have [few jobs](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent-buildimages%22%20%40ci.job.name%3Abuild_%2A&agg_m=%40duration&agg_m_source=base&agg_t=avg&fromUser=false&index=cipipeline&panel=%7B%22queryString%22%3A%22%40duration%3A%5B4162005522040.608%20TO%204233764237937.86%5D%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22duration%22%2C%22value%22%3A%22%5B4162005522040.608%20TO%204233764237937.86%5D%22%7D%5D%2C%22timeRange%22%3A%7B%22from%22%3A1756995592000%2C%22to%22%3A1757600392000%2C%22live%22%3Atrue%7D%7D&viz=distribution&start=1756995872631&end=1757600672631&paused=false) that shouldn't timeout, updated the timeout to 1h30.

It's possible that the 1h10 timeout was made from statistics but we must also include the max time to find a runner and setup the repository (10m), I've added 20m to be sure that we don't hit the limit.

### Motivation

### Possible Drawbacks / Trade-offs

### Additional Notes
