### PR TITLE
[Backport 7.81.x] Fix codecov GPG key URL after Keybase account migration (#1202)

### DIFF
--- a/setup/codecov.sh
+++ b/setup/codecov.sh
@@ -25,7 +25,7 @@ else
 fi
 
 # Integrity checking the uploader
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
 curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/${CODECOV_ARCH}/codecov
 curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/${CODECOV_ARCH}/codecov.SHA256SUM
 curl -Os https://uploader.codecov.io/v${CODECOV_VERSION}/${CODECOV_ARCH}/codecov.SHA256SUM.sig


### PR DESCRIPTION
Backport https://github.com/DataDog/datadog-agent-buildimages/pull/1202 to 7.81.x