### PR TITLE
[Backport 7.80.x] fix(codecov): switch GPG key URL to keybase.io/codecovsecops

### DIFF
--- a/setup/codecov.sh
+++ b/setup/codecov.sh
@@ -25,7 +25,7 @@ else
 fi
 
 # Integrity checking the uploader
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
 curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/${CODECOV_ARCH}/codecov
 curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/${CODECOV_ARCH}/codecov.SHA256SUM
 curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/${CODECOV_ARCH}/codecov.SHA256SUM.sig


### PR DESCRIPTION
## What does this PR do?
Backport of #1202 to fix CI for https://github.com/DataDog/datadog-agent/pull/51868

## Motivation
## Validation
## Additional Notes
