### PR TITLE
Create the non-root dd user at build time and realign it at runtime

### DIFF
--- a/dev-envs/linux/init/entrypoint.sh
+++ b/dev-envs/linux/init/entrypoint.sh
@@ -13,34 +13,43 @@ if [[ -z "${TARGET_HOME}" ]]; then
     TARGET_HOME="${HOME}"
 fi
 
+startup_indicator="/.started"
+
+# On first start, realign the image-provided user to the host's UID/GID before anything
+# else runs. This must happen up front because the startup below writes host-owned
+# files, and because editors and CLIs exec in as this user as soon as the container
+# runs, so it must already exist with the right IDs. The image normally pre-creates the
+# user, so this only adjusts its IDs; the fallback handles images that do not.
+if [[ ! -f "${startup_indicator}" ]]; then
+    TARGET_UID="${HOST_UID:-}"
+    TARGET_GID="${HOST_GID:-${TARGET_UID}}"
+
+    if ! id "${TARGET_USER}" >/dev/null 2>&1; then
+        # Create the user when the image did not pre-create it.
+        TARGET_UID="${TARGET_UID:-1000}"
+        TARGET_GID="${TARGET_GID:-${TARGET_UID}}"
+        getent group "${TARGET_GID}" >/dev/null || groupadd -g "${TARGET_GID}" "${TARGET_GROUP}"
+        useradd -u "${TARGET_UID}" -g "${TARGET_GID}" -G build-shared,sudo "${TARGET_USER}"
+    elif [[ -n "${TARGET_UID}" ]]; then
+        # Realign the pre-created user's GID and then its UID to the host's.
+        if [[ "$(id -g "${TARGET_USER}")" != "${TARGET_GID}" ]]; then
+            if getent group "${TARGET_GID}" >/dev/null; then
+                usermod -g "${TARGET_GID}" "${TARGET_USER}"
+            else
+                groupmod -g "${TARGET_GID}" "$(id -gn "${TARGET_USER}")"
+            fi
+        fi
+        if [[ "$(id -u "${TARGET_USER}")" != "${TARGET_UID}" ]]; then
+            usermod -u "${TARGET_UID}" "${TARGET_USER}"
+        fi
+    fi
+    TARGET_HOME="$(getent passwd "${TARGET_USER}" | cut -d: -f6)"
+fi
+
 # Reassert shared-root metadata on every start so it survives root recreation.
 /init/ensure-shared-roots.sh
 
-startup_indicator="/.started"
 if [[ ! -f "${startup_indicator}" ]]; then
-    if ! id "${TARGET_USER}" >/dev/null 2>&1; then
-        # Choose a UID higher than the one used by the base build image's default user (1001)
-        TARGET_UID="${HOST_UID:-1002}"
-        TARGET_GID="${HOST_GID:-${TARGET_UID}}"
-
-        # Create the primary group if the host GID is not already present.
-        if ! getent group "${TARGET_GID}" >/dev/null; then
-            groupadd -g "${TARGET_GID}" "${TARGET_GROUP}"
-        fi
-        useradd -u "${TARGET_UID}" -g "${TARGET_GID}" "${TARGET_USER}"
-        TARGET_HOME="$(getent passwd "${TARGET_USER}" | cut -d: -f6)"
-
-        supplemental_groups=(
-            # Write access to shared build directories
-            build-shared
-            # Allow passwordless sudo
-            sudo
-        )
-        for group in "${supplemental_groups[@]}"; do
-            usermod -a -G "${group}" "${TARGET_USER}"
-        done
-    fi
-
     # Allow passwordless SSH login for the target user
     passwd -d "${TARGET_USER}"
     usermod -U "${TARGET_USER}"

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -549,11 +549,29 @@ RUN if [ -n "$(find "${DD_BUILD_DATA_ROOT}" -mindepth 1 -print -quit 2>/dev/null
         exit 1; \
     fi
 
-# Default non-root user for CI and interactive use.
-# 1000 is the default UID for the first user on Debian-based systems.
-RUN useradd -m -u 1001 -g build-shared -G sudo -s /bin/bash dd-build && \
-    cp /root/.bashrc /home/dd-build/.bashrc && \
-    chown dd-build:build-shared /home/dd-build/.bashrc
+# Remove the unused `ubuntu` user to free UID 1000 (Debian's default first-user UID)
+# for `dd` below.
+RUN userdel -r ubuntu 2>/dev/null || true
+
+# No account should occupy the human UID range (>= 1000) when `dd` claims UID 1000
+# below. Fail the build if a future base image or tool introduces one.
+RUN unexpected="$(getent passwd | awk -F: '$3 >= 1000 && $3 < 65534 { print $1 " (uid " $3 ")" }')"; \
+    if [ -n "${unexpected}" ]; then \
+        echo "Unexpected non-system account(s) present before creating dd: ${unexpected}" >&2; \
+        exit 1; \
+    fi
+
+# This single non-root user serves both CI builds and developer environments. It joins
+# `build-shared` (shared build dirs) and `sudo`, and its primary group is its own `dd`
+# rather than `build-shared` so the dev-env entrypoint can remap its GID to the host's
+# without changing the shared group's GID. UID 1000 is Debian's first-user UID, so the
+# common Linux host needs no remap. Root's `.bashrc` is deliberately not copied into its
+# home because it sources RVM with the non-interactive early-return stripped, which
+# would load RVM in the dev environment's own non-interactive build shells (which share
+# this home) and fail on an unset $USER under `set -u`. The CI user's shell environment
+# belongs in /etc/profile.d.
+RUN groupadd -g 1000 dd && \
+    useradd -m -u 1000 -g dd -G build-shared,sudo -s /bin/bash dd
 
 # Set up environment
 ARG CTNG_ARCH
@@ -614,7 +632,7 @@ LABEL maintainer="DataDog"
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 
-# USER dd-build
-# WORKDIR /home/dd-build
+# USER dd
+# WORKDIR /home/dd
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
### What does this PR do?

- Replaces the build image's `dd-build` user with a single non-root user `dd` (UID 1000, primary group `dd`, supplementary `build-shared` + `sudo`), used consistently by both CI builds and the Linux developer environment.
- Removes the base image's unused default `ubuntu` user (frees UID 1000) and adds a build-time guard that fails the build if any unexpected account appears in the human UID range (>= 1000), rather than silently colliding with or shadowing it.
- Changes the Linux dev environment entrypoint to **realign the pre-created `dd` user to the host's UID/GID up front**, instead of creating the user lazily on first start.

### Motivation

The Linux developer environment is increasingly consumed through the dev container CLI, which bind-mounts the host checkout and `docker exec`s into the container **as the remote user, as soon as the container is running**. The entrypoint previously created `dd` partway through startup, so on slower hosts (notably CI) the editor/CLI raced ahead and [failed](https://github.com/DataDog/datadog-agent/actions/runs/26966455339/job/79570246031?pr=51762#step:10:370) with:

```
unable to find user dd: no matching entries in passwd file
```

Provisioning `dd` at build time means it always resolves for those execs; the entrypoint then only realigns its UID/GID to the host's (which still must happen up front, before startup creates host-owned files). Unifying on one `dd` name also makes the non-root account consistent across build and dev-env contexts, ahead of the move to `USER dd` for non-root CI builds.

### Describe how you validated your changes

First in this repo:

```
❯ docker buildx bake --set linux-amd64.tags=datadog/agent-buildimages-linux:dev
...
 => => naming to docker.io/datadog/agent-buildimages-linux:dev
❯ dda run build dev-envs\linux datadog/agent-dev-env-linux:dev --build-arg BASE_IMAGE_TAG=dev
...
 => => naming to docker.io/datadog/agent-dev-env-linux:dev
```

Then in the agent repo:

```
❯ dda inv -- devcontainer.setup --image datadog/agent-dev-env-linux:dev
❯ devcontainer up --terminal-columns (term size).columns --terminal-rows (term size).rows --workspace-folder .
[2 ms] @devcontainers/cli 0.87.0. Node.js v25.9.0. win32 10.0.26200 x64.
...
{"outcome":"success","containerId":"c6a3f300a6abd3737a30ffaec4eaaba02fe03e66a550f78caff8a2f93470ec50","remoteUser":"dd","remoteWorkspaceFolder":"/workspaces/datadog-agent"}
```

### Additional notes

This blocks https://github.com/DataDog/datadog-agent/pull/51762