### PR TITLE
fix(codecov): switch GPG key URL to keybase.io/codecovsecops

### DIFF
--- a/setup/codecov.sh
+++ b/setup/codecov.sh
@@ -25,7 +25,7 @@ else
 fi
 
 # Integrity checking the uploader
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
 curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/${CODECOV_ARCH}/codecov
 curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/${CODECOV_ARCH}/codecov.SHA256SUM
 curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/${CODECOV_ARCH}/codecov.SHA256SUM.sig


### PR DESCRIPTION
## What does this PR do?

Updates `setup/codecov.sh` to fetch the Codecov GPG verification key from `keybase.io/codecovsecops` instead of the defunct `keybase.io/codecovsecurity`.

## Motivation

The Keybase URL hardcoded in `codecov.sh` returns HTTP 404:

```
$ curl https://keybase.io/codecovsecurity/pgp_keys.asc
SELF-SIGNED PUBLIC KEY NOT FOUND
```

Codecov announced the migration on 2026-06-07 (https://github.com/codecov/codecov-action/issues/1956):

> We unfortunately lost our ability to update our keybase account and have migrated from `keybase.io/codecovsecurity` to `keybase.io/codecovsecops`. In order to prevent future misuse of the `codecovsecurity`, we have bricked the account.

This broke the `build_rpm_x64` and `build_rpm_arm64` jobs in the post-merge pipeline of PR #1189 with:

```
ERROR: failed to build: failed to solve: process "/bin/sh -c /mnt/codecov.sh" did not complete successfully: exit code: 2
```

The upstream fix in codecov-action v7.0.0 is the same one-line URL change: https://github.com/codecov/codecov-action/compare/v6.0.1...v7.0.0

## Describe how you validated your changes

The old URL returns 404, the new URL returns 200:

```
$ curl -sI https://keybase.io/codecovsecurity/pgp_keys.asc | head -1
HTTP/2 404

$ curl -sI https://keybase.io/codecovsecops/pgp_keys.asc | head -1
HTTP/2 200
```

Ran each verification step from `codecov.sh` manually on a Linux workspace:

```
$ curl -fsSL https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
$ curl -Os https://uploader.codecov.io/v0.6.1/linux/codecov
$ curl -Os https://uploader.codecov.io/v0.6.1/linux/codecov.SHA256SUM
$ curl -Os https://uploader.codecov.io/v0.6.1/linux/codecov.SHA256SUM.sig

$ gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
gpgv: Signature made XXXXXXX
gpgv:                using RSA key XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
gpgv: Good signature from "Codecov Uploader (Codecov Uploader Verification Key) ...."

$ shasum -a 256 -c codecov.SHA256SUM
codecov: OK
```

## Additional Notes