### PR TITLE
[Backport 6.53.x] Install dd-pkg 0.9.0 in docker build image

### DIFF
--- a/docker-x64/Dockerfile
+++ b/docker-x64/Dockerfile
@@ -1,3 +1,5 @@
+FROM registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0 AS dd_pkg
+
 FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10-py3
 
 ARG VAULT_VERSION=1.17.2
@@ -20,3 +22,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends unzip \
 # External calls configuration
 COPY .awsconfig /root/.aws/config
 COPY .curlrc .wgetrc /root/
+
+COPY --from=dd_pkg /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg


### PR DESCRIPTION
## Problem

The Agent 6.53.x public-image publication path now uses `dd-pkg publish-image`, but the branch-native `docker_x64` build image does not contain `dd-pkg`. The current Agent backport PR works around this by pinning a build image produced from `datadog-agent-buildimages` main, which couples the legacy release branch to a newer Docker/Python toolchain.

## Change

Add a minimal multi-stage copy of `dd-pkg` v0.9.0 to the existing 6.53.x `docker-x64` image. This preserves the branch's existing toolchain while providing the client version that forwards `CI_JOB_TOKEN` to Artifact Gateway.

## Validation

- `git diff --check`
- Signed commit verified locally
- `build_docker_x64` succeeded: https://gitlab.ddbuild.io/DataDog/datadog-agent-buildimages/-/jobs/1861362279
- CI published and signed `registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64_test_only:v124754487-65eeac1f@sha256:2e794f820eb25f8a326416eaac6b29a91dd7ffafd8675c89339359907ba07cf4`
- Extracted `usr/local/bin/dd-pkg` is byte-identical to the official v0.9.0 amd64 release binary (`sha256:635edba9bed384f34828b5df438bacfcfde9937d6aa1e2d5295e359ee64f5bc4`)
- Local Docker build was unavailable because Docker Desktop is not running; the repository CI build above is the authoritative image build and signing check

## Follow-up

After merge publishes the signed 6.53.x release image tag, update [DataDog/datadog-agent#53401](https://github.com/DataDog/datadog-agent/pull/53401) to consume that branch-native tag and run an Agent publication canary.

Jira: https://datadoghq.atlassian.net/browse/BARX-1700
