### PR TITLE
Correct permissions of the home directory in the Linux dev env

### DIFF
--- a/dev-envs/linux/Dockerfile
+++ b/dev-envs/linux/Dockerfile
@@ -14,8 +14,8 @@ USER root
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-# Set up HOME as root-owned and build-shared writable so host-mapped users
-# with unknown UID/GID can use it without chown.
+# Set up HOME during the image build. The entrypoint assigns it to the
+# runtime target user before startup creates user state.
 ENV HOME=/home/dd
 ENV PATH="${HOME}/.local/bin:${PATH}"
 RUN mkdir -p "${HOME}" && \

--- a/dev-envs/linux/init/entrypoint.sh
+++ b/dev-envs/linux/init/entrypoint.sh
@@ -58,6 +58,14 @@ if [[ ! -f "${startup_indicator}" ]]; then
         exit 1
     fi
 
+    # Make the target home look like a normal user-owned home before startup creates runtime state.
+    # As this is only necessary for the initial run of the container, we first verify the correct owner
+    # to potentially improve the time it takes to restart.
+    if [[ "$(stat -c %U "${TARGET_HOME}")" != "${TARGET_USER}" ]]; then
+        chown -R "${TARGET_USER}:" "${TARGET_HOME}"
+    fi
+    chmod 0755 "${TARGET_HOME}"
+
     # Persist environment for SSH sessions
     env | grep -Ev "^(HOME=|USER=|MAIL=|LS_COLORS=|HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|_=)" >> /etc/environment
 

--- a/dev-envs/linux/zsh.sh
+++ b/dev-envs/linux/zsh.sh
@@ -38,25 +38,47 @@ OH_MY_ZSH_COMMIT="b26b5002633e865b70e17933536fe4dc99127898"
 
 (
     umask 0002
-    mkdir -p "${HOME}/.oh-my-zsh"
-    curl -fsSL "https://github.com/ohmyzsh/ohmyzsh/archive/${OH_MY_ZSH_COMMIT}.tar.gz" |
-        tar -xz -C "${HOME}/.oh-my-zsh" --strip-components 1
+    zsh_config_dir="${DD_BUILD_CONFIG_ROOT}/zsh"
+    omz_config="${zsh_config_dir}/oh-my-zsh.zsh"
+    mkdir -p "${zsh_config_dir}"
+    cat <<EOF > "${omz_config}"
+export ZSH="\${XDG_DATA_HOME}/oh-my-zsh"
+OH_MY_ZSH_COMMIT="${OH_MY_ZSH_COMMIT}"
 
-    mkdir -p "${HOME}/.config/zsh"
-    cat <<'EOF' > "${HOME}/.config/zsh/oh-my-zsh.zsh"
-export ZSH="${HOME}/.oh-my-zsh"
+if [[ ! -f "\${ZSH}/oh-my-zsh.sh" ]]; then
+    echo "Setting up Oh My Zsh ..."
+    zsh_data_dir="\$(dirname "\${ZSH}")"
+    mkdir -p "\${zsh_data_dir}"
+    omz_tmp="\$(mktemp -d "\${zsh_data_dir}/oh-my-zsh.tmp.XXXXXX")"
+    # Keep full ancestry so Oh My Zsh updates can fast-forward cleanly from the pinned commit.
+    git clone --quiet --filter=blob:none --single-branch --no-checkout https://github.com/ohmyzsh/ohmyzsh.git "\${omz_tmp}"
+    git -C "\${omz_tmp}" reset --quiet --hard "\${OH_MY_ZSH_COMMIT}"
+    # Oh My Zsh's compaudit refuses to load completions from group/other-writable directories.
+    chmod -R go-w "\${omz_tmp}"
+    rm -rf "\${ZSH}"
+    mv "\${omz_tmp}" "\${ZSH}"
+fi
+
 ZSH_THEME="robbyrussell"
-zstyle ':omz:update' mode disabled
 plugins=(
     git
 )
 
-source "${ZSH}/oh-my-zsh.sh"
-EOF
+# Use append-only history for bind-mounted history files whose ownership may differ.
+setopt APPEND_HISTORY
+setopt INC_APPEND_HISTORY
+unsetopt HIST_SAVE_BY_COPY
+unsetopt SHARE_HISTORY
 
-    # Set up Oh My Zsh and Starship toggles.
-    cat <<'EOF' >> "${HOME}/.zshrc"
-source "${HOME}/.config/zsh/oh-my-zsh.zsh"
-# eval "$(starship init zsh)"
+source "\${ZSH}/oh-my-zsh.sh"
 EOF
 )
+
+# Set up Oh My Zsh and Starship toggles.
+cat <<'EOF' >> "${HOME}/.zshrc"
+# Set up Oh My Zsh.
+source "${XDG_CONFIG_HOME}/zsh/oh-my-zsh.zsh"
+
+# Set up Starship.
+# eval "$(starship init zsh)"
+EOF


### PR DESCRIPTION
### What does this PR do?

- Ensure that the home directory of the runtime-created user has the expected permissions
- Fix warnings being emitted from Zsh

### Motivation

- There's no reason to have the user's access to its home directory granted via group membership rather than normal ownership since the root user wouldn't write to the directory at runtime. The only thing to look out for is that the home directory within the image stays barebones so that the `chown` at first startup is fast.
- When using Zsh there was a warning during initialization from Oh My Zsh and another upon exit from Zsh itself.

```
[oh-my-zsh] Insecure completion-dependent directories detected:
drwxrwsr-x 12 root build-shared 4096 May 28 15:57 /home/dd/.oh-my-zsh
drwxrwxr-x  4 root root         4096 May 27 14:37 /home/dd/.oh-my-zsh/custom

[oh-my-zsh] For safety, we will not load completions from these directories until
[oh-my-zsh] you fix their permissions and ownership and restart zsh.
[oh-my-zsh] See the above list for directories with group or other writability.

[oh-my-zsh] To fix your permissions you can do so by disabling
[oh-my-zsh] the write permission of "group" and "others" and making sure that the
[oh-my-zsh] owner of these directories is either root or your current user.
[oh-my-zsh] The following command may help:
[oh-my-zsh]     compaudit | xargs chmod g-w,o-w

[oh-my-zsh] If the above didn't help or you want to skip the verification of
[oh-my-zsh] insecure directories you can set the variable ZSH_DISABLE_COMPFIX to
[oh-my-zsh] "true" before oh-my-zsh is sourced in your zshrc file.
```

```
zsh: rewriting /home/dd/.zsh_history would change its ownership -- skipped
```

### Additional Notes

This also installs Oh My Zsh on-demand rather than being shipped with the image and persists the installation for the user so that their changes aren't tied to container lifecycles