### PR TITLE
Place environment variable in a folder not sourced by default

### DIFF
--- a/dev-envs/linux/variants/workspaces/setup.sh
+++ b/dev-envs/linux/variants/workspaces/setup.sh
@@ -9,7 +9,7 @@ groupadd --gid 501 dog
 useradd --gid dog --uid 501 --home-dir "${dog_home}" --shell /bin/bash --groups users,build-shared,sudo dog
 
 workspace_env_file="${DD_BUILD_CONFIG_ROOT}/dd-agent-workspace-env.sh"
-install -d -m 0755 "$(dirname "${workspace_env_file}")"
+install -d -m 0775 "$(dirname "${workspace_env_file}")"
 while IFS= read -r line; do
     printf 'export %s=%q\n' "${line%%=*}" "${line#*=}"
 done < <(env | grep -Ev "^(CODEX_HOME=|CLAUDE_CONFIG_DIR=|HOME=|USER=|MAIL=|LS_COLORS=|HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|_=)") > "${workspace_env_file}"

--- a/dev-envs/linux/variants/workspaces/setup.sh
+++ b/dev-envs/linux/variants/workspaces/setup.sh
@@ -12,7 +12,7 @@ workspace_env_file="${DD_BUILD_CONFIG_ROOT}/dd-agent-workspace-env.sh"
 install -d -m 0755 "$(dirname "${workspace_env_file}")"
 while IFS= read -r line; do
     printf 'export %s=%q\n' "${line%%=*}" "${line#*=}"
-done < <(env | grep -Ev "^(CLAUDE_CONFIG_DIR=|HOME=|USER=|MAIL=|LS_COLORS=|HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|_=)") > "${workspace_env_file}"
+done < <(env | grep -Ev "^(CODEX_HOME=|CLAUDE_CONFIG_DIR=|HOME=|USER=|MAIL=|LS_COLORS=|HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|_=)") > "${workspace_env_file}"
 
 seed_home() {
     local home="$1"

--- a/dev-envs/linux/variants/workspaces/setup.sh
+++ b/dev-envs/linux/variants/workspaces/setup.sh
@@ -7,10 +7,12 @@ bits_home="/home/bits"
 
 groupadd --gid 501 dog
 useradd --gid dog --uid 501 --home-dir "${dog_home}" --shell /bin/bash --groups users,build-shared,sudo dog
-    
+
+workspace_env_file="${DD_BUILD_CONFIG_ROOT}/dd-agent-workspace-env.sh"
+install -d -m 0755 "$(dirname "${workspace_env_file}")"
 while IFS= read -r line; do
     printf 'export %s=%q\n' "${line%%=*}" "${line#*=}"
-done < <(env | grep -Ev "^(HOME=|USER=|MAIL=|LS_COLORS=|HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|_=)") > /etc/profile.d/dd-agent-workspace-env.sh
+done < <(env | grep -Ev "^(CLAUDE_CONFIG_DIR=|HOME=|USER=|MAIL=|LS_COLORS=|HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|_=)") > "${workspace_env_file}"
 
 seed_home() {
     local home="$1"


### PR DESCRIPTION
### What does this PR do?

We want the image environment variables to be exposed in the workspace. But we do not want it to be exposed before the end of the provisioning, otherwise it can breaks some installation.
Also remove CLAUDE_CONFIG_DIR and CODEX_HOME environment variable, so that we can let the workspaces devcontainer features manage it properly.

### Motivation

### Possible Drawbacks / Trade-offs

### Additional Notes
