### PR TITLE
Install CI identities client on Agent 6 Windows image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -334,6 +334,7 @@ trigger_tests:
     - $SHORT_CI_COMMIT_SHA = $($CI_COMMIT_SHA.Substring(0,8))
     - $SRC_TAG = "v$CI_PIPELINE_ID-$SHORT_CI_COMMIT_SHA"
     - $SRC_IMAGE = "registry.ddbuild.io/ci/datadog-agent-buildimages/${IMAGE}${ECR_TEST_ONLY}:${SRC_TAG}"
+    - aws s3 cp --only-show-errors s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/$CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION/ci-identities-gitlab-job-client-windows-amd64.exe .
     - .\build-container.ps1 -Arch $DD_TARGET_ARCH -Tag $SRC_IMAGE
     - If ($lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
     - If ($CI_PIPELINE_SOURCE -ne "schedule") { docker push $SRC_IMAGE } else { exit 0 }
@@ -348,6 +349,7 @@ build_windows_ltsc2022_x64:
     DOCKERFILE: windows/Dockerfile
     IMAGE: windows_ltsc2022_x64
     DD_TARGET_ARCH: x64
+    CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION: v0.6.4 # version and digest must be updated in windows/versions.ps1 as well
 
 .release:
   stage: release

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -72,10 +72,12 @@ COPY ./windows/helpers/phase1/*.ps1 c:/scripts/helpers/phase1/
 RUN .\install-all.ps1 -TargetContainer -Phase 1
 COPY ./windows/helpers/phase2/*.ps1 c:/scripts/helpers/phase2/
 RUN .\install-all.ps1 -TargetContainer -Phase 2
+COPY ./ci-identities-gitlab-job-client-windows-amd64.exe c:/mnt/
 COPY ./windows/helpers/phase3/*.ps1 c:/scripts/helpers/phase3/
 RUN .\install-all.ps1 -TargetContainer -Phase 3
 COPY ./windows/helpers/phase4/*.ps1 c:/scripts/helpers/phase4/
 RUN .\install-all.ps1 -TargetContainer -Phase 4
+RUN Remove-Item -Recurse -Force c:/mnt
 
 COPY ./windows/entrypoint.bat /entrypoint.bat
 COPY ./windows/helpers/aws_networking.ps1 /aws_networking.ps1

--- a/windows/helpers/phase3/install_ci_identities_gitlab_job_client.ps1
+++ b/windows/helpers/phase3/install_ci_identities_gitlab_job_client.ps1
@@ -1,0 +1,37 @@
+# Installs ci-identities-gitlab-job-client
+# see https://github.com/DataDog/ci-identities/tree/main/apps/ci-identities-gitlab-job-client
+
+param (
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory = $true)][string]$Sha256
+)
+
+$DESTINATION = "C:\devtools\ci-identities-gitlab-job-client.exe"
+
+# The file was downloaded in the CI job before running the "docker build" command.
+# See .gitlab-ci.yml.
+Copy-Item -Path "C:\mnt\ci-identities-gitlab-job-client-windows-amd64.exe" -Destination $DESTINATION
+
+if ( -not (Test-Path $DESTINATION)) {
+    Write-Host -ForegroundColor Red "$DESTINATION not found"
+    throw "$DESTINATION not found"
+}
+
+$actualHash = (Get-FileHash -Algorithm SHA256 $DESTINATION).Hash
+if ($actualHash.ToUpper() -ne $Sha256.ToUpper()) {
+    Write-Host -ForegroundColor Red "Hash mismatch for $DESTINATION"
+    Write-Host -ForegroundColor Red "Expected: $Sha256"
+    Write-Host -ForegroundColor Red "Actual:   $actualHash"
+    Remove-Item $DESTINATION
+    throw "Hash mismatch for $DESTINATION. Expected: $Sha256, Actual: $actualHash"
+}
+
+# Verify version
+$versionOutput = (& $DESTINATION version 2>&1) | Out-String
+if ($versionOutput -notmatch [regex]::Escape($Version)) {
+    Write-Host -ForegroundColor Red "Version mismatch for $DESTINATION"
+    Write-Host -ForegroundColor Red "Expected version: $Version"
+    Write-Host -ForegroundColor Red "Actual output: $versionOutput"
+    Remove-Item $DESTINATION
+    throw "Version mismatch for $DESTINATION. Expected: $Version, Got: $versionOutput"
+}

--- a/windows/install-all.ps1
+++ b/windows/install-all.ps1
@@ -86,6 +86,7 @@ try {
         .\helpers\phase3\install_java.ps1
         .\helpers\phase3\install_winsign.ps1
         .\helpers\phase3\install_rust.ps1 -Rustup_Version $ENV:RUSTUP_VERSION -Rustup_Sha256 $ENV:RUSTUP_SHA256 -Rust_Version $ENV:RUST_VERSION
+        .\helpers\phase3\install_ci_identities_gitlab_job_client.ps1 -Version $ENV:CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION -Sha256 $ENV:CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256
         ## # Add signtool to path
         Add-ToPath -NewPath "${env:ProgramFiles(x86)}\Windows Kits\8.1\bin\x64\" -Global
         & .\set_cpython_compiler.cmd

--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -55,5 +55,11 @@ $SoftwareTable = @{
     "WINSIGN_SHA256"="b2ba5127a5c5141e04d42444ca115af4c95cc053a743caaa9b33c68dd6b13f68";
     "RUSTUP_VERSION"="1.26.0";
     "RUSTUP_SHA256"="365D072AC4EF47F8774F4D2094108035E2291A0073702DB25FA7797A30861FC9";
-    "RUST_VERSION"="1.74.0"
+    "RUST_VERSION"="1.74.0";
+    # The CI ID client is downloaded by the CI job before docker build.
+    # This version is used to verify that the downloaded binary is correct and
+    # must be updated in sync with .gitlab-ci.yml.
+    # See https://github.com/ddoghq/ci-identities/blob/main/apps/ci-identities-gitlab-job-client/CHANGELOG.md
+    "CI_IDENTITIES_GITLAB_JOB_CLIENT_VERSION"="v0.6.4";
+    "CI_IDENTITIES_GITLAB_JOB_CLIENT_SHA256"="ea05f5486ed0755177c754eaecea94de0d9a3a9ddf225fc2a2e8f4c1a3babfa0";
 }


### PR DESCRIPTION
## What changed

- Download `ci-identities-gitlab-job-client` before the Agent 6 Windows image build.
- Copy the pre-downloaded binary into the legacy Windows Docker build context and install it during phase 3.
- Verify the installed binary hash and version using the current mainline `v0.6.4` version and checksum.

## Why

This backports the CI identities client installation from main to the Agent 6 build image branch while adapting it to the older `6.53.x` Windows Dockerfile layout.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".gitlab-ci.yml", aliases: true); puts "yaml ok"'`

Windows Docker build was not run locally.