### PR TITLE
Add Renovate auto-update for datadog-ci

### DIFF
--- a/.github/workflows/update-datadog-ci.yml
+++ b/.github/workflows/update-datadog-ci.yml
@@ -49,14 +49,10 @@ jobs:
           sed -i '/^variable "checksums_arm64"/,/^}/{ /DATADOG_CI_SHA256/s/[a-f0-9]\{64\}/'"${SHA_LINUX_ARM64}"'/ }' docker-bake.hcl
 
           # Update version + x64 SHA in x64 Dockerfiles
-          for f in rpm-x64/Dockerfile docker-x64/Dockerfile dd-agent-testing/Dockerfile; do
+          for f in rpm-x64/Dockerfile docker-x64/Dockerfile dd-agent-testing/Dockerfile agent-deploy/Dockerfile; do
             sed -i "/^ARG DATADOG_CI_VERSION/s/=.*/=${VERSION}/" "$f"
             sed -i "/^ARG DATADOG_CI_SHA/s/[a-f0-9]\{64\}/${SHA_LINUX_X64}/" "$f"
           done
-
-          # agent-deploy uses DATADOG_CI_SHASUM instead of DATADOG_CI_SHA
-          sed -i "/^ARG DATADOG_CI_VERSION/s/=.*/=${VERSION}/" agent-deploy/Dockerfile
-          sed -i "/^ARG DATADOG_CI_SHASUM/s/[a-f0-9]\{64\}/${SHA_LINUX_X64}/" agent-deploy/Dockerfile
 
           # Update version + arm64 SHA in arm64 Dockerfiles
           for f in rpm-arm64/Dockerfile docker-arm64/Dockerfile; do

--- a/.github/workflows/update-datadog-ci.yml
+++ b/.github/workflows/update-datadog-ci.yml
@@ -1,0 +1,81 @@
+name: Update datadog-ci checksums
+
+on:
+  push:
+    branches:
+      - 'renovate/**'
+    paths:
+      - 'docker-bake.hcl'
+
+permissions: {}
+
+jobs:
+  update-checksums:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Extract version and fetch checksums
+        id: version
+        run: |
+          VERSION=$(grep 'DATADOG_CI_VERSION' docker-bake.hcl | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          curl -fsSL "https://github.com/DataDog/datadog-ci/releases/download/v${VERSION}/checksums.txt" -o /tmp/checksums.txt
+
+          SHA_LINUX_X64=$(awk '/datadog-ci_linux-x64$/{print $1}' /tmp/checksums.txt)
+          SHA_LINUX_ARM64=$(awk '/datadog-ci_linux-arm64$/{print $1}' /tmp/checksums.txt)
+          SHA_WIN_X64=$(awk '/datadog-ci_win-x64$/{print $1}' /tmp/checksums.txt)
+
+          echo "sha_linux_x64=${SHA_LINUX_X64}" >> "$GITHUB_OUTPUT"
+          echo "sha_linux_arm64=${SHA_LINUX_ARM64}" >> "$GITHUB_OUTPUT"
+          echo "sha_win_x64=${SHA_WIN_X64}" >> "$GITHUB_OUTPUT"
+
+      - name: Update checksums and propagate version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA_LINUX_X64: ${{ steps.version.outputs.sha_linux_x64 }}
+          SHA_LINUX_ARM64: ${{ steps.version.outputs.sha_linux_arm64 }}
+          SHA_WIN_X64: ${{ steps.version.outputs.sha_win_x64 }}
+        run: |
+          # Update SHAs in docker-bake.hcl (version already updated by Renovate)
+          sed -i '/^variable "checksums_amd64"/,/^}/{ /DATADOG_CI_SHA256/s/[a-f0-9]\{64\}/'"${SHA_LINUX_X64}"'/ }' docker-bake.hcl
+          sed -i '/^variable "checksums_arm64"/,/^}/{ /DATADOG_CI_SHA256/s/[a-f0-9]\{64\}/'"${SHA_LINUX_ARM64}"'/ }' docker-bake.hcl
+
+          # Update version + x64 SHA in x64 Dockerfiles
+          for f in rpm-x64/Dockerfile docker-x64/Dockerfile dd-agent-testing/Dockerfile; do
+            sed -i "/^ARG DATADOG_CI_VERSION/s/=.*/=${VERSION}/" "$f"
+            sed -i "/^ARG DATADOG_CI_SHA/s/[a-f0-9]\{64\}/${SHA_LINUX_X64}/" "$f"
+          done
+
+          # agent-deploy uses DATADOG_CI_SHASUM instead of DATADOG_CI_SHA
+          sed -i "/^ARG DATADOG_CI_VERSION/s/=.*/=${VERSION}/" agent-deploy/Dockerfile
+          sed -i "/^ARG DATADOG_CI_SHASUM/s/[a-f0-9]\{64\}/${SHA_LINUX_X64}/" agent-deploy/Dockerfile
+
+          # Update version + arm64 SHA in arm64 Dockerfiles
+          for f in rpm-arm64/Dockerfile docker-arm64/Dockerfile; do
+            sed -i "/^ARG DATADOG_CI_VERSION/s/=.*/=${VERSION}/" "$f"
+            sed -i "/^ARG DATADOG_CI_SHA/s/[a-f0-9]\{64\}/${SHA_LINUX_ARM64}/" "$f"
+          done
+
+          # Update Windows
+          sed -i 's|\("DATADOG_CI_VERSION"="\)[^"]*|\1'"${VERSION}"'|' windows/versions.ps1
+          sed -i 's|\("DATADOG_CI_SHA256"="\)[^"]*|\1'"${SHA_WIN_X64}"'|' windows/versions.ps1
+
+      - name: Commit and push
+        run: |
+          if git diff --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Update datadog-ci checksums and propagate v${{ steps.version.outputs.version }}"
+          git push

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,17 @@
       ],
       "depNameTemplate": "datadog/datadog-agent-dev",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "docker-bake\\.hcl"
+      ],
+      "matchStrings": [
+        "DATADOG_CI_VERSION\\s*=\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ],
+      "depNameTemplate": "DataDog/datadog-ci",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "minimumReleaseAge": "14 days"

--- a/renovate.json
+++ b/renovate.json
@@ -1,45 +1,29 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabledManagers": [
-    "custom.regex"
-  ],
-  "gitIgnoredAuthors": [
-    "41898282+github-actions[bot]@users.noreply.github.com"
-  ],
-  "labels": [
-    "dependencies"
-  ],
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "14 days",
+  "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"],
+  "labels": ["dependencies"],
   "packageRules": [
     {
-      "matchDepNames": [
-        "DataDog/datadog-agent-dev"
-      ],
+      "matchDepNames": ["DataDog/datadog-agent-dev"],
       "changelogUrl": "https://github.com/DataDog/datadog-agent-dev/releases/tag/v{{newValue}}"
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
-        "dda.env"
-      ],
-      "matchStrings": [
-        "DDA_VERSION=v(?<currentValue>[0-9]+.[0-9]+.[0-9]+)"
-      ],
+      "fileMatch": ["dda.env"],
+      "matchStrings": ["DDA_VERSION=v(?<currentValue>[0-9]+.[0-9]+.[0-9]+)"],
       "depNameTemplate": "datadog/datadog-agent-dev",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "fileMatch": [
-        "docker-bake\\.hcl"
-      ],
-      "matchStrings": [
-        "DATADOG_CI_VERSION\\s*=\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
-      ],
+      "fileMatch": ["docker-bake\\.hcl"],
+      "matchStrings": ["DATADOG_CI_VERSION\\s*=\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""],
       "depNameTemplate": "DataDog/datadog-ci",
       "datasourceTemplate": "github-releases"
     }
-  ],
-  "minimumReleaseAge": "14 days"
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "enabledManagers": [
     "custom.regex"
   ],
+  "gitIgnoredAuthors": [
+    "41898282+github-actions[bot]@users.noreply.github.com"
+  ],
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Summary
- Add a Renovate regex manager to track `DATADOG_CI_VERSION` in `docker-bake.hcl` against `DataDog/datadog-ci` GitHub releases
- Add a GitHub Actions workflow (`.github/workflows/update-datadog-ci.yml`) that triggers on Renovate pushes to fetch checksums and propagate version + SHA updates to all Dockerfiles and `windows/versions.ps1`

## How it works
1. Renovate detects a new `DataDog/datadog-ci` release (with 14-day cooldown) and bumps the version in `docker-bake.hcl`
2. The push to the `renovate/**` branch triggers the workflow
3. The workflow downloads `checksums.txt` from the release, then updates all files with the correct per-architecture SHA256 and version
4. Changes are committed and pushed back to the Renovate PR branch

## Test plan
- [ ] Verify Renovate picks up the new regex manager (check Renovate dashboard)
- [ ] Manually trigger the workflow on a test branch to validate the sed replacements
- [ ] Confirm the workflow correctly updates all 8 target files

🤖 Generated with [Claude Code](https://claude.com/claude-code)