### PR TITLE
fix(devcontainer): replace `add-apt-repository` with `curl|gpg --dearmor`

### DIFF
--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -23,8 +23,12 @@ RUN apt-get update && apt-get upgrade -y && \
     openjdk-11-jre-headless \
     # System-probe dependencies
     clang llvm bpfcc-tools libbpfcc-dev libelf-dev linux-headers-generic &&\
-    # Python setup
-    add-apt-repository -y 'ppa:deadsnakes/ppa' &&\
+    # Python setup: bypass add-apt-repository (Launchpad REST API is timeout-prone)
+    curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF23C5A6CF475977595C89F51BA6932366A755776" \
+        | gpg --dearmor -o /etc/apt/trusted.gpg.d/deadsnakes-ubuntu-ppa.gpg && \
+    echo "deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main" \
+        >/etc/apt/sources.list.d/deadsnakes-ubuntu-ppa-jammy.list && \
+    apt-get update && \
     apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv &&\
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists
 


### PR DESCRIPTION
### What does this PR do?
Replace `add-apt-repository ppa:deadsnakes/ppa` with a direct `curl | gpg --dearmor` key fetch, matching the pattern already used for the Kubernetes repository key in the same file.

### Motivation
`add-apt-repository` fetches the PPA signing key via the Launchpad REST API (`lpppa.getSigningKeyData()`), which intermittently times out (`Connection timed out`, 502/504 errors) and causes the devcontainer image build to fail in CI (observed in DataDog/datadog-agent#50275 and recurrently in the `test devcontainer` GitHub Actions workflow):
- https://github.com/DataDog/datadog-agent/actions/runs/25304653324/job/74177984945?pr=50275
- https://github.com/DataDog/datadog-agent/actions/runs/25304653324/job/74177984971?pr=50275
- etc.

### Additional Notes
Fetching the key directly from `keyserver.ubuntu.com` via HKP over HTTPS bypasses the Launchpad API entirely and requires no `dirmngr` daemon, unlike `gpg --keyserver`.