### PR TITLE
PREVENT_CACHE in linux bake builds

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -66,7 +66,7 @@
       if [[ "$CI_PIPELINE_SOURCE" != "schedule" ]]; then
         PUSH="--push"
       fi
-    - docker buildx bake $PUSH $BAKE_TARGET
+    - docker buildx bake $PUSH ${PREVENT_CACHE:+--no-cache} $BAKE_TARGET
     - |
       if [[ "$CI_PIPELINE_SOURCE" != "schedule" ]]; then
         crane manifest registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION | jq


### PR DESCRIPTION
## Summary

`build.sh` already skips the registry cache when `PREVENT_CACHE` is set, but the linux image jobs (`build_linux_amd64`, `build_linux_arm64`) call `docker buildx bake` directly and were unaffected by that variable.

- Pass `--no-cache` to `docker buildx bake` when `PREVENT_CACHE` is set, consistent with the existing behaviour in `build.sh`
- A single `PREVENT_CACHE=1` variable now disables the registry cache for all build job types

## Test

Triggered a pipeline with `PREVENT_CACHE=1` and verified all build jobs skipped the cache