### PR TITLE
[#incident-56436] Enable NTFS 8.3 short names in the Windows image

### DIFF
--- a/windows/helpers/phase3/install_bazelisk.ps1
+++ b/windows/helpers/phase3/install_bazelisk.ps1
@@ -8,6 +8,9 @@ $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 Set-StrictMode -Version 3.0
 
+# Without filesystem 8.3 aliases, Bazel can't shorten long paths: https://github.com/bazelbuild/bazel/issues/19710
+New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name NtfsDisable8dot3NameCreation -PropertyType DWord -Value 0 -Force
+
 $isInstalled, $isCurrent = Get-InstallUpgradeStatus -Component bazelisk -Keyname version -TargetValue $Version
 if ($isInstalled -and $isCurrent) {
     Write-Host -ForegroundColor Yellow "Skipping bazelisk v$Version reinstallation"


### PR DESCRIPTION
### What does this PR do?
Sets `NtfsDisable8dot3NameCreation` to `0` in `install_bazelisk.ps1` so the Windows build image generates 8.3 short-name aliases on its own filesystem.

### Motivation
Windows GitLab runner images are fine wrt 8dot3 name creation:
```
$ fsutil 8dot3name query C:
The volume state is: 0 (8dot3 name creation is ENABLED)
The registry state is: 2 (Per volume setting - the default)
Based on the above settings, 8dot3 name creation is ENABLED on "C:"
```
But Windows container images aren't:
```
The volume state is: 1 (8dot3 name creation is DISABLED)
The registry state is: 2 (Per volume setting - the default)
Based on the above settings, 8dot3 name creation is DISABLED on "C:"
```
Without those aliases, `GetShortPathNameW` is a no-op, so Bazel cannot shorten long runfiles paths under `MAX_PATH` and test launches fail with "cannot shorten the path enough": bazelbuild/bazel#19710

This presently hinders our CI, leading to [#incident-56436](https://dd.enterprise.slack.com/archives/C0BBPAV0J20).

### Possible Drawbacks / Trade-offs
Each aliased name adds one filename attribute in the MFT plus one parent directory index entry, on the order of 200 bytes, typically absorbed in existing record slack with **no extra cluster allocated**.
Runtime cost is a short-name collision scan at file creation, which only matters in directories holding many same-prefixed names; `bazel` output trees do not.
Only affects files created after the change, which therefore covers the runtime-created "output base" (`C:\bob`).

### Additional Notes
The per-volume alternative (`fsutil 8dot3name set C: 0`) is avoided on purpose: it changes a volume-level NTFS property, not file content, so it may not be captured by the image layers and would not reliably persist into a container's fresh writable layer.
The registry value lives in the SYSTEM hive (a file), so it's guaranteed to travel with the image.

Distinct from the existing `LongPathsEnabled` setting (#992), which only lifts MAX_PATH for git's own file I/O and does not help Bazel's `CreateProcessW` launcher.