### PR TITLE
CI: remove now unused get_agent_version job

### DIFF
--- a/.gitlab/setup.yml
+++ b/.gitlab/setup.yml
@@ -1,19 +1,4 @@
 ---
-get_agent_version:
-  stage: setup
-  tags: ["arch:amd64"]
-  image: $BUILDENV_REGISTRY/images/python:3.12.8
-  script:
-    - export DDA_VERSION=$(grep DDA_VERSION dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')
-    - pip install "dda==${DDA_VERSION}"
-    - export PATH=/home/dog/.local/bin:$PATH
-    - VERSION=$(dda run agent version)
-    - echo "AGENT_VERSION=$VERSION"
-    - echo "AGENT_VERSION=$VERSION" >> version.env
-  artifacts:
-    reports:
-      dotenv: version.env
-
 lint_dockerfiles:
   tags: ["arch:amd64"]
   stage: setup


### PR DESCRIPTION
### What does this PR do?

Removes the `get_agent_version` job from `.gitlab/setup.yml`.

### Motivation

Nothing in the repo consumes the `AGENT_VERSION` variable anymore
The last known consumer (`.gitlab/stats.yml`) was removed a while back and this producer was never cleaned up.

### Possible Drawbacks / Trade-offs

### Additional Notes
