### PR TITLE
rpm-armhf: install libxslt-devel

### DIFF
--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -61,7 +61,7 @@ RUN yum -y install @development which perl-ExtUtils-MakeMaker ncurses-compat-lib
     curl-devel expat-devel gettext-devel openssl-devel systemd-devel zlib-devel bzip2 glibc-static tar pkgconfig  \
     libtool autoconf policycoreutils-python \
     bzip2-devel e2fsprogs-devel file-devel libacl-devel libarchive-devel libattr-devel \
-    libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel java \
+    libxml2-devel lzo-devel nss nss-devel popt-devel sharutils xz-devel java libxslt-devel \
     && yum clean all
 
 # Build zstd from source (not available in CentOS 7 armhfp repos)


### PR DESCRIPTION
### What does this PR do?

Install libxslt-devel

### Motivation

This is needed to bootsrap dda on the build image

### Possible Drawbacks / Trade-offs

### Additional Notes
