### PR TITLE
devcontainer: use dedicated volume for bazel cache

### DIFF
--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -17,7 +17,6 @@ ENV DATADOG_AGENT_EMBEDDED_PATH=/opt/datadog-agent/embedded
 ENV DDA_NO_DYNAMIC_DEPS=${DDA_NO_DYNAMIC_DEPS}
 
 RUN apt-get update && apt-get upgrade -y && \
-    # Common + Agent (Core/Trace/Process) dependencies
     apt-get install -y wget software-properties-common build-essential apt-transport-https libsystemd-dev sudo vim git curl procps ruby ruby-dev autoconf automake libtool libtool-bin gettext autopoint checkpolicy policycoreutils policycoreutils-python-utils bison flex pkg-config docker.io docker-buildx docker-compose-v2 ninja-build zstd \
     # Network feature tests
     openjdk-11-jre-headless \
@@ -30,7 +29,7 @@ RUN apt-get update && apt-get upgrade -y && \
         >/etc/apt/sources.list.d/deadsnakes-ubuntu-ppa-jammy.list && \
     apt-get update && \
     apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv &&\
-    apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists
+    apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Setup python3.12 as default
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 && \
@@ -79,6 +78,8 @@ RUN useradd -g 20 -u 503 -m datadog -s /bin/bash -G sudo,root && \
     pip3 install --no-cache-dir pyasn1==0.6.0 && \
     # Correct some permissions
     mkdir -p $DATADOG_AGENT_EMBEDDED_PATH && chown -R 503:20 $DATADOG_AGENT_EMBEDDED_PATH && \
+    # create bazel cache folder to mount docker volume later and fix permissions on the whole cache folder
+    mkdir -p /home/datadog/.cache/bazel/_bazel_datadog && chown -R 503:20 /home/datadog/.cache && \
     # Omnibus setup
     gem install bundler && \
     mkdir -p /var/cache/omnibus && chmod 775 /var/cache/omnibus && \

--- a/devcontainer/docker-compose.amd64.yaml
+++ b/devcontainer/docker-compose.amd64.yaml
@@ -13,7 +13,9 @@ services:
       - omnibus-cache-amd64:/var/cache/omnibus
       - go-cache-amd64:/home/datadog/go
       - home-directory:/home/datadog
+      - bazel-cache-amd64:/home/datadog/.cache/bazel/_bazel_datadog
 volumes:
   omnibus-cache-amd64: {}
   go-cache-amd64: {}
   home-directory: {}
+  bazel-cache-amd64: {}

--- a/devcontainer/docker-compose.yaml
+++ b/devcontainer/docker-compose.yaml
@@ -13,7 +13,9 @@ services:
       - omnibus-cache:/var/cache/omnibus
       - go-cache:/home/datadog/go
       - home-directory:/home/datadog
+      - bazel-cache:/home/datadog/.cache/bazel/_bazel_datadog
 volumes:
   omnibus-cache: {}
   go-cache: {}
   home-directory: {}
+  bazel-cache: {}


### PR DESCRIPTION
### What does this PR do?

When using both arm64 and amd64 images, sharing the same volume for the folder `~/.cache/bazel` building with the first platform target prevent the second from building. it's reauired the clean the whole cache before switching.

Create a dedicated volume for each cache so each build benefits from it and they don't overwrite each others.

### Motivation

allow the build of arm64 and amd64 images one after another without wiping the whole cache.

### Possible Drawbacks / Trade-offs

increase laptop storage. 

### Additional Notes

when using it, you'll need to remove the 2 instances you have to create the new ones with the new cache, that takes time to rebuild the first time.
