### PR TITLE
Remove public release of workspace image and add a multi arch image

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -153,17 +153,12 @@ build_kernel_version_testing_arm64:
     DOCKERFILE: kernel-version-testing/kernel-version-testing_arm64/Dockerfile
     IMAGE: kernel-version-testing_arm64
 
-build_multiarch:
+.build_multiarch:
   extends: [.no_schedule, .x64]
   stage: build
   id_tokens:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
-  needs:
-    - job: build_linux_amd64
-    - job: build_linux_arm64
-  variables:
-    TARGET_IMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$ECR_TEST_ONLY
   before_script:
     - !reference [.build, before_script]
   script:
@@ -171,6 +166,31 @@ build_multiarch:
       docker manifest create $TARGET_IMAGE:$IMAGE_VERSION
       $TARGET_IMAGE:$IMAGE_VERSION-amd64
       $TARGET_IMAGE:$IMAGE_VERSION-arm64
+    - MANIFEST=$(docker manifest inspect $TARGET_IMAGE:$IMAGE_VERSION)
+    - DIGEST=sha256:$(echo -n "$MANIFEST" | sha256sum | awk '{print $1}')
+    - docker manifest push $TARGET_IMAGE:$IMAGE_VERSION
+    - ddsign sign $TARGET_IMAGE:$IMAGE_VERSION@${DIGEST}
+
+build_multiarch_linux:
+  extends: [.build_multiarch]
+  needs:
+    - job: build_linux_amd64
+    - job: build_linux_arm64
+  variables:
+    TARGET_IMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$ECR_TEST_ONLY
+
+build_multiarch_devenv_workspace:
+  extends: [.build_multiarch]
+  needs:
+    - job: build_dev_env_workspace_x64
+    - job: build_dev_env_workspace_arm64
+  variables:
+    TARGET_IMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace$ECR_TEST_ONLY
+  script:
+    - >
+      docker manifest create $TARGET_IMAGE:$IMAGE_VERSION
+      registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace-amd64$ECR_TEST_ONLY:$IMAGE_VERSION
+      registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace-arm64$ECR_TEST_ONLY:$IMAGE_VERSION
     - MANIFEST=$(docker manifest inspect $TARGET_IMAGE:$IMAGE_VERSION)
     - DIGEST=sha256:$(echo -n "$MANIFEST" | sha256sum | awk '{print $1}')
     - docker manifest push $TARGET_IMAGE:$IMAGE_VERSION
@@ -204,7 +224,7 @@ build_dev_env_workspace_x64:
     - job: build_linux_amd64
   variables:
     DOCKERFILE: dev-envs/linux/Dockerfile
-    IMAGE: dev-env-workspace-$DD_TARGET_ARCH
+    IMAGE: dev-env-workspace-amd64
     BASE_IMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$ECR_TEST_ONLY
     BASE_IMAGE_TAG: $IMAGE_VERSION-amd64
     TARGET: workspace
@@ -215,7 +235,7 @@ build_dev_env_workspace_arm64:
     - job: build_linux_arm64
   variables:
     DOCKERFILE: dev-envs/linux/Dockerfile
-    IMAGE: dev-env-workspace-$DD_TARGET_ARCH
+    IMAGE: dev-env-workspace-arm64
     BASE_IMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$ECR_TEST_ONLY
     BASE_IMAGE_TAG: $IMAGE_VERSION-arm64
     TARGET: workspace

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -17,8 +17,6 @@ release:
     matrix:
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-linux-x64:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA},registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-linux-aarch64:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
         IMG_DESTINATIONS: agent-dev-env-linux:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-dev-env-linux:latest
-      - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace-x64:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA},registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace-aarch64:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-        IMG_DESTINATIONS: agent-dev-env-workspace:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-dev-env-workspace:latest
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_x64:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
         IMG_DESTINATIONS: agent-buildimages-rpm_x64:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA},agent-buildimages-rpm_x64:latest
       - IMG_SOURCES: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_arm64:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -46,7 +46,7 @@ push_to_datadog_agent:
   # TODO: This is not great, we probably should not rely on _test_only images but as we don't push a `latest` tag for validated images we don't really have a choice.
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$ECR_TEST_ONLY:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
   dependencies: [] # do not download artifacts from other jobs
-  needs: [build_multiarch] # wait for the multiarch image to be built as it is used for this job's execution environment
+  needs: [build_multiarch_linux] # wait for the multiarch image to be built as it is used for this job's execution environment
   variables:
     REF: main
     BRANCH: buildimages/$CI_COMMIT_BRANCH


### PR DESCRIPTION
### What does this PR do?

Add a job to publish a multi arch version of the workspace devenv
We do not need to release the image on public registries. This is only meant to be used on internal infrastructure workspaces

### Motivation

### Possible Drawbacks / Trade-offs

### Additional Notes
