### PR TITLE
[ACIX-1069] Fix docker image caching

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,10 +7,9 @@ if [[ "$DOCKERFILE" == "dev-envs/linux/Dockerfile" ]]; then WORKDIR="dev-envs/li
 
 # == Caching logic == #
 function sanitize() {
-    # From docker docs: https://docker-docs.uclv.cu/engine/reference/commandline/tag/#extended-description
-    # A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes.
+    # Docker uses the Go reference format for images: https://pkg.go.dev/github.com/distribution/reference#pkg-overview
+    # A tag name must match the following regex: /[\w][\w.-]{0,127}/
     # Git branch names can contain disallowed characters, so we need to sanitize them.
-    # xargs is used to remove leading and trailing whitespace.
     echo "$1" | tr -C '\na-zA-Z0-9_.-' '_'
 }
 

--- a/build.sh
+++ b/build.sh
@@ -4,13 +4,14 @@ set -euo pipefail
 # Build and push to internal ECR
 WORKDIR="."
 if [[ "$DOCKERFILE" == "dev-envs/linux/Dockerfile" ]]; then WORKDIR="dev-envs/linux"; fi
-CACHE_SOURCE="--cache-from type=registry,ref=registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:cache"
+CACHE_KEY="cache-${DD_TARGET_ARCH}"
+CACHE_SOURCE="--cache-from type=registry,ref=registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:${CACHE_KEY}"
 # Do not use cache on periodic pipeline where we want to test our dependencies.
-if [[ "$CI_PIPELINE_SOURCE" == "schedule" || -n "${PREVENT_CACHE:-}" ]]; then 
+if [[ "$CI_PIPELINE_SOURCE" == "schedule" || -n "${PREVENT_CACHE:-}" ]]; then
     CACHE_SOURCE="--no-cache"
 fi
 PUSH=""
-if [[ "$CI_PIPELINE_SOURCE" != "schedule" ]]; then 
+if [[ "$CI_PIPELINE_SOURCE" != "schedule" ]]; then
     PUSH="--push"
 fi
 
@@ -25,7 +26,7 @@ echo "Run buildx build"
 docker buildx build \
 --platform $PLATFORM \
 --pull $PUSH \
---cache-to type=registry,ref=registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:cache,mode=max ${CACHE_SOURCE} \
+--cache-to type=registry,ref=registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:${CACHE_KEY},mode=max ${CACHE_SOURCE} \
 --build-arg BASE_IMAGE=${BASE_IMAGE:-} \
 --build-arg BASE_IMAGE_TAG=${BASE_IMAGE_TAG:-} \
 --build-arg ARCH=${ARCH:-} \

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ function sanitize() {
     # A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes.
     # Git branch names can contain disallowed characters, so we need to sanitize them.
     # xargs is used to remove leading and trailing whitespace.
-    echo "$1" | tr -C 'a-zA-Z0-9_.-' '_'
+    echo "$1" | tr -C '\na-zA-Z0-9_.-' '_'
 }
 
 # Setup keys

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ function sanitize() {
     # Docker uses the Go reference format for images: https://pkg.go.dev/github.com/distribution/reference#pkg-overview
     # A tag name must match the following regex: /[\w][\w.-]{0,127}/
     # Git branch names can contain disallowed characters, so we need to sanitize them.
+    # `\n` is included here as the pipe adds a newline to the end of the string - not allowing it would mean we get an extra `_` at the end.
     echo "$1" | tr -C '\na-zA-Z0-9_.-' '_'
 }
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
 # Build and push to internal ECR
 WORKDIR="."

--- a/build.sh
+++ b/build.sh
@@ -6,10 +6,18 @@ WORKDIR="."
 if [[ "$DOCKERFILE" == "dev-envs/linux/Dockerfile" ]]; then WORKDIR="dev-envs/linux"; fi
 
 # == Caching logic == #
+function sanitize() {
+    # From docker docs: https://docker-docs.uclv.cu/engine/reference/commandline/tag/#extended-description
+    # A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes.
+    # Git branch names can contain disallowed characters, so we need to sanitize them.
+    # xargs is used to remove leading and trailing whitespace.
+    echo "$1" | tr -C 'a-zA-Z0-9_.-' '_'
+}
+
 # Setup keys
 BRANCH_NAME="${CI_COMMIT_BRANCH:-unknown}"
-CACHE_KEY_BRANCH="cache-${BRANCH_NAME}-${DD_TARGET_ARCH}"
-CACHE_KEY_MAIN="cache-${CI_DEFAULT_BRANCH}-${DD_TARGET_ARCH}"
+CACHE_KEY_BRANCH="$(sanitize "cache-${BRANCH_NAME}-${DD_TARGET_ARCH}")"
+CACHE_KEY_MAIN="$(sanitize "cache-${CI_DEFAULT_BRANCH}-${DD_TARGET_ARCH}")"
 
 CACHE_DETAILS_BRANCH="type=registry,ref=registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE:${CACHE_KEY_BRANCH}"
 CACHE_DETAILS_MAIN="type=registry,ref=registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE:${CACHE_KEY_MAIN}"

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -220,4 +220,6 @@ ENV PKG_CONFIG_LIBDIR=""
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 
+RUN echo hello world
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -220,6 +220,4 @@ ENV PKG_CONFIG_LIBDIR=""
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 
-RUN echo hello world
-
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
### What does this PR do?

Fixes the Docker image caching logic that was broken after we merged the two linux images into a multiarch image.

Also introduces a new caching strategy: each build pull the cache from its own "branch-specific" cache image as well as `main`, but only pushes to its own branch-specific cache image.

This way the `main` cache only gets updated when a PR is merged, but PR builds can benefit from the cached layers coming from builds on `main`.

### Motivation

Increasing the speed of CI, as image builds can sometimes take quite a while (>1h for the main `linux` image)
This should also help with the `buildx`-related hangs we've been seeing.

### Possible Drawbacks / Trade-offs

Increased storage use on ECR - need to figure out a cleanup policy.

### Additional Notes
