### PR TITLE
[Backport 7.78.x] Install dd-pkg v0.9.0 in build images

### DIFF
--- a/agent-deploy/Dockerfile
+++ b/agent-deploy/Dockerfile
@@ -14,6 +14,8 @@ ARG BASE_IMAGE_REGISTRY=registry.ddbuild.io/images/mirror
 ARG DATADOG_PACKAGES_VERSION=cda6d1e48653a8ee83dcc4a85697a40f5e6a9a34
 FROM registry.ddbuild.io/ci/datadog-packages/artifact:${DATADOG_PACKAGES_VERSION} AS datadog_packages
 
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
+
 FROM ${BASE_IMAGE_REGISTRY}/ubuntu:18.04
 
 ARG RUBY_VERSION_ARG=2.7.8
@@ -212,6 +214,9 @@ RUN /bin/bash -l -c "cd /deploy_scripts/cloudfront-invalidation && \
 
 # Install datadog-package
 COPY --from=datadog_packages /datadog-package /go/bin/datadog-package
+
+# Install dd-pkg
+COPY --from=dd_pkg /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg
 
 # Entrypoint
 COPY ./agent-deploy/entrypoint.sh /entrypoint.sh

--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -1,4 +1,7 @@
 ARG BUILDENV_REGISTRY
+
+FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
+
 FROM ${BUILDENV_REGISTRY}/images/docker:27.3.1
 
 ARG PYTHON_VERSION=3.12.6
@@ -86,3 +89,5 @@ RUN --mount=type=bind,src=./setup/authanywhere.sh,dst=/mnt/authanywhere.sh /mnt/
 RUN curl -fsSL https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/datadog-ci_linux-arm64 --output "/usr/local/bin/datadog-ci" && \
   echo "${DATADOG_CI_SHA} /usr/local/bin/datadog-ci" | sha256sum --check && \
   chmod +x /usr/local/bin/datadog-ci
+
+COPY --from=dd_pkg /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -1,4 +1,7 @@
 ARG BUILDENV_REGISTRY
+
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
+
 FROM ${BUILDENV_REGISTRY}/images/docker:27.3.1
 
 ARG PYTHON_VERSION=3.12.6
@@ -108,3 +111,5 @@ RUN curl -sL -o /tmp/master.tar.gz https://github.com/mackyle/xar/archive/master
 # Install authanywhere for infra token management
 ADD --checksum=sha256:05d14b25e4607cc9e14867f2a0f38774869ae609eec890168e57de9a1b428e37 "https://binaries.ddbuild.io/dd-source/authanywhere/v0.0.2/authanywhere-tar.tar.gz" /tmp/authanywhere/authanywhere-tar.tar.gz
 RUN --mount=type=bind,src=./setup/authanywhere.sh,dst=/mnt/authanywhere.sh /mnt/authanywhere.sh
+
+COPY --from=dd_pkg /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -266,6 +266,9 @@ FROM registry.ddbuild.io/dd-octo-sts:$DD_OCTO_STS_VERSION AS dd_octo_sts_builder
 FROM registry.ddbuild.io/ci/datadog-packages/artifact:${DATADOG_PACKAGES_VERSION} AS datadog_packages_builder
 # Dummy stage to download datadog-packages as it is distributed as a container image
 
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg_builder
+# Dummy stage to copy dd-pkg from the release image so CI jobs do not download it at runtime.
+
 FROM common_base AS final
 
 ARG ADDITIONAL_PACKAGE
@@ -402,6 +405,9 @@ ENV GOPATH=/go
 ENV MS_GOTOOLCHAIN_TELEMETRY_ENABLED=0
 ENV PYTHONUTF8=1
 ENV DDA_NO_DYNAMIC_DEPS=1
+
+# dd-pkg
+COPY --from=dd_pkg_builder /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg
 
 # Merge conda initialization with main bashrc
 RUN cat /root/.bashrc.conda >> /root/.bashrc && rm /root/.bashrc.conda

--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y wget
 RUN wget https://curl.se/ca/cacert-${CACERT_BUNDLE_VERSION}.pem -O /cacert.pem
 RUN echo "${CACERT_BUNDLE_SHA256}  /cacert.pem" | sha256sum --check
 
+FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
+
 FROM --platform=linux/armhf ${BASE_IMAGE}
 
 # Build Args
@@ -178,6 +180,9 @@ RUN curl -LO https://releases.hashicorp.com/vault/${VAULT_VERSION}/${VAULT_FILEN
 
 # Force umask to 0022
 RUN echo "umask 0022" >> /root/.bashrc
+
+# Install dd-pkg
+COPY --from=dd_pkg /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg
 
 # Entrypoint - only for local usage, Kubernetes-based Gitlab runners overwrite this
 COPY entrypoint.sh /


### PR DESCRIPTION
## Problem

Agent release branches using the 7.78.x buildimages branch need dd-pkg available in CI images for public image publication through artifact-gateway.

## Change

- Add the dd-pkg release image stage pinned to `v0.9.0`.
- Copy `/usr/local/bin/dd-pkg` into the existing agent-deploy, docker, linux, and rpm-armhf build images.

## Validation

- `git diff --check`
- Verified all `agent-delivery/dd-pkg` references in the touched Dockerfiles point to `v0.9.0`.