### PR TITLE
build: remove .always rule & references to CI_COMMIT_TAG

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,14 +33,10 @@ variables:
 .on_push:
   - if: $CI_PIPELINE_SOURCE == "schedule"
     when: never
-  - if: $CI_COMMIT_TAG != null
-    when: never
   - when: always
 
 .on_default_branch_push:
   - if: $CI_PIPELINE_SOURCE == "schedule"
-    when: never
-  - if: $CI_COMMIT_TAG != null
     when: never
   - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     when: always

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -17,9 +17,7 @@
 
 .no_schedule:
   rules:
-    - if: $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE != "schedule"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-      when: never
+    - if: $CI_PIPELINE_SOURCE != "schedule"
 
 .build:
   stage: build
@@ -239,8 +237,7 @@ build_dev_env_workspace_arm64:
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       when: on_success
-    - if: $CI_COMMIT_TAG == null
-      changes:
+    - changes:
         paths:
           - build-container.ps1
           - windows/**/*

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -15,10 +15,6 @@
     DD_TARGET_ARCH: aarch64
     PLATFORM: linux/arm64
 
-.always:
-  rules:
-    - if: $CI_COMMIT_TAG == null
-
 .no_schedule:
   rules:
     - if: $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE != "schedule"
@@ -83,20 +79,20 @@ build_linux_amd64:
     BAKE_TARGET: linux-amd64-ci$ECR_TEST_ONLY
 
 build_rpm_x64:
-  extends: [.medium_build, .always, .x64]
+  extends: [.medium_build, .x64]
   variables:
     DOCKERFILE: rpm-x64/Dockerfile
     IMAGE: rpm_x64
     BASE_IMAGE: centos:7
 
 build_dd_agent_testing:
-  extends: [.fast_build, .always, .x64]
+  extends: [.fast_build, .x64]
   variables:
     DOCKERFILE: dd-agent-testing/Dockerfile
     IMAGE: dd-agent-testing
 
 build_docker_x64:
-  extends: [.build_bake, .always, .x64]
+  extends: [.build_bake, .x64]
   timeout: 30m
   id_tokens:
     DDSIGN_ID_TOKEN:
@@ -115,13 +111,13 @@ build_docker_x64:
       fi
 
 build_btf_gen:
-  extends: [.fast_build, .always, .x64]
+  extends: [.fast_build, .x64]
   variables:
     DOCKERFILE: btf-gen/Dockerfile
     IMAGE: btf-gen
 
 build_gitlab_agent_deploy:
-  extends: [.fast_build, .always, .x64]
+  extends: [.fast_build, .x64]
   variables:
     DOCKERFILE: agent-deploy/Dockerfile
     IMAGE: gitlab_agent_deploy
@@ -133,14 +129,14 @@ build_linux_arm64:
     BAKE_TARGET: linux-arm64-ci$ECR_TEST_ONLY
 
 build_rpm_arm64:
-  extends: [.medium_build, .always, .arm]
+  extends: [.medium_build, .arm]
   variables:
     DOCKERFILE: rpm-arm64/Dockerfile
     IMAGE: rpm_arm64
     BASE_IMAGE: amazonlinux:2.0.20181114
 
 build_rpm_armhf:
-  extends: [.medium_build, .always, .arm]
+  extends: [.medium_build, .arm]
   variables:
     DOCKERFILE: rpm-armhf/Dockerfile
     IMAGE: rpm_armhf
@@ -148,7 +144,7 @@ build_rpm_armhf:
     DD_TARGET_ARCH: armhf
 
 build_docker_arm64:
-  extends: [.fast_build, .always, .arm]
+  extends: [.fast_build, .arm]
   variables:
     DOCKERFILE: docker-arm64/Dockerfile
     IMAGE: docker_arm64

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -15,8 +15,7 @@ trigger_tests:
         CI_IMAGE_WIN_LTSC2022_X64_SUFFIX: "${ECR_TEST_ONLY}"
         CI_IMAGE_WIN_LTSC2025_X64: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
         CI_IMAGE_WIN_LTSC2025_X64_SUFFIX: "${ECR_TEST_ONLY}"
-    - if: $CI_COMMIT_TAG == null
-      changes:
+    - changes:
         paths:
           - build-container.ps1
           - windows/**/*


### PR DESCRIPTION
### What does this PR do?

Remove the `.always` tag & references to `CI_COMMIT_TAG`

### Motivation

Despite its name, the `.always` tag means "Don't run on tag pipelines"
However, this repository has no tags, and no plan to rely on them, so this is just noise and can be removed to simplify the CI setup

### Possible Drawbacks / Trade-offs

### Additional Notes
