### PR TITLE
[Backport 7.82.x] Revert "[SINT-5203] Upgrade JSign (#1201)" and "[SINT-5203] Upgrade Windows Code Signer (#1219)" (#1265)

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -8,7 +8,7 @@ ARG BASE_IMAGE_TAG=4.8-windowsservercore-ltsc2022
 ARG BASE_IMAGE=${BASE_IMAGE_REGISTRY}/dotnet/framework/runtime:${BASE_IMAGE_TAG}
 
 # required for the COPY --from instruction later
-FROM registry.ddbuild.io/windows-code-signer/go:v0.8.0@sha256:bb1715e19445abff13e9487ba68c33d1879ca258991d85a84c6ff7b63f26549a AS windows-code-signer
+FROM registry.ddbuild.io/windows-code-signer/go:v0.7.0@sha256:64aa5ad1fccf9b7ab05c110f756e3e055be6e9e3941275b7797c8e14489a2180 AS windows-code-signer
 
 FROM ${BASE_IMAGE}
 

--- a/windows/helpers/phase3/install_java.ps1
+++ b/windows/helpers/phase3/install_java.ps1
@@ -47,13 +47,4 @@ if (-Not (test-path $jsignjardir)) {
 }
 (New-Object System.Net.WebClient).DownloadFile($jsignjarsrc, $jsignout)
 
-$actualHash = (Get-FileHash -Algorithm SHA256 $jsignout).Hash
-if ($actualHash.ToUpper() -ne $ENV:JSIGN_SHA256.ToUpper()) {
-    Write-Host -ForegroundColor Red "Hash mismatch for $jsignout"
-    Write-Host -ForegroundColor Red "Expected: $ENV:JSIGN_SHA256"
-    Write-Host -ForegroundColor Red "Actual:   $actualHash"
-    Remove-Item $jsignout
-    throw "Hash mismatch for $jsignout. Expected: $ENV:JSIGN_SHA256, Actual: $actualHash"
-}
-
 Add-EnvironmentVariable -Variable JARSIGN_JAR -Value $jsignout -Global

--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -54,8 +54,7 @@ $SoftwareTable = @{
     "CACERTS_HASH"="8ac40bdd3d3e151a6b4078d2b2029796e8f843e3f86fbf2adbc4dd9f05e79def";
     "JAVA_VERSION"="17.0.8";
     "JAVA_SHA256"="db6e7e7506296b8a2338f6047fdc94bf4bbc147b7a3574d9a035c3271ae1a92b";
-    "JSIGN_VERSION"="7.4";
-    "JSIGN_SHA256"="2abf2ade9ea322acc2d60c24794eadc465ff9380938fca4c932d09e0b25f1c28";
+    "JSIGN_VERSION"="5.0";
     "WINSIGN_VERSION"="0.3.5";
     "WINSIGN_SHA256"="b2ba5127a5c5141e04d42444ca115af4c95cc053a743caaa9b33c68dd6b13f68";
     "RUSTUP_VERSION"="1.26.0";
@@ -80,6 +79,6 @@ $SoftwareTable = @{
     # with a "COPY --from" instruction in the Dockerfile
     # recall to update the digest of the image in the Dockerfile
     # when updating the version
-    "WINDOWS_CODE_SIGNER_VERSION"="v0.8.0";
-    "WINDOWS_CODE_SIGNER_SHA256"="941dbad45eddcb9428ec1940200e40fa41eb48f1870869d444a8e437cf7e3f68";
+    "WINDOWS_CODE_SIGNER_VERSION"="v0.7.0";
+    "WINDOWS_CODE_SIGNER_SHA256"="89eb7490e7bec62fea47fdbe4b202f65c8a068b84ce2d2c629a33ce924774cf7";
 }


### PR DESCRIPTION
Backport of #1265

### What does this PR do?
This reverts commit 5f64674 and 6a88995.

### Motivation
See if it fixes the CI issues we have with Windows.

Able to bump Go version to 1.26.5 in `datadog-agent` on `7.82.x` branch

### Possible Drawbacks / Trade-offs

### Additional Notes
