### PR TITLE
Add internal certificates to the Linux build image

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -11,6 +11,13 @@ FROM ${BASE_IMAGE} AS common_base
 RUN apt-get update -qy && apt-get install -y --no-install-recommends \
     ca-certificates
 
+# Install Datadog default internal certificates so tools trust internal
+# endpoints served with the Datadog internal CA.
+COPY --from=registry.ddbuild.io/images/datadog-ca-certs:standard /certs/ /usr/local/share/ca-certificates/
+# Make the staged certs non-world-writable, then register them in the system trust store.
+RUN chmod -R o-w /usr/local/share/ca-certificates \
+    && update-ca-certificates
+
 # Minimal base for stages doing simple extraction (no compilation)
 FROM common_base AS extraction_base
 # Do an apt update only once at the beginning


### PR DESCRIPTION
### Motivation

Unblock https://github.com/DataDog/datadog-agent/pull/52499 so that we don't encounter [errors](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1788425835) like:

```
github.com/golang-jwt/jwt@v3.2.1+incompatible: verifying module: github.com/golang-jwt/jwt@v3.2.1+incompatible: checking tree#55893670 against tree#55893779: Get "https://depot-read-api-go.rapid-dependency-management-depot.all-clusters.local-dc.fabric.dog:8443/magicmirror/magicmirror/@current/sumdb/sum.golang.org/supported": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

### Additional Notes

This matches what [equivalent](https://github.com/DataDog/images/blob/2f6527d522690f03de6e3640a669c4ada4d65040/base/gbi-ubuntu_2404/release/Dockerfile#L49-L52) internal images do.