### PR TITLE
Activate conda env like in CI

### DIFF
--- a/dev-envs/linux/init/entrypoint.sh
+++ b/dev-envs/linux/init/entrypoint.sh
@@ -68,11 +68,8 @@ if [[ ! -f "${startup_indicator}" ]]; then
     fi
 
     # Make the target home look like a normal user-owned home before startup creates runtime state.
-    # As this is only necessary for the initial run of the container, we first verify the correct owner
-    # to potentially improve the time it takes to restart.
-    if [[ "$(stat -c %U "${TARGET_HOME}")" != "${TARGET_USER}" ]]; then
-        chown -R "${TARGET_USER}:" "${TARGET_HOME}"
-    fi
+    # This is needed because the operation initializing tools are executed as root and can lead to root owner files in the user's home.
+    chown -R "${TARGET_USER}:" "${TARGET_HOME}"
     chmod 0755 "${TARGET_HOME}"
 
     # Persist environment for SSH sessions

--- a/dev-envs/linux/init/startup.sh
+++ b/dev-envs/linux/init/startup.sh
@@ -84,6 +84,12 @@ if [[ -n "${GIT_AUTHOR_EMAIL:-}" ]]; then
     git config --global user.email "${GIT_AUTHOR_EMAIL}"
 fi
 
+# Configure python
+for shell in bash zsh; do
+    conda init "${shell}"
+    echo "conda activate ddpy3" >> "${HOME}/.${shell}rc"
+done
+
 # Configure pass
 # NOTE: We create a separate gpg dir for pass, and configure pass to always use that gpg
 # homedir. This ensures we don't conflict with a forwarded gpg-agent


### PR DESCRIPTION
### What does this PR do?

When the image is used in the CI we make sure conda is activated: https://github.com/DataDog/datadog-agent-buildimages/blob/main/setup/python.sh#L139
Let's do the same in the developer environment so that we get the same python environment as used in the CI. Otherwise it prevents us from building the agent with `agent.buid`

Remove a guard on running `chown` on the home directory. Because it was leading with a home owned by the target user, but with some files owned by root due to the setup (.zshrc). The guard is not needed as the operation does not take any time to be executed


### Motivation

### Possible Drawbacks / Trade-offs

### Additional Notes
