### PR TITLE
Update CI Identities Client

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -217,7 +217,7 @@ build_dev_env_linux_arm64:
     CI_IDENTITY_ROLE_NAME_OVERRIDE: windows-ci-tmp-gitlab-id-token-datadog-agent-buildimages-all-refs
     DOCKERFILE: windows/Dockerfile
     DD_TARGET_ARCH: x64
-    CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION: v0.6.3 # version and digest must be updated in windows/versions.ps1 as well
+    CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION: v0.6.4 # version and digest must be updated in windows/versions.ps1 as well
     BASE_IMAGE_REGISTRY: registry.ddbuild.io/images/mirror
   script:
     - aws s3 cp --only-show-errors s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/$CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION/ci-identities-gitlab-job-client-windows-amd64.exe .

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -217,7 +217,7 @@ build_dev_env_linux_arm64:
     CI_IDENTITY_ROLE_NAME_OVERRIDE: windows-ci-tmp-gitlab-id-token-datadog-agent-buildimages-all-refs
     DOCKERFILE: windows/Dockerfile
     DD_TARGET_ARCH: x64
-    CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION: v0.3.0 # version and digest must be updated in windows/versions.ps1 as well
+    CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION: v0.6.3 # version and digest must be updated in windows/versions.ps1 as well
     BASE_IMAGE_REGISTRY: registry.ddbuild.io/images/mirror
   script:
     - aws s3 cp --only-show-errors s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/$CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION/ci-identities-gitlab-job-client-windows-amd64.exe .

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -8,7 +8,7 @@ ARG BASE_IMAGE_TAG=4.8-windowsservercore-ltsc2022
 ARG BASE_IMAGE=${BASE_IMAGE_REGISTRY}/dotnet/framework/runtime:${BASE_IMAGE_TAG}
 
 # required for the COPY --from instruction later
-FROM registry.ddbuild.io/windows-code-signer/go:v0.6.0@sha256:2a308fb8a524445be2e0c7f303dac973625438208c9f3aabd4d3337c45c4d565 AS windows-code-signer
+FROM registry.ddbuild.io/windows-code-signer/go:v0.7.0@sha256:64aa5ad1fccf9b7ab05c110f756e3e055be6e9e3941275b7797c8e14489a2180 AS windows-code-signer
 
 FROM ${BASE_IMAGE}
 

--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -71,7 +71,8 @@ $SoftwareTable = @{
     # the CI ID client is actually downloaded in the CI job before running the "docker build" command
     # this "version" variable is used to *check* that we downloaded the correct version;
     # it must updated in sync with the version in .gitlab/build.yml
-    "CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION"="v0.3.0";
+    # See https://github.com/ddoghq/ci-identities/blob/main/apps/ci-identities-gitlab-job-client/CHANGELOG.md
+    "CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION"="v0.6.3";
     "CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256"="2cfce3de0976245a6665f99585a7762b01d78b9af5c8748f5a917de312a9356d";
     # Similarly for windows-code-signer.exe,
     # except that it's downloaded during the "docker build"

--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -79,6 +79,6 @@ $SoftwareTable = @{
     # with a "COPY --from" instruction in the Dockerfile
     # recall to update the digest of the image in the Dockerfile
     # when updating the version
-    "WINDOWS_CODE_SIGNER_VERSION"="v0.6.0";
+    "WINDOWS_CODE_SIGNER_VERSION"="v0.7.0";
     "WINDOWS_CODE_SIGNER_SHA256"="e51bd1e36773114cc2dee43f02246acde4f8163e84e6e5928a8ef188cb4abb63";
 }

--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -80,5 +80,5 @@ $SoftwareTable = @{
     # recall to update the digest of the image in the Dockerfile
     # when updating the version
     "WINDOWS_CODE_SIGNER_VERSION"="v0.7.0";
-    "WINDOWS_CODE_SIGNER_SHA256"="e51bd1e36773114cc2dee43f02246acde4f8163e84e6e5928a8ef188cb4abb63";
+    "WINDOWS_CODE_SIGNER_SHA256"="89eb7490e7bec62fea47fdbe4b202f65c8a068b84ce2d2c629a33ce924774cf7";
 }

--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -70,10 +70,10 @@ $SoftwareTable = @{
     "BAZELISK_SHA256"="b9d65a1f7c2d7af885a96a4fd5aa36b40fb41816d30944390569eef908bdc954";
     # the CI ID client is actually downloaded in the CI job before running the "docker build" command
     # this "version" variable is used to *check* that we downloaded the correct version;
-    # it must updated in sync with the version in .gitlab/build.yml
+    # it must be updated in sync with the version in .gitlab/build.yml
     # See https://github.com/ddoghq/ci-identities/blob/main/apps/ci-identities-gitlab-job-client/CHANGELOG.md
     "CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION"="v0.6.4";
-    "CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256"="8fa93bac14796ac3d383c6f8b531f2e3c23f3879751d93b837add48088da52a9";
+    "CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256"="ea05f5486ed0755177c754eaecea94de0d9a3a9ddf225fc2a2e8f4c1a3babfa0";
     # Similarly for windows-code-signer.exe,
     # except that it's downloaded during the "docker build"
     # with a "COPY --from" instruction in the Dockerfile

--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -72,7 +72,7 @@ $SoftwareTable = @{
     # this "version" variable is used to *check* that we downloaded the correct version;
     # it must updated in sync with the version in .gitlab/build.yml
     # See https://github.com/ddoghq/ci-identities/blob/main/apps/ci-identities-gitlab-job-client/CHANGELOG.md
-    "CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION"="v0.6.3";
+    "CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION"="v0.6.4";
     "CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256"="8fa93bac14796ac3d383c6f8b531f2e3c23f3879751d93b837add48088da52a9";
     # Similarly for windows-code-signer.exe,
     # except that it's downloaded during the "docker build"

--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -73,7 +73,7 @@ $SoftwareTable = @{
     # it must updated in sync with the version in .gitlab/build.yml
     # See https://github.com/ddoghq/ci-identities/blob/main/apps/ci-identities-gitlab-job-client/CHANGELOG.md
     "CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION"="v0.6.3";
-    "CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256"="2cfce3de0976245a6665f99585a7762b01d78b9af5c8748f5a917de312a9356d";
+    "CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256"="8fa93bac14796ac3d383c6f8b531f2e3c23f3879751d93b837add48088da52a9";
     # Similarly for windows-code-signer.exe,
     # except that it's downloaded during the "docker build"
     # with a "COPY --from" instruction in the Dockerfile


### PR DESCRIPTION
### What does this PR do?

Use the latest version of the CI Identities client

### Motivation

Mostly better observability. See changelog mentioned in the diff

### Possible Drawbacks / Trade-offs

### Additional Notes

Also uses the latest release of the Windows code signer, although the changes are mostly in the container image of the signer and we simply extract the binary from it so we don't expect many changes.