### PR TITLE
Fix `pass` config for Nushell

### DIFF
--- a/dev-envs/linux/init/startup.sh
+++ b/dev-envs/linux/init/startup.sh
@@ -94,8 +94,8 @@ mkdir -m 700 -p ${PASS_GPG_HOME}
 
 gpg --homedir ${PASS_GPG_HOME} --batch --passphrase '' --quick-generate-key --yes password-store
 pass init "password-store"
-set-ev PASSWORD_STORE_GPG_OPTS "--homedir \"${PASS_GPG_HOME}\""
-set-ev PASSWORD_STORE_DIR "\"${PASSWORD_STORE_DIR}\""
+set-ev PASSWORD_STORE_GPG_OPTS "--homedir ${PASS_GPG_HOME}"
+set-ev PASSWORD_STORE_DIR "${PASSWORD_STORE_DIR}"
 
 # Reset saved data/cache directories from previous runs
 dda config restore


### PR DESCRIPTION
### Motivation

`set-ev` persists these variables into both bash/zsh and nushell syntax. The escaped double quotes around `PASSWORD_STORE_DIR`/`PASSWORD_STORE_GPG_OPTS` are stripped by Bash/Zsh but kept literally by Nushell, embedding quote characters in the path. Since `pass` got a bogus path in Nushell, tools like `ddtool` failed to write to the secure store.

```
    Error: You must run:
        pass init your-gpg-id
    before you may use the password store.
```