### PR TITLE
[SINT-5203] Reapply Windows Code Signer Upgrade

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -8,7 +8,7 @@ ARG BASE_IMAGE_TAG=4.8-windowsservercore-ltsc2022
 ARG BASE_IMAGE=${BASE_IMAGE_REGISTRY}/dotnet/framework/runtime:${BASE_IMAGE_TAG}
 
 # required for the COPY --from instruction later
-FROM registry.ddbuild.io/windows-code-signer/go:v0.7.0@sha256:64aa5ad1fccf9b7ab05c110f756e3e055be6e9e3941275b7797c8e14489a2180 AS windows-code-signer
+FROM registry.ddbuild.io/windows-code-signer/go:v0.8.0@sha256:bb1715e19445abff13e9487ba68c33d1879ca258991d85a84c6ff7b63f26549a AS windows-code-signer
 
 FROM ${BASE_IMAGE}
 

--- a/windows/versions.ps1
+++ b/windows/versions.ps1
@@ -79,6 +79,6 @@ $SoftwareTable = @{
     # with a "COPY --from" instruction in the Dockerfile
     # recall to update the digest of the image in the Dockerfile
     # when updating the version
-    "WINDOWS_CODE_SIGNER_VERSION"="v0.7.0";
-    "WINDOWS_CODE_SIGNER_SHA256"="89eb7490e7bec62fea47fdbe4b202f65c8a068b84ce2d2c629a33ce924774cf7";
+    "WINDOWS_CODE_SIGNER_VERSION"="v0.8.0";
+    "WINDOWS_CODE_SIGNER_SHA256"="941dbad45eddcb9428ec1940200e40fa41eb48f1870869d444a8e437cf7e3f68";
 }


### PR DESCRIPTION
We reapply 6a8899519e6afc4fd394a1cd775bec186f193190 (see https://github.com/DataDog/datadog-agent-buildimages/pull/1219) after it was reverted in https://github.com/DataDog/datadog-agent-buildimages/pull/1265.

The test suite was fixed in https://github.com/DataDog/datadog-agent-buildimages/pull/1275 so we should be able to check that this change does not re-introduce the bug of https://app.datadoghq.com/incidents/57509. I suspect it was https://github.com/DataDog/datadog-agent-buildimages/pull/1201 that caused the incident, although at this point we are not completely sure.

# Tests

See PR comments: we triggered a test pipeline in the agent repository and the jobs that were failing in https://app.datadoghq.com/incidents/57509 were successful.