### PR TITLE
Do not set OMNIBUS_GIT_CACHE_DIR on the image

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -340,7 +340,6 @@ ENV BAZELISK_HOME="${XDG_CACHE_HOME}/bazelisk" \
     PIP_CACHE_DIR="${XDG_CACHE_HOME}/pip" \
     OMNIBUS_BASE_DIR="${XDG_CACHE_HOME}/omnibus" \
     OMNIBUS_CACHE_DIR="${XDG_CACHE_HOME}/omnibus/cache" \
-    OMNIBUS_GIT_CACHE_DIR="${XDG_CACHE_HOME}/omnibus/git-cache" \
     OMNIBUS_GOMODCACHE="${XDG_CACHE_HOME}/go/pkg/mod" \
     BUNDLE_PATH="${XDG_CACHE_HOME}/omnibus/bundle"
 


### PR DESCRIPTION
### What does this PR do?

It avoids baking `OMNIBUS_GIT_CACHE_DIR` into the image.

### Motivation

We're phasing out the Omnibus git cache on CI (https://github.com/DataDog/datadog-agent/pull/53976), and found out that the image has a default value for it. This variable is explicitly set in CI (and therefore this baked in value was originally not used). Users can still set it explicitly for their builds (like [this](https://github.com/DataDog/datadog-agent/blob/e0b2e15cc001b244a2fffb0f75abf91306d8f2ec/tasks/omnibus.py#L685) does) if they need – though along with its removal from CI we're reaching a point where this could be considered as deprecated and not recommended.

### Possible Drawbacks / Trade-offs

### Additional Notes
