### PR TITLE
fix(ci): Bump timeouts for `.fast_build` and `.medium_build` jobs

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -43,11 +43,11 @@
 # Timeout values were chosen to be just above the longest historically-available runtime of the corresponding job's successful runs
 .fast_build:
   extends: .build
-  timeout: 15m
+  timeout: 30m
 
 .medium_build:
   extends: .build
-  timeout: 33m
+  timeout: 45m
 
 .slow_build:
   extends: .build


### PR DESCRIPTION
### What does this PR do?

Increase timeout duration for `.fast_build` and `.medium_build`

### Motivation

We've been seeing these classes of jobs wrongly going to timeout more often lately, especially `build_gitlab_agent_deploy`. (See [notebook](https://app.datadoghq.com/notebook/12840350/setting-timeouts-for-buildimages-build-jobs?range=2678400000&start=1756209302670&live=true)).
Their build durations must have increased slightly which warrants a timeout increase to avoid failures.


### Possible Drawbacks / Trade-offs

### Additional Notes
