### PR TITLE
Temporarily revert Python 3.14 to 3.12 in Go update workflow

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Python and pip
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14"
+          python-version: "3.12"
 
       - name: Get access token via dd-octo-sts
         uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4

--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Python and pip
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.12"  # temporary: 3.14 breaks httpcore 1.0.7, revert when dda bumps httpcore to >=1.0.8
 
       - name: Get access token via dd-octo-sts
         uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4


### PR DESCRIPTION
## What does this PR do?

Temporarily reverts the Python version in the Go update workflow from 3.14 back to 3.12.

## Motivation

PR #1238 bumped Python to 3.14, which broke the workflow. `httpcore` 1.0.7 (pinned in `dda`'s `uv.lock`) is incompatible with Python 3.14 it fails on import with:

```
AttributeError: 'typing.Union' object has no attribute '__module__' and no
__dict__ for setting new attributes
```
This is a known issue that was fixed with `httpcore` [1.0.8](https://github.com/encode/httpcore/releases/tag/1.0.8).
Failing run: https://github.com/DataDog/datadog-agent-buildimages/actions/runs/28949011257/job/85891789495

This is a temporary unblock. The proper fix is to bump `httpcore` to `>=1.0.8` in `datadog-agent-dev`'s `uv.lock` and release a new `dda` version, at which point this can be reverted back to 3.14.

## Describe how you validated your changes

Python 3.12 was the version used before #1238 and the workflow was working correctly.
The 7.81.x branch also runs this workflow on Python 3.12 and succeeds.

## Additional Notes
