### PR TITLE
feat(renovate): track datadog-packages commit digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,14 @@
       "matchStrings": ["DATADOG_CI_VERSION\\s*=\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""],
       "depNameTemplate": "DataDog/datadog-ci",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["docker-bake\\.hcl", "agent-deploy/Dockerfile"],
+      "matchStrings": ["DATADOG_PACKAGES_VERSION\\s*=\\s*\"?(?<currentDigest>[a-f0-9]{40})\"?"],
+      "depNameTemplate": "DataDog/datadog-packages",
+      "datasourceTemplate": "github-commits",
+      "currentValueTemplate": "main"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -27,11 +27,13 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["docker-bake\\.hcl", "agent-deploy/Dockerfile"],
+      "managerFilePatterns": ["docker-bake\\.hcl", "agent-deploy/Dockerfile"],
       "matchStrings": ["DATADOG_PACKAGES_VERSION\\s*=\\s*\"?(?<currentDigest>[a-f0-9]{40})\"?"],
-      "depNameTemplate": "DataDog/datadog-packages",
+      "currentValueTemplate": "main",
+      "depNameTemplate": "datadog-packages",
+      "packageNameTemplate": "https://github.com/DataDog/datadog-packages",
       "datasourceTemplate": "git-refs",
-      "currentValueTemplate": "main"
+      "registryUrlTemplate": ""
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,7 @@
       "fileMatch": ["docker-bake\\.hcl", "agent-deploy/Dockerfile"],
       "matchStrings": ["DATADOG_PACKAGES_VERSION\\s*=\\s*\"?(?<currentDigest>[a-f0-9]{40})\"?"],
       "depNameTemplate": "DataDog/datadog-packages",
-      "datasourceTemplate": "github-commits",
+      "datasourceTemplate": "git-refs",
       "currentValueTemplate": "main"
     }
   ]


### PR DESCRIPTION
## Summary

- Adds a Renovate custom regex manager to automatically bump `DATADOG_PACKAGES_VERSION` to the latest commit digest on `DataDog/datadog-packages@main`
- Covers both `docker-bake.hcl` and `agent-deploy/Dockerfile` where the SHA is hardcoded

## Notes

The dependency is consumed via Docker multi-stage build (`COPY --from=`), so no shasum verification exists — integrity is tied to the image tag (the commit SHA itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)