### PR TITLE
[Backport 7.81.x] Update dd-pkg image to v0.9.0

### DIFF
--- a/agent-deploy/Dockerfile
+++ b/agent-deploy/Dockerfile
@@ -14,7 +14,7 @@ ARG BASE_IMAGE_REGISTRY=registry.ddbuild.io/images/mirror
 ARG DATADOG_PACKAGES_VERSION=42796a26609b975947ddaafe1672dd04f47418ea
 FROM registry.ddbuild.io/ci/datadog-packages/artifact:${DATADOG_PACKAGES_VERSION} AS datadog_packages
 
-FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.4 AS dd_pkg
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
 
 FROM ${BASE_IMAGE_REGISTRY}/ubuntu:18.04
 

--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILDENV_REGISTRY
 
-FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.4 AS dd_pkg
+FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
 
 FROM ${BUILDENV_REGISTRY}/images/docker:27.3.1
 

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILDENV_REGISTRY
 FROM registry.ddbuild.io/dd-octo-sts:${DD_OCTO_STS_VERSION} AS dd_octo_sts_builder
 # Dummy stage to download dd-octo-sts as it is distributed as a container image
 
-FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.4 AS dd_pkg
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
 
 FROM ${BUILDENV_REGISTRY}/images/docker:27.3.1
 

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -288,7 +288,7 @@ FROM registry.ddbuild.io/dd-octo-sts:$DD_OCTO_STS_VERSION AS dd_octo_sts_builder
 FROM registry.ddbuild.io/ci/datadog-packages/artifact:${DATADOG_PACKAGES_VERSION} AS datadog_packages_builder
 # Dummy stage to download datadog-packages as it is distributed as a container image
 
-FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.4 AS dd_pkg_builder
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg_builder
 # Dummy stage to copy dd-pkg from the release image so CI jobs do not download it at runtime.
 
 FROM common_base AS final

--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y wget
 RUN wget https://curl.se/ca/cacert-${CACERT_BUNDLE_VERSION}.pem -O /cacert.pem
 RUN echo "${CACERT_BUNDLE_SHA256}  /cacert.pem" | sha256sum --check
 
-FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.4 AS dd_pkg
+FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
 
 FROM --platform=linux/armhf ${BASE_IMAGE}
 


### PR DESCRIPTION
## What

Backports the dd-pkg image bump from main to the `7.81.x` buildimages branch.

## Why

`datadog-agent` 7.81.x currently has a buildimage update PR (#53440) that points at a 7.81.x buildimage tag still containing `dd-pkg` v0.7.4. The Agent public-images artifact-gateway path needs dd-pkg v0.9.0.

This PR keeps the 7.81.x branch-specific buildimage fixes and updates only the `registry.ddbuild.io/agent-delivery/dd-pkg` stage to v0.9.0.

## Validation

- Cherry-picked from main commit 627631bfbeca6c1dfb32b238f3a484884395bf68
- Resolved conflicts by changing only dd-pkg image tags
- Signed commit created locally