### PR TITLE
[Backport 7.79.x] Fix dev env build of agent repo-owned tool

### DIFF
--- a/dev-envs/linux/tools.sh
+++ b/dev-envs/linux/tools.sh
@@ -71,7 +71,7 @@ go install github.com/fatih/gomodifytags@latest
 GOLANGCI_LINT_VERSION="$(curl "${curl_opts[@]}" https://raw.githubusercontent.com/DataDog/datadog-agent/main/internal/tools/go.mod | grep -Po '/golangci-lint.+v\K.+')"
 install-binary \
     --version "${GOLANGCI_LINT_VERSION}" \
-    --digest "94e80cdb51c73c20a313bd3afa1fb23137728813c19fd730248a1e8678fcc46d" \
-    --digest "493aaaca2eba6c8bcef847d92716bbd91bbac4b22cdbb0ab5b6a581b32946091" \
+    --digest "200c5b7503f67b59a6743ccf32133026c174e272b930ee79aa2aa6f37aca7ef1" \
+    --digest "3bcfa2e6f3d32b2bf5cd75eaa876447507025e0303698633f722a05331988db4" \
     --url "https://github.com/golangci/golangci-lint/releases/download/v{{version}}/golangci-lint-{{version}}-linux-${short_arch}.tar.gz" \
     --name "golangci-lint"


### PR DESCRIPTION
### What does this PR do?
Backport #1155 to restore a green CI for the 7.79.x release branch.
Updates outdated golangci-lint hashes in tools.sh which were causing dev env image builds to fail.

### Motivation

### Possible Drawbacks / Trade-offs

### Additional Notes
