### PR TITLE
[Backport 7.73.x] Install dd-pkg v0.9.0 in build images

### DIFF
--- a/agent-deploy/Dockerfile
+++ b/agent-deploy/Dockerfile
@@ -7,6 +7,8 @@
 # When updating the gitlab-agent-deploy image, don't forget to update these three repos
 # and test that promotion jobs work as expected with the new image.
 
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
+
 FROM registry.ddbuild.io/images/mirror/ubuntu:18.04
 
 ARG RUBY_VERSION_ARG=2.7.8
@@ -195,6 +197,9 @@ RUN chmod +x /deploy_scripts/check_apt_pool.sh
 RUN chmod +x /deploy_scripts/fail_deb_is_pkg_already_exists.sh
 RUN /bin/bash -l -c "cd /deploy_scripts/cloudfront-invalidation && \
     bundle install"
+
+# Install dd-pkg
+COPY --from=dd_pkg /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg
 
 # Entrypoint
 COPY ./agent-deploy/entrypoint.sh /entrypoint.sh

--- a/docker-arm64/Dockerfile
+++ b/docker-arm64/Dockerfile
@@ -1,4 +1,7 @@
 ARG BUILDENV_REGISTRY
+
+FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
+
 FROM ${BUILDENV_REGISTRY}/images/docker:27.3.1
 
 ARG PYTHON_VERSION=3.12.6
@@ -84,3 +87,5 @@ RUN --mount=type=bind,dst=/mnt /mnt/setup/authanywhere.sh
 RUN curl -fsSL https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/datadog-ci_linux-arm64 --output "/usr/local/bin/datadog-ci" && \
   echo "${DATADOG_CI_SHA} /usr/local/bin/datadog-ci" | sha256sum --check && \
   chmod +x /usr/local/bin/datadog-ci
+
+COPY --from=dd_pkg /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg

--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -1,4 +1,7 @@
 ARG BUILDENV_REGISTRY
+
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
+
 FROM ${BUILDENV_REGISTRY}/images/docker:27.3.1
 
 ARG PYTHON_VERSION=3.12.6
@@ -101,3 +104,5 @@ RUN curl -sL -o /tmp/master.tar.gz https://github.com/mackyle/xar/archive/master
 
 # Install authanywhere for infra token management
 RUN --mount=type=bind,dst=/mnt /mnt/setup/authanywhere.sh
+
+COPY --from=dd_pkg /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -1,3 +1,5 @@
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg_builder
+
 FROM ubuntu:24.04
 
 # Common build arguments
@@ -205,6 +207,9 @@ RUN curl -fsSL https://github.com/DataDog/datadog-ci/releases/download/v${DATADO
 # Install authanywhere for infra token management
 RUN --mount=type=bind,dst=/mnt /mnt/setup/authanywhere.sh
 
+
+# Install dd-pkg
+COPY --from=dd_pkg_builder /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg
 
 # Common environment setup
 RUN echo "umask 0022" >> /root/.bashrc && \

--- a/rpm-armhf/Dockerfile
+++ b/rpm-armhf/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && apt-get install -y wget
 RUN wget https://curl.se/ca/cacert-${CACERT_BUNDLE_VERSION}.pem -O /cacert.pem
 RUN echo "${CACERT_BUNDLE_SHA256}  /cacert.pem" | sha256sum --check
 
+FROM --platform=linux/arm64 registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
+
 FROM ${BASE_IMAGE}
 
 # Build Args
@@ -175,6 +177,9 @@ RUN curl -LO https://releases.hashicorp.com/vault/${VAULT_VERSION}/${VAULT_FILEN
 
 # Force umask to 0022
 RUN echo "umask 0022" >> /root/.bashrc
+
+# Install dd-pkg
+COPY --from=dd_pkg /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg
 
 # Entrypoint - only for local usage, Kubernetes-based Gitlab runners overwrite this
 COPY entrypoint.sh /


### PR DESCRIPTION
## Problem

Agent release branches using the 7.73.x buildimages branch need dd-pkg available in CI images for public image publication through artifact-gateway.

## Change

- Add the dd-pkg release image stage pinned to `v0.9.0`.
- Copy `/usr/local/bin/dd-pkg` into the existing agent-deploy, docker, linux, and rpm-armhf build images.

## Validation

- `git diff --check`
- Verified all `agent-delivery/dd-pkg` references in the touched Dockerfiles point to `v0.9.0`.