### PR TITLE
Bump go-update workflow to Python 3.14

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Python and pip
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"  # temporary: 3.14 breaks httpcore 1.0.7, revert when dda bumps httpcore to >=1.0.8
+          python-version: "3.14"
 
       - name: Get access token via dd-octo-sts
         uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4


### PR DESCRIPTION
### What does this PR do?

Bumps `python-version` in `.github/workflows/go-update.yml` from `3.12` back to `3.14`, and drops the accompanying temporary comment.

### Motivation

Follow-up to #1296 (dda v0.38.0), which brings `httpcore` 1.0.9 (fixes the Python 3.14 incompatibility). Reverts the temporary 3.12 pin from #1250.

### Possible Drawbacks / Trade-offs

### Additional Notes