### PR TITLE
Install dd-pkg in Docker build images

### DIFF
--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -1,4 +1,7 @@
 ARG BUILDENV_REGISTRY
+
+FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.3 AS dd_pkg
+
 FROM ${BUILDENV_REGISTRY}/images/docker:27.3.1
 
 ARG PYTHON_VERSION=3.12.6
@@ -86,3 +89,5 @@ RUN --mount=type=bind,src=./setup/authanywhere.sh,dst=/mnt/authanywhere.sh /mnt/
 RUN curl -fsSL https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/datadog-ci_linux-arm64 --output "/usr/local/bin/datadog-ci" && \
   echo "${DATADOG_CI_SHA} /usr/local/bin/datadog-ci" | sha256sum --check && \
   chmod +x /usr/local/bin/datadog-ci
+
+COPY --from=dd_pkg /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -4,6 +4,8 @@ ARG BUILDENV_REGISTRY
 FROM registry.ddbuild.io/dd-octo-sts:${DD_OCTO_STS_VERSION} AS dd_octo_sts_builder
 # Dummy stage to download dd-octo-sts as it is distributed as a container image
 
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.3 AS dd_pkg
+
 FROM ${BUILDENV_REGISTRY}/images/docker:27.3.1
 
 ARG PY3_VERSION
@@ -118,3 +120,5 @@ RUN --mount=type=bind,src=./setup/authanywhere.sh,dst=/mnt/authanywhere.sh /mnt/
 ARG DD_OCTO_STS_VERSION
 COPY --from=dd_octo_sts_builder /usr/local/bin/dd-octo-sts /usr/local/bin/dd-octo-sts
 LABEL dd_octo_sts_version="${DD_OCTO_STS_VERSION}"
+
+COPY --from=dd_pkg /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg


### PR DESCRIPTION
## Problem

Agent public-image publication jobs now use `dd-pkg`. The shared Agent publish template runs in `docker_x64`, but the Docker build images did not include the `dd-pkg` binary, so jobs could fail with `dd-pkg: command not found` unless they downloaded it at runtime.

## Changes

- Copy `dd-pkg` from `registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.3` into `docker_x64`.
- Copy the arm64 `dd-pkg` binary into `docker_arm64` as well so both Docker build images have the same publishing tool available on `PATH`.

Jira: BARX-1697

## Validation

- `git diff --check`
- `docker buildx bake docker_x64-ci --print`
- `build_docker_x64` passed in GitLab pipeline `116481808`.
- `build_docker_arm64` passed in GitLab pipeline `116481808`.
- Verified the pushed branch images contain the `COPY /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg` layer:
  - `registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64_test_only:v116481808-6cfda90e`
  - `registry.ddbuild.io/ci/datadog-agent-buildimages/docker_arm64_test_only:v116481808-6cfda90e`
