### PR TITLE
Sign Linux images with dd-sign, add AWS CLI v2 + lint tooling to deb-x64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,6 +104,9 @@ get_agent_version:
   stage: build
   rules:
     - if: $CI_COMMIT_TAG == null
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
   before_script:
     - curl "https://awscli.amazonaws.com/awscli-exe-linux-$ARCH.zip" -o "awscliv2.zip"
     - unzip awscliv2.zip
@@ -129,6 +132,10 @@ get_agent_version:
     # Build and push directly via buildx (no local daemon required)
     - GO_BUILD_ARGS=$(cat go.env | sed -e 's/^/--build-arg /' | tr '\n' ' ')
     - docker buildx build --push --platform $PLATFORM --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg DD_TARGET_ARCH=$DD_TARGET_ARCH $GO_BUILD_ARGS $CUSTOM_BUILD_ARGS --tag registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA} --file $DOCKERFILE .
+    # Sign the pushed image so containerd-image-verifier accepts pulls of it (see main's .gitlab/build.yml)
+    - MANIFEST=$(crane manifest registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA})
+    - DIGEST=sha256:$(echo -n "$MANIFEST" | sha256sum | awk '{print $1}')
+    - ddsign sign registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}@${DIGEST}
     # Also tag as pipeline-ID-only for testing purposes
     - if [ "$CI_PIPELINE_SOURCE" != "schedule" ]; then docker buildx imagetools create --tag registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}; fi
   after_script:
@@ -140,6 +147,9 @@ get_agent_version:
   stage: build
   rules:
     - if: $CI_COMMIT_TAG == null
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
   before_script:
     - curl "https://awscli.amazonaws.com/awscli-exe-linux-$ARCH.zip" -o "awscliv2.zip"
     - unzip awscliv2.zip
@@ -160,6 +170,10 @@ get_agent_version:
     # Build
     - GO_BUILD_ARGS=$(cat go.env | sed -e 's/^/--build-arg /' | tr '\n' ' ')
     - docker buildx build --push --platform $PLATFORM --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg DD_TARGET_ARCH=$DD_TARGET_ARCH $GO_BUILD_ARGS $CUSTOM_BUILD_ARGS --tag registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA} --label target=none --file $DOCKERFILE .
+    # Sign the pushed image so containerd-image-verifier accepts pulls of it (see main's .gitlab/build.yml)
+    - MANIFEST=$(crane manifest registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA})
+    - DIGEST=sha256:$(echo -n "$MANIFEST" | sha256sum | awk '{print $1}')
+    - ddsign sign registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}@${DIGEST}
     - if [ "$CI_PIPELINE_SOURCE" != "schedule" ]; then docker buildx imagetools create --tag registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID registry.ddbuild.io/ci/datadog-agent-buildimages/$IMAGE${ECR_TEST_ONLY}:v$CI_PIPELINE_ID-${CI_COMMIT_SHORT_SHA}; fi
   after_script:
     - if [ "${CI_JOB_STATUS}" != 'success' ]; then echo "failed build, not sending metrics"; exit 0; fi

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -192,6 +192,18 @@ RUN ./setup_python.sh
 ENV PATH "${CONDA_PATH}/condabin:${PATH}"
 ENV PKG_CONFIG_LIBDIR "${PKG_CONFIG_LIBDIR}:${CONDA_PATH}/lib/pkgconfig"
 
+# Install Python lint tooling (flake8, black, isort, vulture) needed by datadog-agent's
+# lint_python CI job, which used to run on the now-unsigned, no-longer-built
+# circleci-runner image. Installed into the ddpy3 conda env (which already has pip) and
+# symlinked into /usr/local/bin, the same way setup_python.sh symlinks `inv` above: a
+# plain `python3 -m pip install` here would hit the system Python 3.4 (no pip module at
+# all), since this RUN's non-interactive shell doesn't source .bashrc and so never
+# activates ddpy3 the way setup_python.sh's own shell does.
+RUN "${CONDA_PATH}/envs/ddpy3/bin/pip" install -r requirements/circleci.txt \
+    && for tool in black flake8 isort vulture; do \
+         ln -s "${CONDA_PATH}/envs/ddpy3/bin/${tool}" /usr/local/bin; \
+       done
+
 # RVM
 COPY ./rvm/gpg-keys /gpg-keys
 RUN gpg --import /gpg-keys/*

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -272,11 +272,17 @@ RUN curl --retry 10 -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI
 # Install AWS CLI v2: https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst
 # Needed by e2e test jobs (`aws ecr get-login-password`, `aws s3 cp`, ...), which
 # previously installed it ad-hoc in .gitlab-ci.yml's before_script on every job run.
+# requirements.txt (installed into the ddpy3 conda env by setup_python.sh, above)
+# pulls in awscli v1, and /root/.bashrc activates ddpy3 by default, which prepends
+# its bin/ to PATH ahead of /usr/local/bin. That only matters for contexts that
+# source .bashrc (e.g. this image's own ENTRYPOINT) -- GitLab CI job shells don't --
+# but re-point ddpy3's aws at the v2 binary too so it's not shadowed there either.
 RUN curl -LO https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip \
     && echo "${AWSCLI_SHA256}  awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" | sha256sum --check \
     && unzip -q awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip \
     && ./aws/install \
-    && rm -rf awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip aws
+    && rm -rf awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip aws \
+    && ln -sf /usr/local/bin/aws "${CONDA_PATH}/envs/ddpy3/bin/aws"
 
 # Install dd-octo-sts
 COPY --from=registry.ddbuild.io/dd-octo-sts:v1.9.3 /usr/local/bin/dd-octo-sts /usr/local/bin/dd-octo-sts

--- a/deb-x64/Dockerfile
+++ b/deb-x64/Dockerfile
@@ -41,6 +41,8 @@ ARG OPENSSH_VERSION=9.9p2
 ARG OPENSSH_SHA256=91aadb603e08cc285eddf965e1199d02585fa94d994d6cae5b41e1721e215673
 ARG OPENSSL_VERSION=1.1.1w
 ARG OPENSSL_SHA256=cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8
+ARG AWSCLI_VERSION=2.24.0
+ARG AWSCLI_SHA256=4e3c39d9881cb6f893ea93219d971390864b1f7e3756197413a7de38ce059609
 
 # Environment
 ENV GOPATH /go
@@ -266,6 +268,15 @@ RUN curl -LO https://releases.hashicorp.com/vault/$VAULT_VERSION/$VAULT_FILENAME
 # Install Pulumi
 RUN curl --retry 10 -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI_VERSION && \
     mv ~/.pulumi/bin/* /usr/local/bin
+
+# Install AWS CLI v2: https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst
+# Needed by e2e test jobs (`aws ecr get-login-password`, `aws s3 cp`, ...), which
+# previously installed it ad-hoc in .gitlab-ci.yml's before_script on every job run.
+RUN curl -LO https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip \
+    && echo "${AWSCLI_SHA256}  awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" | sha256sum --check \
+    && unzip -q awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip \
+    && ./aws/install \
+    && rm -rf awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip aws
 
 # Install dd-octo-sts
 COPY --from=registry.ddbuild.io/dd-octo-sts:v1.9.3 /usr/local/bin/dd-octo-sts /usr/local/bin/dd-octo-sts


### PR DESCRIPTION
## Summary
- Sign Linux build images with `dd-sign` (backports the `crane manifest` + `ddsign sign` step from main's `.gitlab/build.yml` to the `.build`/`.build_ddregistry` templates). Without this, images pushed from `6.53.x` are unsigned and `containerd-image-verifier` on GitLab runner infra rejects pulling them with `signature manifest not found` — this is causing systemic image-pull failures downstream (confirmed on `datadog-agent` pipeline 123790125: `deploy_rpm_testing-a6_x64`, `periodic_kitchen_cleanup_ec2` failing to pull `gitlab_agent_deploy`).
- Install AWS CLI v2 in `deb-x64`, needed by e2e/KMT test jobs that call `aws` directly.
- Install the Python lint tooling (`black`, `flake8` + plugins, `isort`, `vulture`) that datadog-agent's `lint_python` job needs, into deb-x64's `ddpy3` conda env (symlinked into `/usr/local/bin`). This is prep to move `lint_python` off `gcr.io/datadoghq/agent-circleci-runner`, whose build/release jobs were removed from `6.53.x` a while back — it can never be re-signed and is permanently rejected now.

## Test plan
- [ ] CI green on this branch (deb-x64 build + signing, docker-x64/arm64, etc.)
- [ ] Confirm signed images can be pulled without `signature manifest not found`
- [ ] Follow-up PR in `datadog-agent` to point `lint_python` at `deb_x64` instead of the dead `circleci-runner` image