### PR TITLE
[SINT-5112] Use new docker-credentials-helper token

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -211,10 +211,9 @@ build_dev_env_linux_arm64:
         compare_to: $COMPARE_TO_BRANCH
   timeout: 2h 30m
   id_tokens:
-    CI_IDENTITY_GITLAB_JWT:
-      aud: https://vault.us1.ddbuild.io
+    CI_IDENTITIES_GITLAB_ID_TOKEN:
+      aud: ci-identities
   variables:
-    CI_IDENTITY_ROLE_NAME_OVERRIDE: windows-ci-tmp-gitlab-id-token-datadog-agent-buildimages-all-refs
     DOCKERFILE: windows/Dockerfile
     DD_TARGET_ARCH: x64
     CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION: v0.3.0 # version and digest must be updated in windows/versions.ps1 as well

--- a/build-container.ps1
+++ b/build-container.ps1
@@ -20,8 +20,18 @@ if ($Buildkit) {
     .\containerd.ps1
     .\cni.ps1
     .\buildkit.ps1
-    # Start buildkitd
+    # Start buildkitd and wait for it to be ready
     Start-Process -FilePath "buildkitd.exe"
+    $timeout = 30
+    $elapsed = 0
+    while (-not (Test-Path "\\.\pipe\buildkitd") -and $elapsed -lt $timeout) {
+        Start-Sleep -Seconds 1
+        $elapsed++
+    }
+    if (-not (Test-Path "\\.\pipe\buildkitd")) {
+        Write-Error "buildkitd did not start within $timeout seconds"
+        exit 1
+    }
     $build_opt = "--opt build-arg:"
     $cmd_args = -split "--progress=plain --output type=image,name=$OUTPUT_IMAGE,push=true --frontend=dockerfile.v0 --local context=. --local dockerfile=.\windows "
     # Set cache arguments


### PR DESCRIPTION
### What does this PR do?

Use new docker-credentials-helper method using [CI Identities mechanism](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/4956889069/Authenticating+to+Datadog+s+Registry+as+a+Windows+CI+Job+Using+CI+Identities) + adds a poll loop that waits up to 30 seconds for \\.\pipe\buildkitd to appear before proceeding with buildctl. If it never appears, the script exits with an error rather than letting buildctl fail with the cryptic transport error.

### Motivation

This technique is more reliable and common than the bypass used until now

### Possible Drawbacks / Trade-offs

### Additional Notes
