### PR TITLE
Improve python environment management for workspaces, add back claude in dev env

### DIFF
--- a/dev-envs/linux/Dockerfile
+++ b/dev-envs/linux/Dockerfile
@@ -63,7 +63,7 @@ ENV DD_DEFAULT_CONFIG_ROOT="/var/config/dd-defaults"
 ENV XDG_CONFIG_HOME="${DD_BUILD_CONFIG_ROOT}"
 
 # Install pass password manager
-RUN apt-get update && apt-get install -y pass apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y pass && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # MCP
 EXPOSE 9000

--- a/dev-envs/linux/Dockerfile
+++ b/dev-envs/linux/Dockerfile
@@ -51,6 +51,8 @@ RUN --mount=type=bind,src=./docker.sh,dst=/mnt/docker.sh /mnt/docker.sh
 RUN --mount=type=bind,src=./fonts.sh,dst=/mnt/fonts.sh /mnt/fonts.sh
 # Set up Starship prompt
 RUN --mount=type=bind,src=./starship.sh,dst=/mnt/starship.sh /mnt/starship.sh
+# Set up Claude
+RUN --mount=type=bind,src=./claude.sh,dst=/mnt/claude.sh /mnt/claude.sh
 # Set up editor integrations
 RUN --mount=type=bind,src=./editors.sh,dst=/mnt/editors.sh /mnt/editors.sh
 

--- a/dev-envs/linux/Dockerfile
+++ b/dev-envs/linux/Dockerfile
@@ -51,8 +51,6 @@ RUN --mount=type=bind,src=./docker.sh,dst=/mnt/docker.sh /mnt/docker.sh
 RUN --mount=type=bind,src=./fonts.sh,dst=/mnt/fonts.sh /mnt/fonts.sh
 # Set up Starship prompt
 RUN --mount=type=bind,src=./starship.sh,dst=/mnt/starship.sh /mnt/starship.sh
-# Set up Claude
-RUN --mount=type=bind,src=./claude.sh,dst=/mnt/claude.sh /mnt/claude.sh
 # Set up editor integrations
 RUN --mount=type=bind,src=./editors.sh,dst=/mnt/editors.sh /mnt/editors.sh
 

--- a/dev-envs/linux/Dockerfile
+++ b/dev-envs/linux/Dockerfile
@@ -63,7 +63,7 @@ ENV DD_DEFAULT_CONFIG_ROOT="/var/config/dd-defaults"
 ENV XDG_CONFIG_HOME="${DD_BUILD_CONFIG_ROOT}"
 
 # Install pass password manager
-RUN apt-get update && apt-get install -y pass
+RUN apt-get update && apt-get install -y pass apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # MCP
 EXPOSE 9000

--- a/dev-envs/linux/Dockerfile
+++ b/dev-envs/linux/Dockerfile
@@ -62,6 +62,9 @@ ENV DD_DEFAULT_CONFIG_ROOT="/var/config/dd-defaults"
 # Runtime config should target the persisted config root.
 ENV XDG_CONFIG_HOME="${DD_BUILD_CONFIG_ROOT}"
 
+# Install pass password manager
+RUN apt-get update && apt-get install -y pass
+
 # MCP
 EXPOSE 9000
 

--- a/dev-envs/linux/tools.txt
+++ b/dev-envs/linux/tools.txt
@@ -5,7 +5,6 @@ bat
 btm
 claude
 dd-gitsign
-ddtool
 delta
 dust
 eza

--- a/dev-envs/linux/tools.txt
+++ b/dev-envs/linux/tools.txt
@@ -1,5 +1,6 @@
 ambr
 ambs
+aws-vault
 bat
 btm
 claude

--- a/dev-envs/linux/tools.txt
+++ b/dev-envs/linux/tools.txt
@@ -2,6 +2,7 @@ ambr
 ambs
 bat
 btm
+claude
 delta
 dust
 eza

--- a/dev-envs/linux/tools.txt
+++ b/dev-envs/linux/tools.txt
@@ -4,6 +4,8 @@ aws-vault
 bat
 btm
 claude
+dd-gitsign
+ddtool
 delta
 dust
 eza
@@ -21,5 +23,6 @@ staticcheck
 uv
 uvx
 watchexec
+workspaces-tool-helper
 ya
 yazi

--- a/dev-envs/linux/variants/workspaces/adduser.sh
+++ b/dev-envs/linux/variants/workspaces/adduser.sh
@@ -79,7 +79,7 @@ su - bits << EOF
     export PASS_GPG_HOME=\$HOME/.config/password-store/gpg
     mkdir -m 700 -p \$PASS_GPG_HOME
     gpg --homedir \$PASS_GPG_HOME --batch --passphrase '' --quick-generate-key --yes password-store
-    PASSWORD_STORE_GPG_OPTS="--homedir \$PASS_GPG_HOME" pass init 'password-store'
+    export PASSWORD_STORE_GPG_OPTS="--homedir \$PASS_GPG_HOME" pass init 'password-store'
 
     if [ -e /etc/container-config/compose.yaml ]; then
         echo "Copying some files"
@@ -89,7 +89,7 @@ su - bits << EOF
     if command -v dd-gitsign &> /dev/null; then
         echo "Setting up dd-gitsign"
         GIT_DISPLAY_NAME=\$(curl -s https://api.github.com/users/${github_username} | jq -r '.name // "${github_username}"')
-        GIT_EMAIL="${workspace_user}@datadoghq.com"
+        GIT_EMAIL="${real_user}@datadoghq.com"
         dd-gitsign install --remote --github="${github_username}" --name "\${GIT_DISPLAY_NAME}" --email "\${GIT_EMAIL}"
     fi
 EOF

--- a/dev-envs/linux/variants/workspaces/adduser.sh
+++ b/dev-envs/linux/variants/workspaces/adduser.sh
@@ -67,6 +67,32 @@ if [[ -z "${github_username}" ]]; then
     echo "GitHub username is required to authorize ${workspace_user}" >&2
     exit 1
 fi
+# do user specific configuration *as* the user (to ensure permissions and paths are correct)
+su - bits << EOF
+    echo "Fetching keys from github.com/${github_username}"
+    curl "https://github.com/${github_username}.keys" -o ~/.ssh/authorized_keys
+    chmod 600 ~/.ssh/authorized_keys
+
+    echo "Setting up password-store"
+    # NOTE: We create a separate gpg dir for pass, and configure pass to always use that gpg
+    # homedir. This ensures we don't conflict with a forwarded gpg-agent
+    export PASS_GPG_HOME=\$HOME/.config/password-store/gpg
+    mkdir -m 700 -p \$PASS_GPG_HOME
+    gpg --homedir \$PASS_GPG_HOME --batch --passphrase '' --quick-generate-key --yes password-store
+    PASSWORD_STORE_GPG_OPTS="--homedir \$PASS_GPG_HOME" pass init 'password-store'
+
+    if [ -e /etc/container-config/compose.yaml ]; then
+        echo "Copying some files"
+        cp /etc/container-config/compose.yaml ~/dd/compose.yaml
+    fi
+
+    if command -v dd-gitsign &> /dev/null; then
+        echo "Setting up dd-gitsign"
+        GIT_DISPLAY_NAME=\$(curl -s https://api.github.com/users/${github_username} | jq -r '.name // "${github_username}"')
+        GIT_EMAIL="${workspace_user}@datadoghq.com"
+        dd-gitsign install --remote --github="${github_username}" --name "\${GIT_DISPLAY_NAME}" --email "\${GIT_EMAIL}"
+    fi
+EOF
 
 curl --fail --silent --show-error --location \
     "https://github.com/${github_username}.keys" \

--- a/dev-envs/linux/variants/workspaces/setup.sh
+++ b/dev-envs/linux/variants/workspaces/setup.sh
@@ -41,7 +41,8 @@ cat >/etc/sudoers.d/95-dog-nopasswd <<'EOF'
 EOF
 chmod 0440 /etc/sudoers.d/95-dog-nopasswd
 
-su bits -c "conda init --all"
+
+su bits -c "${DD_BUILD_INSTALL_ROOT}/conda/condabin/conda init --all"
 
 echo "conda activate ddpy3" >> /home/bits/.zshrc
 # zsh does not source /etc/profile.d by default. Workspaces and the Agent

--- a/dev-envs/linux/variants/workspaces/setup.sh
+++ b/dev-envs/linux/variants/workspaces/setup.sh
@@ -41,6 +41,9 @@ cat >/etc/sudoers.d/95-dog-nopasswd <<'EOF'
 EOF
 chmod 0440 /etc/sudoers.d/95-dog-nopasswd
 
+su bits -c "conda init --all"
+
+echo "conda activate ddpy3" >> /home/bits/.zshrc
 # zsh does not source /etc/profile.d by default. Workspaces and the Agent
 # feature both write *-workspace-env.sh snippets there.
 install -d /etc/zsh

--- a/tools/dotslash/config/aws-vault.json
+++ b/tools/dotslash/config/aws-vault.json
@@ -1,0 +1,39 @@
+{
+  "__extra_metadata": {
+    "platforms": {
+      "linux-aarch64": {
+        "uncompressed_size": 13923318
+      },
+      "linux-x86_64": {
+        "uncompressed_size": 14645544
+      }
+    }
+  },
+  "name": "aws-vault",
+  "platforms": {
+    "linux-aarch64": {
+      "digest": "176fa59b9e3981720361cd6ed87b5389741953c62ba0a6fa4f2db401f8bef735",
+      "hash": "sha256",
+      "path": "aws-vault",
+      "providers": [
+        {
+          "type": "http",
+          "url": "https://github.com/99designs/aws-vault/releases/download/v7.2.0/aws-vault-linux-arm64"
+        }
+      ],
+      "size": 13923318
+    },
+    "linux-x86_64": {
+      "digest": "b92bcfc4a78aa8c547ae5920d196943268529c5dbc9c5aca80b797a18a5d0693",
+      "hash": "sha256",
+      "path": "aws-vault",
+      "providers": [
+        {
+          "type": "http",
+          "url": "https://github.com/99designs/aws-vault/releases/download/v7.2.0/aws-vault-linux-amd64"
+        }
+      ],
+      "size": 14645544
+    }
+  }
+}

--- a/tools/dotslash/config/claude.json
+++ b/tools/dotslash/config/claude.json
@@ -1,0 +1,39 @@
+{
+  "__extra_metadata": {
+    "platforms": {
+      "linux-aarch64": {
+        "uncompressed_size": 232437384
+      },
+      "linux-x86_64": {
+        "uncompressed_size": 232572624
+      }
+    }
+  },
+  "name": "claude",
+  "platforms": {
+    "linux-aarch64": {
+      "digest": "dc931e24f62afbadc8dc68115278b08493825a3ed1ea753d587077181a6cc63b",
+      "hash": "sha256",
+      "path": "claude",
+      "providers": [
+        {
+          "type": "http",
+          "url": "https://downloads.claude.ai/claude-code-releases/2.1.141/linux-arm64/claude"
+        }
+      ],
+      "size": 232437384
+    },
+    "linux-x86_64": {
+      "digest": "832be26e8f15b2ae99e520a22b034fc4bfad1cb5b84de6b706487072c56bb42e",
+      "hash": "sha256",
+      "path": "claude",
+      "providers": [
+        {
+          "type": "http",
+          "url": "https://downloads.claude.ai/claude-code-releases/2.1.141/linux-x64/claude"
+        }
+      ],
+      "size": 232572624
+    }
+  }
+}

--- a/tools/dotslash/config/dd-gitsign.json
+++ b/tools/dotslash/config/dd-gitsign.json
@@ -1,0 +1,41 @@
+{
+  "__extra_metadata": {
+    "platforms": {
+      "linux-aarch64": {
+        "uncompressed_size": 67292970
+      },
+      "linux-x86_64": {
+        "uncompressed_size": 67292970
+      }
+    }
+  },
+  "name": "dd-gitsign",
+  "platforms": {
+    "linux-aarch64": {
+      "digest": "4fe4bf6ac5d14b4fcdbab2d213c7b6d74c916975c62cec4bfa376c4c167ab660",
+      "format": "tar.gz",
+      "hash": "sha256",
+      "path": "dd-gitsign-linux-arm64",
+      "providers": [
+        {
+          "type": "http",
+          "url": "https://binaries.ddbuild.io/dd-source/dd-gitsign/v1.8.0/dd-gitsign-tar.tar.gz"
+        }
+      ],
+      "size": 33106380
+    },
+    "linux-x86_64": {
+      "digest": "4fe4bf6ac5d14b4fcdbab2d213c7b6d74c916975c62cec4bfa376c4c167ab660",
+      "format": "tar.gz",
+      "hash": "sha256",
+      "path": "dd-gitsign-linux-amd64",
+      "providers": [
+        {
+          "type": "http",
+          "url": "https://binaries.ddbuild.io/dd-source/dd-gitsign/v1.8.0/dd-gitsign-tar.tar.gz"
+        }
+      ],
+      "size": 33106380
+    }
+  }
+}

--- a/tools/dotslash/config/ddtool.json
+++ b/tools/dotslash/config/ddtool.json
@@ -1,0 +1,41 @@
+{
+  "__extra_metadata": {
+    "platforms": {
+      "linux-aarch64": {
+        "uncompressed_size": 277359853
+      },
+      "linux-x86_64": {
+        "uncompressed_size": 277359853
+      }
+    }
+  },
+  "name": "ddtool",
+  "platforms": {
+    "linux-aarch64": {
+      "digest": "dbfcbe70c89b7a32b89c606aec44d6af16520c0772e6b794451dedffc221c237",
+      "format": "tar.gz",
+      "hash": "sha256",
+      "path": "ddtool_linux_arm64",
+      "providers": [
+        {
+          "type": "http",
+          "url": "https://binaries.ddbuild.io/ddtool/v1.110.0/ddtool.tar.gz"
+        }
+      ],
+      "size": 85822742
+    },
+    "linux-x86_64": {
+      "digest": "dbfcbe70c89b7a32b89c606aec44d6af16520c0772e6b794451dedffc221c237",
+      "format": "tar.gz",
+      "hash": "sha256",
+      "path": "ddtool_linux_amd64",
+      "providers": [
+        {
+          "type": "http",
+          "url": "https://binaries.ddbuild.io/ddtool/v1.110.0/ddtool.tar.gz"
+        }
+      ],
+      "size": 85822742
+    }
+  }
+}

--- a/tools/dotslash/config/workspaces-tool-helper.json
+++ b/tools/dotslash/config/workspaces-tool-helper.json
@@ -1,0 +1,41 @@
+{
+  "__extra_metadata": {
+    "platforms": {
+      "linux-aarch64": {
+        "uncompressed_size": 24408162
+      },
+      "linux-x86_64": {
+        "uncompressed_size": 24408162
+      }
+    }
+  },
+  "name": "workspaces-tool-helper",
+  "platforms": {
+    "linux-aarch64": {
+      "digest": "4dc40fac4c1287a65ad496bcb7154409270e65bc0184a080c2ee2aff5072f8ba",
+      "format": "tar.gz",
+      "hash": "sha256",
+      "path": "workspaces-tool-helper-linux-arm64",
+      "providers": [
+        {
+          "type": "http",
+          "url": "https://binaries.ddbuild.io/dd-source/workspaces-tool-helper/v0.3.1/workspaces-tool-helper-tar.tar.gz"
+        }
+      ],
+      "size": 12913279
+    },
+    "linux-x86_64": {
+      "digest": "4dc40fac4c1287a65ad496bcb7154409270e65bc0184a080c2ee2aff5072f8ba",
+      "format": "tar.gz",
+      "hash": "sha256",
+      "path": "workspaces-tool-helper-linux-amd64",
+      "providers": [
+        {
+          "type": "http",
+          "url": "https://binaries.ddbuild.io/dd-source/workspaces-tool-helper/v0.3.1/workspaces-tool-helper-tar.tar.gz"
+        }
+      ],
+      "size": 12913279
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Improve python environment handling, when logged in as bits user in workspaces it should also enable python conda environment. So that everything works as expected, like in the CI
Also add a dotslash install of Claude

### Motivation

### Possible Drawbacks / Trade-offs

### Additional Notes
