### PR TITLE
Fix dev env build of agent repo-owned tool

### DIFF
--- a/dev-envs/linux/scripts/install-binary.sh
+++ b/dev-envs/linux/scripts/install-binary.sh
@@ -9,6 +9,7 @@ DIGESTS=()
 ALGORITHM="sha256"
 TOP_LEVEL="0"
 UNPACK_COMMAND=""
+IGNORE_DIGESTS="0"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -25,6 +26,10 @@ while [[ $# -gt 0 ]]; do
         --digest)
             DIGESTS+=("$2")
             shift
+            shift
+            ;;
+        --ignore-digests)
+            IGNORE_DIGESTS="1"
             shift
             ;;
         --name)
@@ -60,22 +65,24 @@ file_path="/tmp/${file_name}"
 
 curl "${URL}" -Lo "${file_path}"
 
-digest=$(openssl dgst -"${ALGORITHM}" "${file_path}" | cut -d' ' -f2)
-match="0"
-for d in "${DIGESTS[@]}"; do
-    if [[ "${d}" == "${digest}" ]]; then
-        match="1"
-        break
-    fi
-done
-if [[ "${match}" == "0" ]]; then
-    echo "Digest mismatch"
-    echo "Expected:"
+if [[ "${IGNORE_DIGESTS}" == "0" ]]; then
+    digest=$(openssl dgst -"${ALGORITHM}" "${file_path}" | cut -d' ' -f2)
+    match="0"
     for d in "${DIGESTS[@]}"; do
-        echo "    ${d}"
+        if [[ "${d}" == "${digest}" ]]; then
+            match="1"
+            break
+        fi
     done
-    echo "Got: ${digest}"
-    exit 1
+    if [[ "${match}" == "0" ]]; then
+        echo "Digest mismatch"
+        echo "Expected:"
+        for d in "${DIGESTS[@]}"; do
+            echo "    ${d}"
+        done
+        echo "Got: ${digest}"
+        exit 1
+    fi
 fi
 
 if [[ "${file_name}" =~ \.tar\.gz$ ]]; then

--- a/dev-envs/linux/tools.sh
+++ b/dev-envs/linux/tools.sh
@@ -71,7 +71,6 @@ go install github.com/fatih/gomodifytags@latest
 GOLANGCI_LINT_VERSION="$(curl "${curl_opts[@]}" https://raw.githubusercontent.com/DataDog/datadog-agent/main/internal/tools/go.mod | grep -Po '/golangci-lint.+v\K.+')"
 install-binary \
     --version "${GOLANGCI_LINT_VERSION}" \
-    --digest "200c5b7503f67b59a6743ccf32133026c174e272b930ee79aa2aa6f37aca7ef1" \
-    --digest "3bcfa2e6f3d32b2bf5cd75eaa876447507025e0303698633f722a05331988db4" \
+    --ignore-digests \
     --url "https://github.com/golangci/golangci-lint/releases/download/v{{version}}/golangci-lint-{{version}}-linux-${short_arch}.tar.gz" \
     --name "golangci-lint"


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/datadog-agent/commit/0f348bd9888e770dbb2ade563c69dd10f7f25241

### Additional Notes

This keeps happening (e.g. https://github.com/DataDog/datadog-agent-buildimages/pull/1155) because the version is managed externally so I disabled the digest check.