### PR TITLE
[#incident-56436] Enable NTFS 8.3 short names at startup

### DIFF
--- a/windows/entrypoint.bat
+++ b/windows/entrypoint.bat
@@ -11,6 +11,12 @@
 @echo.
 @echo Agent Windows Build Docker Container
 
+:: Bazel relies on NTFS 8.3 aliases to shorten long paths (https://github.com/bazelbuild/bazel/issues/19710), but the
+:: setting does not persist from image build (https://github.com/microsoft/Windows-Containers/issues/507) and thus has
+:: to be enabled on the runtime scratch volume.
+:: TODO(agent-build): remove once https://github.com/bazelbuild/bazel/pull/29921 (or equivalent) is in effect
+fsutil 8dot3name set C: 0 >nul
+
 @echo AWS_NETWORKING is %AWS_NETWORKING%
 if defined AWS_NETWORKING (
     @echo Detected AWS container, setting up networking

--- a/windows/helpers/phase3/install_bazelisk.ps1
+++ b/windows/helpers/phase3/install_bazelisk.ps1
@@ -8,9 +8,6 @@ $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 Set-StrictMode -Version 3.0
 
-# Without filesystem 8.3 aliases, Bazel can't shorten long paths: https://github.com/bazelbuild/bazel/issues/19710
-New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name NtfsDisable8dot3NameCreation -PropertyType DWord -Value 0 -Force
-
 $isInstalled, $isCurrent = Get-InstallUpgradeStatus -Component bazelisk -Keyname version -TargetValue $Version
 if ($isInstalled -and $isCurrent) {
     Write-Host -ForegroundColor Yellow "Skipping bazelisk v$Version reinstallation"


### PR DESCRIPTION
### What does this PR do?
Enable NTFS 8.3 short-name creation on the container scratch volume at startup, via `fsutil 8dot3name set C: 0` in the entrypoint.

The registry key from #1212 is dropped because it is now superseded and provably inert for the scratch volume.

### Motivation
#1212 set `NtfsDisable8dot3NameCreation` to 0 in the image, betting the SYSTEM-hive value would travel with the layers.
It **does travel**, but a container's fresh scratch volume surprisingly still comes up disabled at runtime despite `fsutil` output:
```
The volume state is: 1 (8dot3 name creation is DISABLED)
The registry state is: 0 (8dot3 name creation is ENABLED on all volumes)
Based on the above settings, 8dot3 name creation is ENABLED on "C:"
```
`fsutil` **mistakenly** reports ENABLED after the registry override, yet freshly created files **still get no 8.3 alias**, so `GetShortPathNameW` stays a no-op and Bazel still cannot shorten long paths (bazelbuild/bazel#19710), root cause of [#incident-56436](https://dd.enterprise.slack.com/archives/C0BBPAV0J20).

#1212 also anticipated that a build-time `fsutil 8dot3name set` would not persist, which a test image confirmed: the build volume flips to state 0, but a container started from that image is back to state 1.

Per microsoft/Windows-Containers#507 and Microsoft Q&A[^1], the per-volume flag only takes hold across an unmount/remount and is not carried by image layers, so it must be (re)applied at runtime.

=> The entrypoint is the earliest such point, ahead of any build.

### Possible Drawbacks / Trade-offs
`fsutil 8dot3name set` runs on every container start, but it is a cheap per-volume metadata write.

### Additional Notes
Validated by DataDog/datadog-agent#52500 against this image: `bazel:test:windows-amd64` is green with the runtime override removed.

There's work in progress we'll monitor to remove the workaround:
- bazelbuild/bazel#29921.

[^1]:
    - https://learn.microsoft.com/en-us/answers/questions/1406321/enable-8dot3-name-creation-for-volume-c-in-windows
    - https://learn.microsoft.com/en-us/answers/questions/2455648/8-3-filename-support
    - etc.