### PR TITLE
chore: update renovate cooldown from 14 days to 2 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,5 +27,5 @@
       "datasourceTemplate": "github-releases"
     }
   ],
-  "minimumReleaseAge": "14 days"
+  "minimumReleaseAge": "2 days"
 }


### PR DESCRIPTION
> [!NOTE]
> **Merge only if this is still needed and your repo is not managed by ADMS.**
> If your repository is already managed by ADMS, feel free to close or ignore this PR.

---

We are updating the Renovate cooldown (`minimumReleaseAge`) from 14 days to 2 days to reduce the risk of zero-day vulnerabilities.

If your repository is already managed by ADMS and no longer requires these configurations, feel free to close or ignore the PR.