### PR TITLE
Grant the dev env user access to the Docker socket

### DIFF
--- a/dev-envs/linux/init/entrypoint.sh
+++ b/dev-envs/linux/init/entrypoint.sh
@@ -43,6 +43,27 @@ if [[ ! -f "${startup_indicator}" ]]; then
             usermod -u "${TARGET_UID}" "${TARGET_USER}"
         fi
     fi
+
+    # Grant the target user access to the host-mounted Docker socket. The socket's
+    # group varies across Linux, macOS, and Windows hosts, so follow the mounted
+    # socket rather than assuming the image's docker group is relevant.
+    if [[ -S /var/run/docker.sock ]]; then
+        docker_sock_gid="$(stat -c "%g" /var/run/docker.sock)"
+        docker_sock_group="$(getent group "${docker_sock_gid}" | cut -d: -f1 || true)"
+
+        if [[ -z "${docker_sock_group}" ]]; then
+            docker_sock_group="docker-host"
+            if getent group "${docker_sock_group}" >/dev/null; then
+                docker_sock_group="docker-host-${docker_sock_gid}"
+            fi
+            groupadd -g "${docker_sock_gid}" "${docker_sock_group}"
+        fi
+
+        if ! id -G "${TARGET_USER}" | tr " " "\n" | grep -Fxq "${docker_sock_gid}"; then
+            usermod -aG "${docker_sock_group}" "${TARGET_USER}"
+        fi
+    fi
+
     TARGET_HOME="$(getent passwd "${TARGET_USER}" | cut -d: -f6)"
 fi
 


### PR DESCRIPTION
### Motivation

After https://github.com/DataDog/datadog-agent-buildimages/pull/1089, the user is no longer `root` and therefore cannot use Docker without `sudo`.

<img width="1801" height="380" alt="image" src="https://github.com/user-attachments/assets/14d435b6-3c18-49d7-8b47-e9ae6df570be" />