### PR TITLE
[Backport 7.80.x] Update dd-pkg image to v0.9.0

### DIFF
--- a/agent-deploy/Dockerfile
+++ b/agent-deploy/Dockerfile
@@ -14,7 +14,7 @@ ARG BASE_IMAGE_REGISTRY=registry.ddbuild.io/images/mirror
 ARG DATADOG_PACKAGES_VERSION=42796a26609b975947ddaafe1672dd04f47418ea
 FROM registry.ddbuild.io/ci/datadog-packages/artifact:${DATADOG_PACKAGES_VERSION} AS datadog_packages
 
-FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.3 AS dd_pkg
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
 
 FROM ${BASE_IMAGE_REGISTRY}/ubuntu:18.04
 

--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILDENV_REGISTRY
 
-FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.3 AS dd_pkg
+FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
 
 FROM ${BUILDENV_REGISTRY}/images/docker:27.3.1
 

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILDENV_REGISTRY
 FROM registry.ddbuild.io/dd-octo-sts:${DD_OCTO_STS_VERSION} AS dd_octo_sts_builder
 # Dummy stage to download dd-octo-sts as it is distributed as a container image
 
-FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.3 AS dd_pkg
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
 
 FROM ${BUILDENV_REGISTRY}/images/docker:27.3.1
 

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -284,7 +284,7 @@ FROM registry.ddbuild.io/dd-octo-sts:$DD_OCTO_STS_VERSION AS dd_octo_sts_builder
 FROM registry.ddbuild.io/ci/datadog-packages/artifact:${DATADOG_PACKAGES_VERSION} AS datadog_packages_builder
 # Dummy stage to download datadog-packages as it is distributed as a container image
 
-FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.3 AS dd_pkg_builder
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg_builder
 # Dummy stage to copy dd-pkg from the release image so CI jobs do not download it at runtime.
 
 FROM common_base AS final

--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y wget
 RUN wget https://curl.se/ca/cacert-${CACERT_BUNDLE_VERSION}.pem -O /cacert.pem
 RUN echo "${CACERT_BUNDLE_SHA256}  /cacert.pem" | sha256sum --check
 
-FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.7.3 AS dd_pkg
+FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
 
 FROM --platform=linux/armhf ${BASE_IMAGE}
 


### PR DESCRIPTION
## Problem

Agent release branches using the 7.80.x buildimages branch need the dd-pkg image that includes the public-images artifact-gateway fixes.

## Change

- Update the existing dd-pkg build stage from `v0.7.3` to `v0.9.0` in the 7.80.x build images that already install dd-pkg.

## Validation

- `git diff --check`
- Verified all `agent-delivery/dd-pkg` references in the touched Dockerfiles point to `v0.9.0`.