### PR TITLE
Stop the `bazel` install test from bloating an image layer

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -32,8 +32,6 @@ variable "versions" {
     PULUMI_VERSION         = "3.207.0"
     DD_OCTO_STS_VERSION    = "v1.9.3"
     MOLD_VERSION           = "2.40.4"
-    # Version of Bazel to test that Bazelisk properly bootstraps Bazel, which will also be pre-installed into the final image.
-    TEST_BAZEL_VERSION  = "9.1.0"
   }
 }
 

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -318,8 +318,7 @@ ARG OSXCROSS_PATH="${DD_BUILD_INSTALL_ROOT}/osxcross" \
     RVM_PATH="${DD_BUILD_INSTALL_ROOT}/rvm"
 
 # Cache directories
-ENV BAZELISK_HOME="${XDG_CACHE_HOME}/bazelisk" \
-    DOTSLASH_CACHE="${XDG_CACHE_HOME}/dotslash" \
+ENV DOTSLASH_CACHE="${XDG_CACHE_HOME}/dotslash" \
     GOPATH="${XDG_CACHE_HOME}/go" \
     GOCACHE="${XDG_CACHE_HOME}/go/build" \
     GOMODCACHE="${XDG_CACHE_HOME}/go/pkg/mod" \
@@ -475,15 +474,16 @@ ADD --chmod=755 --checksum=sha256:${BAZELISK_SHA256} "https://github.com/bazelbu
 # Symlink bazelisk to bazel
 RUN ln -s /usr/local/bin/bazelisk /usr/local/bin/bazel
 
-# Verify Bazelisk properly bootstraps Bazel - this also preinstalls Bazel ${TEST_BAZEL_VERSION}
-ARG TEST_BAZEL_VERSION
+# Verify Bazelisk properly bootstraps Bazel - keeping the downloaded Bazel tarball & extracted runtime would only bloat
+# the image because their version is almost guaranteed to be out of sync with each downstream branch's `.bazelversion`
 RUN readlink -f "$(command -v bazel)" | tee /dev/stderr | grep -Fqx /usr/local/bin/bazelisk
-RUN --mount=type=bind,src=./linux/scripts/fix-shared-perms.sh,dst=/mnt/fix-shared-perms.sh \
-    USE_BAZEL_VERSION=${TEST_BAZEL_VERSION} \
-    # TODO(incident-47542): Remove this once `releases.bazel.build` is back online
-    BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download \
-    bazel --version | tee /dev/stderr | grep -Fqx "bazel ${TEST_BAZEL_VERSION}" && \
-    /mnt/fix-shared-perms.sh "${BAZELISK_HOME}"
+RUN tmp_dir="$(mktemp -d)" \
+    && export USE_BAZEL_VERSION=9.1.0 \
+    && XDG_CACHE_HOME="$tmp_dir" \
+       # TODO(incident-47542): Remove this once `releases.bazel.build` is back online
+       BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download \
+       bazel --version | tee /dev/stderr | grep -Fqx "bazel $USE_BAZEL_VERSION" \
+    && rm -r "$tmp_dir"
 
 # Rust
 COPY --from=rust_builder /usr/local/cargo-bin/ /usr/local/bin/

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -317,8 +317,10 @@ ARG OSXCROSS_PATH="${DD_BUILD_INSTALL_ROOT}/osxcross" \
     CONDA_PATH="${DD_BUILD_INSTALL_ROOT}/conda" \
     RVM_PATH="${DD_BUILD_INSTALL_ROOT}/rvm"
 
-# Cache directories
-ENV DOTSLASH_CACHE="${XDG_CACHE_HOME}/dotslash" \
+# Cache directories - some of these may look redundant on Linux where most tools honor $XDG_CACHE_HOME, but we make them
+# explicit here for eventual parity with the Windows build image where XDG_CACHE_HOME isn't conventional
+ENV BAZELISK_HOME="${XDG_CACHE_HOME}/bazelisk" \
+    DOTSLASH_CACHE="${XDG_CACHE_HOME}/dotslash" \
     GOPATH="${XDG_CACHE_HOME}/go" \
     GOCACHE="${XDG_CACHE_HOME}/go/build" \
     GOMODCACHE="${XDG_CACHE_HOME}/go/pkg/mod" \
@@ -480,6 +482,7 @@ RUN readlink -f "$(command -v bazel)" | tee /dev/stderr | grep -Fqx /usr/local/b
 RUN tmp_dir="$(mktemp -d)" \
     && export USE_BAZEL_VERSION=9.1.0 \
     && XDG_CACHE_HOME="$tmp_dir" \
+       BAZELISK_HOME="$tmp_dir/bazelisk" \
        # TODO(incident-47542): Remove this once `releases.bazel.build` is back online
        BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download \
        bazel --version | tee /dev/stderr | grep -Fqx "bazel $USE_BAZEL_VERSION" \

--- a/setup/bazelisk.sh
+++ b/setup/bazelisk.sh
@@ -23,4 +23,4 @@ ln -s bazelisk /usr/local/bin/bazel
 
 echo "Verifying Bazelisk $version properly bootstraps Bazel..."
 readlink -f "$(command -v bazel)" | tee /dev/stderr | grep -Fqx /usr/local/bin/bazelisk$version
-BAZELISK_HOME=$tmp_dir USE_BAZEL_VERSION=7.6.1 BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download bazel --version | tee /dev/stderr | grep -Fqx 'bazel 7.6.1'
+XDG_CACHE_HOME=$tmp_dir USE_BAZEL_VERSION=7.6.1 BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download bazel --version | tee /dev/stderr | grep -Fqx 'bazel 7.6.1'

--- a/windows/helpers/phase3/install_bazelisk.ps1
+++ b/windows/helpers/phase3/install_bazelisk.ps1
@@ -29,10 +29,11 @@ try {
 Add-ToPath -NewPath $targetDir -Global -Local
 Write-Host -ForegroundColor Green "Installed bazelisk v$Version"
 
-$bazeliskHome = (New-Item -ItemType Directory -Path (Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName()))).FullName
+$tmpDir = (New-Item -ItemType Directory -Path (Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName()))).FullName
 try {
     $output = & {
-        $env:BAZELISK_HOME = "$bazeliskHome"
+        $env:XDG_CACHE_HOME = "$tmpDir"
+        $env:BAZELISK_HOME = "$env:XDG_CACHE_HOME\bazelisk"
         $env:USE_BAZEL_VERSION = '8.5.1'
         # TODO(incident-47542): Remove this once `releases.bazel.build` is back online
         $env:BAZELISK_BASE_URL = 'https://github.com/bazelbuild/bazel/releases/download'
@@ -42,7 +43,7 @@ try {
         throw "Unexpected bazel version: '$output'"
     }
 } finally {
-    Remove-Item -Recurse -Verbose "$bazeliskHome"
+    Remove-Item -Recurse -Verbose "$tmpDir"
 }
 
 Set-InstalledVersionKey -Component bazelisk -Keyname version -TargetValue $Version


### PR DESCRIPTION
### What does this PR do?
Also delete any directories `bazelisk`'s `bazel` install test may produce, so nothing useless lingers in the image layer:
- on Linux, that just means handing the temporary directory through `XDG_CACHE_HOME`, **which both `bazelisk` and `bazel` honor** (resp. `$XDG_CACHE_HOME/bazelisk` and `$XDG_CACHE_HOME/bazel`),
- on Windows, `bazel` still ignores `XDG_CACHE_HOME`, but we pass it anyway should bazelbuild/bazel#27808 be addressed at some point.

### Motivation
The smoke test only has to prove that `bazelisk` can bootstrap `bazel`, whatever it downloads or unpacks is dead weight afterward.

The scripts already discard `bazelisk`'s own downloads, but `bazel` may keep an auto-extracted install base in the user's home directory, outside the directory they wipe.

Left there, that scratch would keep riding along in the Docker image layer, inflating it for no reason with about ~200MB (self-extracting executable, `A-server.jar`, `embedded_tools/`, etc.).

### Possible Drawbacks / Trade-offs
None: the smoke test still bootstraps `bazel` through `bazelisk` just as before.

### Additional Notes
It's really not worth keeping the auto-extracted `bazel` installation: the version it ships is almost guaranteed to be out-of-sync with any downstream branch's `.bazelversion`.