### PR TITLE
Also fix `MAX_PATH` issues on Windows containers

### DIFF
--- a/windows/helpers/phase1/install_mingit.ps1
+++ b/windows/helpers/phase1/install_mingit.ps1
@@ -64,4 +64,7 @@ if($installed){
     & git config --system core.symlinks false
 
 }
+# https://andrewlock.net/fixing-max_path-issues-in-gitlab/
+New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWord -Force
+& git config --system core.longpaths true
 return


### PR DESCRIPTION
### Motivation
Long story short:
```
FileNotFoundError: [WinError 206] The filename or extension is too long:
'C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\Bazel.runfiles_7ghfo0_s\\runfiles\\rules_python++python+python_3_11_x86_64-pc-windows-msvc\\Lib\\site-packages\\pkg_resources\\tests\\data\\my-test-package_unpacked-egg\\my_test_package-1.0-py3.7.egg\\EGG-INFO'
```
(https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1143760432#L636)

### What does this PR do?
The present change is a counterpart of DataDog/ci-platform-machine-images#429 which _did_ fix `MAX_PATH` issues on Windows runners where `git` was unable to manage paths consisting of more than 260 characters.

### Additional Notes
The recipe proposed here comes from the following article: https://andrewlock.net/fixing-max_path-issues-in-gitlab/