### PR TITLE
Fix build issues

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -69,6 +69,7 @@
     - docker buildx bake $PUSH ${PREVENT_CACHE:+--no-cache} $BAKE_TARGET
     - |
       if [[ "$CI_PIPELINE_SOURCE" != "schedule" ]]; then
+        ./verify-image-layers.sh registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION
         crane manifest registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION | jq
         crane config registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION | jq
         export SIZE=$(crane manifest registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION | jq '.config.size + ([.layers[].size] | add)')

--- a/build.sh
+++ b/build.sh
@@ -90,6 +90,11 @@ if [[ "$CI_PIPELINE_SOURCE" != "schedule" ]]; then
     ddsign sign registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION --docker-metadata-file ${METADATA_FILE}
 fi
 
+# Reject images that picked up a foreign accelerator layer.
+if [[ "$CI_PIPELINE_SOURCE" != "schedule" ]]; then
+    ./verify-image-layers.sh registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION
+fi
+
 # Statistics
 if [[ "$CI_PIPELINE_SOURCE" != "schedule" ]]; then
     crane manifest registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:$IMAGE_VERSION | jq

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -218,6 +218,12 @@ variable "CI" {
   default = ""
 }
 
+variable "PREVENT_CACHE" {
+  type = string
+  // When set in the environment, disable build-cache import so a poisoned cache can be rebuilt.
+  default = ""
+}
+
 variable CI_COMMIT_BRANCH {
   type = string
   // Will pull in the env var if it is defined, but otherwise will be empty
@@ -263,7 +269,9 @@ variable "linux_cache_details_branch" {
 target "_fake_linux-local" {
   dockerfile = "linux/Dockerfile"
   context    = "./"
-  cache-from = [linux_cache_details_main]
+  # Bake merges cache-from across inherited targets, so this base must honor
+  # PREVENT_CACHE too; otherwise the cache leaks into the -ci targets that inherit it.
+  cache-from = PREVENT_CACHE != "" ? [] : [linux_cache_details_main]
   tags       = ["${repo_name}/linux:latest"]
   # Outside CI, use GITLAB_TOKEN from env var
   secret     = ["type=env,id=gitlab-token,env=GITLAB_TOKEN"]
@@ -315,7 +323,7 @@ variable "linux-image-tag" {
 target "_fake_linux-ci" {
   # In CI, use CI_JOB_TOKEN as GITLAB_TOKEN
   secret     = ["type=env,id=gitlab-token,env=CI_JOB_TOKEN"]
-  cache-from = [linux_cache_details_branch, linux_cache_details_main]
+  cache-from = PREVENT_CACHE != "" ? [] : [linux_cache_details_branch, linux_cache_details_main]
   cache-to   = [linux_cache_details_branch]
   tags       = ["${registry_name}/${repo_name}/linux:${linux-image-tag}"]
   output     = ["type=docker,dest=./linux-${linux-image-tag}.tar"]
@@ -371,7 +379,8 @@ target "_fake_docker_x64-local" {
   dockerfile = "docker-x64/Dockerfile"
   context    = "./"
   platforms  = ["linux/amd64"]
-  cache-from = [docker_x64_cache_details_main]
+  # As in _fake_linux-local, cache-from is merged across inherited targets.
+  cache-from = PREVENT_CACHE != "" ? [] : [docker_x64_cache_details_main]
   tags       = ["${repo_name}/docker_x64:latest"]
   args       = merge(versions, go_versions, checksums_amd64, go_checksums_amd64, { BUILDENV_REGISTRY = BUILDENV_REGISTRY })
 }
@@ -381,7 +390,7 @@ target "docker_x64" {
 }
 
 target "_fake_docker_x64-ci" {
-  cache-from = [docker_x64_cache_details_branch, docker_x64_cache_details_main]
+  cache-from = PREVENT_CACHE != "" ? [] : [docker_x64_cache_details_branch, docker_x64_cache_details_main]
   cache-to   = [docker_x64_cache_details_branch]
   tags       = ["${registry_name}/${repo_name}/docker_x64:${docker_x64-image-tag}"]
   output     = ["type=docker,dest=./docker_x64-${docker_x64-image-tag}.tar"]

--- a/setup/codecov.sh
+++ b/setup/codecov.sh
@@ -25,7 +25,7 @@ else
 fi
 
 # Integrity checking the uploader
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl -fsSL https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
 curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/${CODECOV_ARCH}/codecov
 curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/${CODECOV_ARCH}/codecov.SHA256SUM
 curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/${CODECOV_ARCH}/codecov.SHA256SUM.sig

--- a/verify-image-layers.sh
+++ b/verify-image-layers.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Verify that an image contains only standard tar-based filesystem layers.
+#
+# A foreign accelerator layer (e.g. a Nydus blob from a COPY --from source or a poisoned
+# BuildKit cache) breaks `docker pull` with "failed to register layer: invalid input:
+# magic number mismatch". This guard fails the build before such an image is promoted.
+#
+# Usage: ./verify-image-layers.sh <image-ref>
+set -euo pipefail
+
+readonly IMAGE="${1:?usage: verify-image-layers.sh <image-ref>}"
+
+# Every legitimate filesystem-layer media type contains "tar"; accelerator and
+# attestation blobs (Nydus, SOCI, in-toto) do not.
+layer_media_types() {
+    local manifest
+    manifest="$(crane manifest "$IMAGE")"
+
+    if jq -e 'has("manifests")' <<<"$manifest" >/dev/null; then
+        # For a multi-arch index, descend into each real platform, skipping unknown/unknown
+        # attestation manifests.
+        jq -r '.manifests[] | "\(.platform.os)/\(.platform.architecture)"' <<<"$manifest" \
+            | while read -r platform; do
+                [[ "$platform" == "unknown/unknown" ]] && continue
+                crane manifest --platform "$platform" "$IMAGE" | jq -r '.layers[]?.mediaType'
+            done
+    else
+        jq -r '.layers[]?.mediaType' <<<"$manifest"
+    fi
+}
+
+types="$(layer_media_types)"
+unexpected="$(grep -ivF tar <<<"$types" | sort -u || true)"
+
+if [[ -n "$unexpected" ]]; then
+    {
+        echo "ERROR: ${IMAGE} contains non-tar (foreign/accelerator) layer media type(s):"
+        echo "$unexpected" | sed 's/^/  - /'
+        echo
+        echo "These break 'docker pull' for standard clients ('magic number mismatch')."
+        echo "They usually leak in from a 'COPY --from' source image or a poisoned BuildKit"
+        echo "registry cache. Remediate by purging the 'cache-<branch>-<arch>' cache image"
+        echo "(or rebuilding with PREVENT_CACHE=1) and rebuilding from a clean source."
+    } >&2
+    exit 1
+fi
+
+echo "OK: all layers in ${IMAGE} are tar-based filesystem layers."


### PR DESCRIPTION
### Motivation

The [image](https://hub.docker.com/layers/datadog/agent-buildimages-linux/v118120647-42d4c574/images/sha256-c4da00738f6ec1bf9c0d16c496b3a5c3f9666f950109a207b0124a00b28fc547) built from 42d4c574 somehow contained a [Nydus](https://github.com/dragonflyoss/nydus) layer:

```
❯ crane manifest --platform linux/amd64 datadog/agent-buildimages-linux:v118120647-42d4c574 | from json | get layers | group-by mediaType | transpose mediaType layers | each {|r| {mediaType: $r.mediaType, count: ($r.layers | length)} }
╭───┬───────────────────────────────────────────────────┬───────╮
│ # │                     mediaType                     │ count │
├───┼───────────────────────────────────────────────────┼───────┤
│ 0 │ application/vnd.docker.image.rootfs.diff.tar.gzip │    52 │
│ 1 │ application/vnd.oci.image.layer.nydus.blob.v1     │     1 │
╰───┴───────────────────────────────────────────────────┴───────╯
```

Further confirmed by the header containing Zstandard's [magic number](https://github.com/facebook/zstd/blob/5233c58e6ca0b1c4c6b353ad79649191ed195bdc/doc/zstd_compression_format.md#zstandard-frames):

```
❯ crane manifest --platform linux/amd64 datadog/agent-buildimages-linux:v118120647-42d4c574 | from json | get layers | where mediaType !~ "tar" | first | get digest
sha256:6c24424576a85564db5489ffa72f9d9d458cf5529d5254f204426a6634eac158
❯ crane blob "datadog/agent-buildimages-linux@sha256:6c24424576a85564db5489ffa72f9d9d458cf5529d5254f204426a6634eac158" | into binary | first 8
Length: unknown (stream) | null_char printable whitespace ascii_other non_ascii
00000000:   28 b5 2f fd  60 00 1f f5                             (×/×`0•×
```

This causes errors like:

```
❯ docker pull datadog/agent-buildimages-linux
...
failed to register layer: invalid input: magic number mismatch
```

### What does this PR do?

This adds a check for such issues that gates publishing. Also, builds now support the `PREVENT_CACHE` variable for the modern Linux image just like the older images that still use [`build.sh`](https://github.com/DataDog/datadog-agent-buildimages/blob/42d4c57456a682cb822f8026ee22a432be57da91/build.sh#L30).