### PR TITLE
Handle existing host GID in dev env entrypoint

### DIFF
--- a/dev-envs/linux/init/entrypoint.sh
+++ b/dev-envs/linux/init/entrypoint.sh
@@ -23,8 +23,10 @@ if [[ ! -f "${startup_indicator}" ]]; then
         TARGET_UID="${HOST_UID:-1002}"
         TARGET_GID="${HOST_GID:-${TARGET_UID}}"
 
-        # Create primary user and group
-        groupadd -g "${TARGET_GID}" "${TARGET_GROUP}"
+        # Create the primary group if the host GID is not already present.
+        if ! getent group "${TARGET_GID}" >/dev/null; then
+            groupadd -g "${TARGET_GID}" "${TARGET_GROUP}"
+        fi
         useradd -u "${TARGET_UID}" -g "${TARGET_GID}" "${TARGET_USER}"
         TARGET_HOME="$(getent passwd "${TARGET_USER}" | cut -d: -f6)"
 


### PR DESCRIPTION
### What does this PR do?

The dev environment entrypoint maps the container user to the host UID/GID so mounted files keep the expected ownership. On macOS the primary group is commonly staff with GID 20, which already exists in the base image as dialout. Creating a new group with that GID fails and prevents sshd from starting.

Today, we only check if `TARGET_USER` exists before creating *the group* and the user.

Check whether the numeric host GID already exists before calling groupadd, then pass the numeric GID to useradd. This preserves the host GID mapping while avoiding the startup failure.

### Motivation

Current test running:

```sh
dda --version
dda, version 0.34.0
dda env dev remove
dda env dev start
Waiting for container: dda-linux-container-default
[...]
RuntimeError: Container `dda-linux-container-default` is not ready
[...]
+[08:04:58.575] groupadd -g 20 dd
groupadd: GID '20' already exists
```