### PR TITLE
[SINT-5065] Install windows-code-signer.exe

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -15,6 +15,10 @@ ENV WINDOWS_VERSION=2022
 ENV TARGET_ARCH=x64
 ENV MS_GOTOOLCHAIN_TELEMETRY_ENABLED=0
 
+# Using ARG
+# because ENV is not usable in a COPY --from
+ARG WINDOWS_CODE_SIGNER_VERSION=":v0.6.0@sha256:e51bd1e36773114cc2dee43f02246acde4f8163e84e6e5928a8ef188cb4abb63"
+
 ARG DDA_NO_DYNAMIC_DEPS
 ENV DDA_NO_DYNAMIC_DEPS=$DDA_NO_DYNAMIC_DEPS
 
@@ -34,7 +38,7 @@ RUN --mount=type=bind,source=/windows/helpers/phase1,dst=/mnt/windows/helpers/ph
 RUN --mount=type=bind,source=/windows/helpers/phase2,dst=/mnt/windows/helpers/phase2 `
     --mount=type=bind,source=/python-packages-versions.txt,dst=/mnt/python-packages-versions.txt `
     /mnt/windows/install-all.ps1 -TargetContainer -Phase 2
-COPY --from=registry.ddbuild.io/windows-code-signer/go@sha256:2a308fb8a524445be2e0c7f303dac973625438208c9f3aabd4d3337c45c4d565 C:/windows-code-signer/windows-code-signer.exe C:/devtools/windows-code-signer.exe
+COPY --from=registry.ddbuild.io/windows-code-signer/go${WINDOWS_CODE_SIGNER_VERSION} C:/windows-code-signer/windows-code-signer.exe C:/devtools/windows-code-signer.exe
 RUN --mount=type=bind,source=/windows/helpers/phase3,dst=/mnt/windows/helpers/phase3 `
     --mount=type=bind,source=/ci-identities-gitlab-job-client-windows-amd64.exe,dst=/mnt/ci-identities-gitlab-job-client-windows-amd64.exe `
     /mnt/windows/install-all.ps1 -TargetContainer -Phase 3

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -34,6 +34,7 @@ RUN --mount=type=bind,source=/windows/helpers/phase1,dst=/mnt/windows/helpers/ph
 RUN --mount=type=bind,source=/windows/helpers/phase2,dst=/mnt/windows/helpers/phase2 `
     --mount=type=bind,source=/python-packages-versions.txt,dst=/mnt/python-packages-versions.txt `
     /mnt/windows/install-all.ps1 -TargetContainer -Phase 2
+COPY --from=registry.ddbuild.io/windows-code-signer/go@sha256:2a308fb8a524445be2e0c7f303dac973625438208c9f3aabd4d3337c45c4d565 C:/windows-code-signer/windows-code-signer.exe C:/devtools/windows-code-signer.exe
 RUN --mount=type=bind,source=/windows/helpers/phase3,dst=/mnt/windows/helpers/phase3 `
     --mount=type=bind,source=/ci-identities-gitlab-job-client-windows-amd64.exe,dst=/mnt/ci-identities-gitlab-job-client-windows-amd64.exe `
     /mnt/windows/install-all.ps1 -TargetContainer -Phase 3

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -7,6 +7,9 @@ ARG BASE_IMAGE_REGISTRY=mcr.microsoft.com
 ARG BASE_IMAGE_TAG=4.8-windowsservercore-ltsc2022
 ARG BASE_IMAGE=${BASE_IMAGE_REGISTRY}/dotnet/framework/runtime:${BASE_IMAGE_TAG}
 
+# required for the COPY --from instruction later
+FROM registry.ddbuild.io/windows-code-signer/go:v0.6.0@sha256:2a308fb8a524445be2e0c7f303dac973625438208c9f3aabd4d3337c45c4d565 AS windows-code-signer
+
 FROM ${BASE_IMAGE}
 
 
@@ -14,10 +17,6 @@ ENV WINDOWS_VERSION=2022
 
 ENV TARGET_ARCH=x64
 ENV MS_GOTOOLCHAIN_TELEMETRY_ENABLED=0
-
-# Using ARG
-# because ENV is not usable in a COPY --from
-ARG WINDOWS_CODE_SIGNER_VERSION=":v0.6.0@sha256:e51bd1e36773114cc2dee43f02246acde4f8163e84e6e5928a8ef188cb4abb63"
 
 ARG DDA_NO_DYNAMIC_DEPS
 ENV DDA_NO_DYNAMIC_DEPS=$DDA_NO_DYNAMIC_DEPS
@@ -38,7 +37,7 @@ RUN --mount=type=bind,source=/windows/helpers/phase1,dst=/mnt/windows/helpers/ph
 RUN --mount=type=bind,source=/windows/helpers/phase2,dst=/mnt/windows/helpers/phase2 `
     --mount=type=bind,source=/python-packages-versions.txt,dst=/mnt/python-packages-versions.txt `
     /mnt/windows/install-all.ps1 -TargetContainer -Phase 2
-COPY --from=registry.ddbuild.io/windows-code-signer/go${WINDOWS_CODE_SIGNER_VERSION} C:/windows-code-signer/windows-code-signer.exe C:/devtools/windows-code-signer.exe
+COPY --from=windows-code-signer C:/windows-code-signer/windows-code-signer.exe C:/devtools/windows-code-signer.exe
 RUN --mount=type=bind,source=/windows/helpers/phase3,dst=/mnt/windows/helpers/phase3 `
     --mount=type=bind,source=/ci-identities-gitlab-job-client-windows-amd64.exe,dst=/mnt/ci-identities-gitlab-job-client-windows-amd64.exe `
     /mnt/windows/install-all.ps1 -TargetContainer -Phase 3

--- a/windows/helpers/phase3/install_windows_code_signer.ps1
+++ b/windows/helpers/phase3/install_windows_code_signer.ps1
@@ -10,6 +10,13 @@ param (
 
 $DESTINATION = "C:\devtools\windows-code-signer.exe"
 
+if($Env:DD_DEV_TARGET -ne "Container") {
+    # the binary is downloaded in the Dockerfile,
+    # so if we are not building the container
+    # the binary is not present
+    return
+}
+
 if ( -not (Test-Path $DESTINATION)) {
     Write-Host -ForegroundColor Red "$DESTINATION not found"
     throw "$DESTINATION not found"

--- a/windows/helpers/phase3/install_windows_code_signer.ps1
+++ b/windows/helpers/phase3/install_windows_code_signer.ps1
@@ -1,0 +1,35 @@
+# Checks the installed version of windows-code-signer.exe.
+# See https://github.com/DataDog/windows-code-signer.
+# The file was downloaded during the "docker build"
+# with a "COPY --from" instruction in the Dockerfile
+
+param (
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory = $true)][string]$Sha256
+)
+
+$DESTINATION = "C:\devtools\windows-code-signer.exe"
+
+if ( -not (Test-Path $DESTINATION)) {
+    Write-Host -ForegroundColor Red "$DESTINATION not found"
+    throw "$DESTINATION not found"
+}
+
+$actualHash = (Get-FileHash -Algorithm SHA256 $DESTINATION).Hash
+if ($actualHash.ToUpper() -ne $Sha256.ToUpper()) {
+    Write-Host -ForegroundColor Red "Hash mismatch for $DESTINATION"
+    Write-Host -ForegroundColor Red "Expected: $Sha256"
+    Write-Host -ForegroundColor Red "Actual:   $actualHash"
+    Remove-Item $DESTINATION
+    throw "Hash mismatch for $DESTINATION. Expected: $Sha256, Actual: $actualHash"
+}
+
+# Verify version
+$versionOutput = (& $DESTINATION version 2>&1) | Out-String
+if ($versionOutput -notmatch [regex]::Escape($Version)) {
+    Write-Host -ForegroundColor Red "Version mismatch for $DESTINATION"
+    Write-Host -ForegroundColor Red "Expected version: $Version"
+    Write-Host -ForegroundColor Red "Actual output: $versionOutput"
+    Remove-Item $DESTINATION
+    throw "Version mismatch for $DESTINATION. Expected: $Version, Got: $versionOutput"
+}

--- a/windows/helpers/phase3/install_winsign.ps1
+++ b/windows/helpers/phase3/install_winsign.ps1
@@ -1,3 +1,7 @@
+# Legacy code installing the old Python-based Windows Code Signer "dd-wcs";
+# see "install_windows_code_signer.ps1" for the new version.
+# TODO remove this file after confirming it's not used anymore by users of this image
+
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 

--- a/windows/install-all.ps1
+++ b/windows/install-all.ps1
@@ -104,6 +104,7 @@ try {
         Invoke-Script { .\helpers\phase3\install_awscli.ps1 -Version $ENV:AWSCLI_VERSION -Sha256 $ENV:AWSCLI_SHA256 }
         Invoke-Script { .\helpers\phase3\install_bazelisk.ps1 -Version $ENV:BAZELISK_VERSION -Sha256 $ENV:BAZELISK_SHA256 }
         Invoke-Script { .\helpers\phase3\install_ci_identities_gitlab_job_client.ps1 -Version $ENV:CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION -Sha256 $ENV:CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256 } # requires the AWS CLI
+        Invoke-Script { .\helpers\phase3\install_windows_code_signer.ps1 -Version $ENV:WINDOWS_CODE_SIGNER_VERSION -Sha256 $ENV:WINDOWS_CODE_SIGNER_SHA256 }
 
         ## # Add signtool to path
         Add-ToPath -NewPath "${env:ProgramFiles(x86)}\Windows Kits\8.1\bin\x64\" -Global

--- a/windows/install-all.ps1
+++ b/windows/install-all.ps1
@@ -12,6 +12,12 @@ $ErrorActionPreference = 'Stop'
 # this includes the helper functions
 . .\helpers.ps1
 
+function Invoke-Script {
+    param([scriptblock]$Script)
+    & $Script
+    if ($LASTEXITCODE) { throw "Script exited with code $LASTEXITCODE" }
+}
+
 # set the environment variables from the versions file
 
 # Global Variables for saving env variables and path additions on the local build
@@ -40,7 +46,7 @@ foreach ($h in $SoftwareTable.GetEnumerator()){
     [Environment]::SetEnvironmentVariable($key, $val, [System.EnvironmentVariableTarget]::Process)
 }
 
-.\helpers\install_cert.ps1
+Invoke-Script { .\helpers\install_cert.ps1 }
 
 ## only do this if building the container
 if($TargetContainer){
@@ -60,44 +66,44 @@ try {
     # Phase 4 is empty by default. Before starting work on updating an item move the script to Phase 4.
     #
     if ($Phase -eq 0 -or $Phase -eq 1) {
-        .\helpers\phase1\install_net35.ps1
-        .\helpers\phase1\install_7zip.ps1 -Version $ENV:SEVENZIP_VERSION -Sha256 $ENV:SEVENZIP_SHA256
-        .\helpers\phase1\install_7zip_standalone.ps1 -Version $ENV:SEVENZIP_STANDALONE_VERSION -Sha256 $ENV:SEVENZIP_STANDALONE_SHA256
-        .\helpers\phase1\install_mingit.ps1 -Version $ENV:GIT_VERSION -Sha256 $ENV:GIT_SHA256
-        .\helpers\phase1\install_vstudio.ps1
-        .\helpers\phase1\install_wdk.ps1
-        .\helpers\phase1\install_dotnetcore.ps1
-        .\helpers\phase1\install_wix.ps1 -Version $ENV:WIX_VERSION
-        .\helpers\phase1\install_nuget.ps1 -Version $ENV:NUGET_VERSION -Sha256 $ENV:NUGET_SHA256
-        .\helpers\phase1\install_cmake.ps1 -Version $ENV:CMAKE_VERSION -Sha256 $ENV:CMAKE_SHA256
+        Invoke-Script { .\helpers\phase1\install_net35.ps1 }
+        Invoke-Script { .\helpers\phase1\install_7zip.ps1 -Version $ENV:SEVENZIP_VERSION -Sha256 $ENV:SEVENZIP_SHA256 }
+        Invoke-Script { .\helpers\phase1\install_7zip_standalone.ps1 -Version $ENV:SEVENZIP_STANDALONE_VERSION -Sha256 $ENV:SEVENZIP_STANDALONE_SHA256 }
+        Invoke-Script { .\helpers\phase1\install_mingit.ps1 -Version $ENV:GIT_VERSION -Sha256 $ENV:GIT_SHA256 }
+        Invoke-Script { .\helpers\phase1\install_vstudio.ps1 }
+        Invoke-Script { .\helpers\phase1\install_wdk.ps1 }
+        Invoke-Script { .\helpers\phase1\install_dotnetcore.ps1 }
+        Invoke-Script { .\helpers\phase1\install_wix.ps1 -Version $ENV:WIX_VERSION }
+        Invoke-Script { .\helpers\phase1\install_nuget.ps1 -Version $ENV:NUGET_VERSION -Sha256 $ENV:NUGET_SHA256 }
+        Invoke-Script { .\helpers\phase1\install_cmake.ps1 -Version $ENV:CMAKE_VERSION -Sha256 $ENV:CMAKE_SHA256 }
         # # vcpkg depends on cmake
-        .\helpers\phase1\install_vcpkg.ps1
-        .\helpers\phase1\install_codecov.ps1 -Version $ENV:CODECOV_VERSION -Sha256 $ENV:CODECOV_SHA256
+        Invoke-Script { .\helpers\phase1\install_vcpkg.ps1 }
+        Invoke-Script { .\helpers\phase1\install_codecov.ps1 -Version $ENV:CODECOV_VERSION -Sha256 $ENV:CODECOV_SHA256 }
     }
 
     if ($Phase -eq 0 -or $Phase -eq 2) {
-        .\helpers\phase2\install_docker.ps1
-        .\helpers\phase2\install_ruby.ps1 -Version $ENV:RUBY_VERSION -Sha256 $ENV:RUBY_SHA256
+        Invoke-Script { .\helpers\phase2\install_docker.ps1 }
+        Invoke-Script { .\helpers\phase2\install_ruby.ps1 -Version $ENV:RUBY_VERSION -Sha256 $ENV:RUBY_SHA256 }
         # msys depends on ruby
-        .\helpers\phase2\install_msys.ps1 -Version $ENV:MSYS_VERSION -Sha256 $ENV:MSYS_SHA256
-        .\helpers\phase2\install_python.ps1 -Version $ENV:PYTHON_VERSION -Sha256 $ENV:PYTHON_SHA256
-        .\helpers\phase2\install_gcloud_sdk.ps1
-        .\helpers\phase2\install_embedded_pythons.ps1
+        Invoke-Script { .\helpers\phase2\install_msys.ps1 -Version $ENV:MSYS_VERSION -Sha256 $ENV:MSYS_SHA256 }
+        Invoke-Script { .\helpers\phase2\install_python.ps1 -Version $ENV:PYTHON_VERSION -Sha256 $ENV:PYTHON_SHA256 }
+        Invoke-Script { .\helpers\phase2\install_gcloud_sdk.ps1 }
+        Invoke-Script { .\helpers\phase2\install_embedded_pythons.ps1 }
     }
 
     if ($Phase -eq 0 -or $Phase -eq 3) {
-        .\helpers\phase3\install_winget.ps1 -Version $ENV:WINGET_VERSION -Sha256 $ENV:WINGET_SHA256
-        .\helpers\phase3\install_go.ps1
-        .\helpers\phase3\install_codeql.ps1
-        .\helpers\phase3\install_ninja.ps1 -Version $ENV:NINJA_VERSION -Sha256 $ENV:NINJA_SHA256
-        .\helpers\phase3\install_java.ps1
-        .\helpers\phase3\install_vault.ps1 -Version $ENV:VAULT_VERSION -Sha256 $ENV:VAULT_HASH
-        .\helpers\phase3\install_winsign.ps1
-        .\helpers\phase3\install_rust.ps1 -Rustup_Version $ENV:RUSTUP_VERSION -Rustup_Sha256 $ENV:RUSTUP_SHA256 -Rust_Version $ENV:RUST_VERSION
-        .\helpers\phase3\install_datadog_ci.ps1 -Version $ENV:DATADOG_CI_VERSION -Sha256 $ENV:DATADOG_CI_SHA256
-        .\helpers\phase3\install_awscli.ps1 -Version $ENV:AWSCLI_VERSION -Sha256 $ENV:AWSCLI_SHA256
-        .\helpers\phase3\install_bazelisk.ps1 -Version $ENV:BAZELISK_VERSION -Sha256 $ENV:BAZELISK_SHA256
-        .\helpers\phase3\install_ci_identities_gitlab_job_client.ps1 -Version $ENV:CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION -Sha256 $ENV:CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256 # requires the AWS CLI
+        Invoke-Script { .\helpers\phase3\install_winget.ps1 -Version $ENV:WINGET_VERSION -Sha256 $ENV:WINGET_SHA256 }
+        Invoke-Script { .\helpers\phase3\install_go.ps1 }
+        Invoke-Script { .\helpers\phase3\install_codeql.ps1 }
+        Invoke-Script { .\helpers\phase3\install_ninja.ps1 -Version $ENV:NINJA_VERSION -Sha256 $ENV:NINJA_SHA256 }
+        Invoke-Script { .\helpers\phase3\install_java.ps1 }
+        Invoke-Script { .\helpers\phase3\install_vault.ps1 -Version $ENV:VAULT_VERSION -Sha256 $ENV:VAULT_HASH }
+        Invoke-Script { .\helpers\phase3\install_winsign.ps1 }
+        Invoke-Script { .\helpers\phase3\install_rust.ps1 -Rustup_Version $ENV:RUSTUP_VERSION -Rustup_Sha256 $ENV:RUSTUP_SHA256 -Rust_Version $ENV:RUST_VERSION }
+        Invoke-Script { .\helpers\phase3\install_datadog_ci.ps1 -Version $ENV:DATADOG_CI_VERSION -Sha256 $ENV:DATADOG_CI_SHA256 }
+        Invoke-Script { .\helpers\phase3\install_awscli.ps1 -Version $ENV:AWSCLI_VERSION -Sha256 $ENV:AWSCLI_SHA256 }
+        Invoke-Script { .\helpers\phase3\install_bazelisk.ps1 -Version $ENV:BAZELISK_VERSION -Sha256 $ENV:BAZELISK_SHA256 }
+        Invoke-Script { .\helpers\phase3\install_ci_identities_gitlab_job_client.ps1 -Version $ENV:CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION -Sha256 $ENV:CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256 } # requires the AWS CLI
 
         ## # Add signtool to path
         Add-ToPath -NewPath "${env:ProgramFiles(x86)}\Windows Kits\8.1\bin\x64\" -Global

--- a/windows/install-all.ps1
+++ b/windows/install-all.ps1
@@ -12,12 +12,6 @@ $ErrorActionPreference = 'Stop'
 # this includes the helper functions
 . .\helpers.ps1
 
-function Invoke-Script {
-    param([scriptblock]$Script)
-    & $Script
-    if ($LASTEXITCODE) { throw "Script exited with code $LASTEXITCODE" }
-}
-
 # set the environment variables from the versions file
 
 # Global Variables for saving env variables and path additions on the local build
@@ -46,7 +40,7 @@ foreach ($h in $SoftwareTable.GetEnumerator()){
     [Environment]::SetEnvironmentVariable($key, $val, [System.EnvironmentVariableTarget]::Process)
 }
 
-Invoke-Script { .\helpers\install_cert.ps1 }
+.\helpers\install_cert.ps1
 
 ## only do this if building the container
 if($TargetContainer){
@@ -66,45 +60,45 @@ try {
     # Phase 4 is empty by default. Before starting work on updating an item move the script to Phase 4.
     #
     if ($Phase -eq 0 -or $Phase -eq 1) {
-        Invoke-Script { .\helpers\phase1\install_net35.ps1 }
-        Invoke-Script { .\helpers\phase1\install_7zip.ps1 -Version $ENV:SEVENZIP_VERSION -Sha256 $ENV:SEVENZIP_SHA256 }
-        Invoke-Script { .\helpers\phase1\install_7zip_standalone.ps1 -Version $ENV:SEVENZIP_STANDALONE_VERSION -Sha256 $ENV:SEVENZIP_STANDALONE_SHA256 }
-        Invoke-Script { .\helpers\phase1\install_mingit.ps1 -Version $ENV:GIT_VERSION -Sha256 $ENV:GIT_SHA256 }
-        Invoke-Script { .\helpers\phase1\install_vstudio.ps1 }
-        Invoke-Script { .\helpers\phase1\install_wdk.ps1 }
-        Invoke-Script { .\helpers\phase1\install_dotnetcore.ps1 }
-        Invoke-Script { .\helpers\phase1\install_wix.ps1 -Version $ENV:WIX_VERSION }
-        Invoke-Script { .\helpers\phase1\install_nuget.ps1 -Version $ENV:NUGET_VERSION -Sha256 $ENV:NUGET_SHA256 }
-        Invoke-Script { .\helpers\phase1\install_cmake.ps1 -Version $ENV:CMAKE_VERSION -Sha256 $ENV:CMAKE_SHA256 }
+        .\helpers\phase1\install_net35.ps1
+        .\helpers\phase1\install_7zip.ps1 -Version $ENV:SEVENZIP_VERSION -Sha256 $ENV:SEVENZIP_SHA256
+        .\helpers\phase1\install_7zip_standalone.ps1 -Version $ENV:SEVENZIP_STANDALONE_VERSION -Sha256 $ENV:SEVENZIP_STANDALONE_SHA256
+        .\helpers\phase1\install_mingit.ps1 -Version $ENV:GIT_VERSION -Sha256 $ENV:GIT_SHA256
+        .\helpers\phase1\install_vstudio.ps1
+        .\helpers\phase1\install_wdk.ps1
+        .\helpers\phase1\install_dotnetcore.ps1
+        .\helpers\phase1\install_wix.ps1 -Version $ENV:WIX_VERSION
+        .\helpers\phase1\install_nuget.ps1 -Version $ENV:NUGET_VERSION -Sha256 $ENV:NUGET_SHA256
+        .\helpers\phase1\install_cmake.ps1 -Version $ENV:CMAKE_VERSION -Sha256 $ENV:CMAKE_SHA256
         # # vcpkg depends on cmake
-        Invoke-Script { .\helpers\phase1\install_vcpkg.ps1 }
-        Invoke-Script { .\helpers\phase1\install_codecov.ps1 -Version $ENV:CODECOV_VERSION -Sha256 $ENV:CODECOV_SHA256 }
+        .\helpers\phase1\install_vcpkg.ps1
+        .\helpers\phase1\install_codecov.ps1 -Version $ENV:CODECOV_VERSION -Sha256 $ENV:CODECOV_SHA256
     }
 
     if ($Phase -eq 0 -or $Phase -eq 2) {
-        Invoke-Script { .\helpers\phase2\install_docker.ps1 }
-        Invoke-Script { .\helpers\phase2\install_ruby.ps1 -Version $ENV:RUBY_VERSION -Sha256 $ENV:RUBY_SHA256 }
+        .\helpers\phase2\install_docker.ps1
+        .\helpers\phase2\install_ruby.ps1 -Version $ENV:RUBY_VERSION -Sha256 $ENV:RUBY_SHA256
         # msys depends on ruby
-        Invoke-Script { .\helpers\phase2\install_msys.ps1 -Version $ENV:MSYS_VERSION -Sha256 $ENV:MSYS_SHA256 }
-        Invoke-Script { .\helpers\phase2\install_python.ps1 -Version $ENV:PYTHON_VERSION -Sha256 $ENV:PYTHON_SHA256 }
-        Invoke-Script { .\helpers\phase2\install_gcloud_sdk.ps1 }
-        Invoke-Script { .\helpers\phase2\install_embedded_pythons.ps1 }
+        .\helpers\phase2\install_msys.ps1 -Version $ENV:MSYS_VERSION -Sha256 $ENV:MSYS_SHA256
+        .\helpers\phase2\install_python.ps1 -Version $ENV:PYTHON_VERSION -Sha256 $ENV:PYTHON_SHA256
+        .\helpers\phase2\install_gcloud_sdk.ps1
+        .\helpers\phase2\install_embedded_pythons.ps1
     }
 
     if ($Phase -eq 0 -or $Phase -eq 3) {
-        Invoke-Script { .\helpers\phase3\install_winget.ps1 -Version $ENV:WINGET_VERSION -Sha256 $ENV:WINGET_SHA256 }
-        Invoke-Script { .\helpers\phase3\install_go.ps1 }
-        Invoke-Script { .\helpers\phase3\install_codeql.ps1 }
-        Invoke-Script { .\helpers\phase3\install_ninja.ps1 -Version $ENV:NINJA_VERSION -Sha256 $ENV:NINJA_SHA256 }
-        Invoke-Script { .\helpers\phase3\install_java.ps1 }
-        Invoke-Script { .\helpers\phase3\install_vault.ps1 -Version $ENV:VAULT_VERSION -Sha256 $ENV:VAULT_HASH }
-        Invoke-Script { .\helpers\phase3\install_winsign.ps1 }
-        Invoke-Script { .\helpers\phase3\install_rust.ps1 -Rustup_Version $ENV:RUSTUP_VERSION -Rustup_Sha256 $ENV:RUSTUP_SHA256 -Rust_Version $ENV:RUST_VERSION }
-        Invoke-Script { .\helpers\phase3\install_datadog_ci.ps1 -Version $ENV:DATADOG_CI_VERSION -Sha256 $ENV:DATADOG_CI_SHA256 }
-        Invoke-Script { .\helpers\phase3\install_awscli.ps1 -Version $ENV:AWSCLI_VERSION -Sha256 $ENV:AWSCLI_SHA256 }
-        Invoke-Script { .\helpers\phase3\install_bazelisk.ps1 -Version $ENV:BAZELISK_VERSION -Sha256 $ENV:BAZELISK_SHA256 }
-        Invoke-Script { .\helpers\phase3\install_ci_identities_gitlab_job_client.ps1 -Version $ENV:CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION -Sha256 $ENV:CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256 } # requires the AWS CLI
-        Invoke-Script { .\helpers\phase3\install_windows_code_signer.ps1 -Version $ENV:WINDOWS_CODE_SIGNER_VERSION -Sha256 $ENV:WINDOWS_CODE_SIGNER_SHA256 }
+        .\helpers\phase3\install_winget.ps1 -Version $ENV:WINGET_VERSION -Sha256 $ENV:WINGET_SHA256
+        .\helpers\phase3\install_go.ps1
+        .\helpers\phase3\install_codeql.ps1
+        .\helpers\phase3\install_ninja.ps1 -Version $ENV:NINJA_VERSION -Sha256 $ENV:NINJA_SHA256
+        .\helpers\phase3\install_java.ps1
+        .\helpers\phase3\install_vault.ps1 -Version $ENV:VAULT_VERSION -Sha256 $ENV:VAULT_HASH
+        .\helpers\phase3\install_winsign.ps1
+        .\helpers\phase3\install_rust.ps1 -Rustup_Version $ENV:RUSTUP_VERSION -Rustup_Sha256 $ENV:RUSTUP_SHA256 -Rust_Version $ENV:RUST_VERSION
+        .\helpers\phase3\install_datadog_ci.ps1 -Version $ENV:DATADOG_CI_VERSION -Sha256 $ENV:DATADOG_CI_SHA256
+        .\helpers\phase3\install_awscli.ps1 -Version $ENV:AWSCLI_VERSION -Sha256 $ENV:AWSCLI_SHA256
+        .\helpers\phase3\install_bazelisk.ps1 -Version $ENV:BAZELISK_VERSION -Sha256 $ENV:BAZELISK_SHA256
+        .\helpers\phase3\install_ci_identities_gitlab_job_client.ps1 -Version $ENV:CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION -Sha256 $ENV:CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256 # requires the AWS CLI
+        .\helpers\phase3\install_windows_code_signer.ps1 -Version $ENV:WINDOWS_CODE_SIGNER_VERSION -Sha256 $ENV:WINDOWS_CODE_SIGNER_SHA256
 
         ## # Add signtool to path
         Add-ToPath -NewPath "${env:ProgramFiles(x86)}\Windows Kits\8.1\bin\x64\" -Global

--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -73,4 +73,11 @@ $SoftwareTable = @{
     # it must updated in sync with the version in .gitlab/build.yml
     "CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION"="v0.3.0";
     "CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256"="2cfce3de0976245a6665f99585a7762b01d78b9af5c8748f5a917de312a9356d";
+    # Similarly for windows-code-signer.exe,
+    # except that it's downloaded during the "docker build"
+    # with a "COPY --from" instruction in the Dockerfile
+    # recall to update the digest of the image in the Dockerfile
+    # when updating the version
+    "WINDOWS_CODE_SIGNER_VERSION"="v0.6.0";
+    "WINDOWS_CODE_SIGNER_SHA256"="TODO";
 }

--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -79,5 +79,5 @@ $SoftwareTable = @{
     # recall to update the digest of the image in the Dockerfile
     # when updating the version
     "WINDOWS_CODE_SIGNER_VERSION"="v0.6.0";
-    "WINDOWS_CODE_SIGNER_SHA256"="TODO";
+    "WINDOWS_CODE_SIGNER_SHA256"="e51bd1e36773114cc2dee43f02246acde4f8163e84e6e5928a8ef188cb4abb63";
 }


### PR DESCRIPTION
### What does this PR do?

Installs the new version of https://github.com/DataDog/windows-code-signer, which is now a Go binary instead of a Python script (it still calls a Java program though).

### Motivation

The new version has improved observability and is able to use "CI Identities".

### Possible Drawbacks / Trade-offs

### Additional Notes

We will remove the old Python one later.

I started by trying to make `install-all.ps1` more robust by detecting subscripts that exited with a non-zero status ([c309ad6](https://github.com/DataDog/datadog-agent-buildimages/pull/1124/commits/c309ad6e45f648cc7a3106550052567a79be6f63)), but it seems like there are some subscripts that are currently failing silently this way (see failing CI jobs) so we have to fix these errors before. I reverted [c309ad6](https://github.com/DataDog/datadog-agent-buildimages/pull/1124/commits/c309ad6e45f648cc7a3106550052567a79be6f63), we should do it in an further PR.
