### PR TITLE
Update DotSlash tools

### DIFF
--- a/tools/dotslash/config/agent-browser.json
+++ b/tools/dotslash/config/agent-browser.json
@@ -2,38 +2,38 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 9983368
+        "uncompressed_size": 12050560
       },
       "linux-x86_64": {
-        "uncompressed_size": 11420912
+        "uncompressed_size": 13748144
       }
     }
   },
   "name": "agent-browser",
   "platforms": {
     "linux-aarch64": {
-      "digest": "c9edec860bd49eaa7902d37947d4208a49c90e7bd551a5d04aa5d8e4c210d24a",
+      "digest": "2dd93fac3b2b09e7d4f1fbf8f63fa125bdc67443bc5c855a651482627976cf29",
       "hash": "blake3",
       "path": "agent-browser",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/vercel-labs/agent-browser/releases/download/v0.27.0/agent-browser-linux-musl-arm64"
+          "url": "https://github.com/vercel-labs/agent-browser/releases/download/v0.33.2/agent-browser-linux-musl-arm64"
         }
       ],
-      "size": 9983368
+      "size": 12050560
     },
     "linux-x86_64": {
-      "digest": "fab01fef427be8077ecaed7d12e47801495c22ca2d2797941186b149d9347043",
+      "digest": "d90b52026745c79f8115f363551ab6a76e858649eefbb084d03cbf2085a30d90",
       "hash": "blake3",
       "path": "agent-browser",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/vercel-labs/agent-browser/releases/download/v0.27.0/agent-browser-linux-musl-x64"
+          "url": "https://github.com/vercel-labs/agent-browser/releases/download/v0.33.2/agent-browser-linux-musl-x64"
         }
       ],
-      "size": 11420912
+      "size": 13748144
     }
   }
 }

--- a/tools/dotslash/config/ast-grep.json
+++ b/tools/dotslash/config/ast-grep.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 51021352
+        "uncompressed_size": 53364008
       },
       "linux-x86_64": {
-        "uncompressed_size": 51432936
+        "uncompressed_size": 53742192
       }
     }
   },
   "name": "ast-grep",
   "platforms": {
     "linux-aarch64": {
-      "digest": "f770612a9742416811f7a4ab65dd1700ae2f57cf1d90ddb8f7448545cb4cb320",
+      "digest": "0555d27b101a9f8f564c16a6f4e9c7e36b62af5885be28e5cb7a0430acd9a73c",
       "format": "zip",
       "hash": "blake3",
       "path": "ast-grep",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/ast-grep/ast-grep/releases/download/0.42.3/app-aarch64-unknown-linux-gnu.zip"
+          "url": "https://github.com/ast-grep/ast-grep/releases/download/0.45.0/app-aarch64-unknown-linux-gnu.zip"
         }
       ],
-      "size": 7587177
+      "size": 7978902
     },
     "linux-x86_64": {
-      "digest": "ed5888bb0a0ccd6f77048e579341745ead43f019f6e29f6e0722160dd98fcabc",
+      "digest": "5ba8147a859d260f55ad859ced119002ed3778a1f8f49304f9c892357bc29841",
       "format": "zip",
       "hash": "blake3",
       "path": "ast-grep",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/ast-grep/ast-grep/releases/download/0.42.3/app-x86_64-unknown-linux-gnu.zip"
+          "url": "https://github.com/ast-grep/ast-grep/releases/download/0.45.0/app-x86_64-unknown-linux-gnu.zip"
         }
       ],
-      "size": 7864746
+      "size": 8250437
     }
   }
 }

--- a/tools/dotslash/config/bat.json
+++ b/tools/dotslash/config/bat.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 5299556
+        "uncompressed_size": 6343084
       },
       "linux-x86_64": {
-        "uncompressed_size": 5893844
+        "uncompressed_size": 7068620
       }
     }
   },
   "name": "bat",
   "platforms": {
     "linux-aarch64": {
-      "digest": "dc1fef74981d8d42be3e64baa617d080cea2cfecf8dd8e662c967a371d315cda",
+      "digest": "7676a63bc601fa39d7911534c920331a983fea16f2cd2e4681f435be77ceded2",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "bat-v0.24.0-aarch64-unknown-linux-gnu/bat",
+      "path": "bat-v0.26.1-aarch64-unknown-linux-gnu/bat",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/sharkdp/bat/releases/download/v0.24.0/bat-v0.24.0-aarch64-unknown-linux-gnu.tar.gz"
+          "url": "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-aarch64-unknown-linux-gnu.tar.gz"
         }
       ],
-      "size": 2856747
+      "size": 3345545
     },
     "linux-x86_64": {
-      "digest": "e8432f56e16b23ec0ae54eb4c968c95869d8084fad9c940814dfbae5ac7ca243",
+      "digest": "70c338f12c0492e8867b54c76b091639c0defcd8348c9496978cc04ca0d758c8",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "bat-v0.24.0-x86_64-unknown-linux-musl/bat",
+      "path": "bat-v0.26.1-x86_64-unknown-linux-musl/bat",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/sharkdp/bat/releases/download/v0.24.0/bat-v0.24.0-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 3038788
+      "size": 3584928
     }
   }
 }

--- a/tools/dotslash/config/btm.json
+++ b/tools/dotslash/config/btm.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 3935199
+        "uncompressed_size": 4312156
       },
       "linux-x86_64": {
-        "uncompressed_size": 4931143
+        "uncompressed_size": 5258948
       }
     }
   },
   "name": "btm",
   "platforms": {
     "linux-aarch64": {
-      "digest": "5b4dca7279956329b322592ca1d96f5cc58fce728f0dc06ce376fc9bf7b68d1f",
+      "digest": "c3e16ccab62b6431d07daf633dd2f5940e0e1e6a386e689cd5a13383397f7680",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "btm",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/ClementTsang/bottom/releases/download/0.10.2/bottom_aarch64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/ClementTsang/bottom/releases/download/0.14.7/bottom_aarch64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 1808205
+      "size": 1911156
     },
     "linux-x86_64": {
-      "digest": "402b50ec077c8c9bf3092a221e862e8e3211d1e7a9017cf63dfbd22317f6a8b5",
+      "digest": "639db2b3fa2b73610d517889d32060889d6be40c265d6dca8a830f1de25b838a",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "btm",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/ClementTsang/bottom/releases/download/0.10.2/bottom_x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/ClementTsang/bottom/releases/download/0.14.7/bottom_x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 2018204
+      "size": 2119000
     }
   }
 }

--- a/tools/dotslash/config/claude.json
+++ b/tools/dotslash/config/claude.json
@@ -2,38 +2,38 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 232437384
+        "uncompressed_size": 292404152
       },
       "linux-x86_64": {
-        "uncompressed_size": 232572624
+        "uncompressed_size": 295676936
       }
     }
   },
   "name": "claude",
   "platforms": {
     "linux-aarch64": {
-      "digest": "fb595618d6722e62dc38986419dd5d7ae77d5b17f69e0b2b2ea3dfc9bf4003ec",
+      "digest": "d0f64c4d44c180a38058499755978f6cf82289384d528f434791d6ad6a4f6da9",
       "hash": "blake3",
       "path": "claude",
       "providers": [
         {
           "type": "http",
-          "url": "https://downloads.claude.ai/claude-code-releases/2.1.141/linux-arm64/claude"
+          "url": "https://downloads.claude.ai/claude-code-releases/2.1.224/linux-arm64/claude"
         }
       ],
-      "size": 232437384
+      "size": 292404152
     },
     "linux-x86_64": {
-      "digest": "a9e488ddd4b1d867757bf05d10c9f500dbd1cb7ca90362aee65dd070d2d6966e",
+      "digest": "ae255fe316722ccfef0f3ba575cb84fbbdc38b3c92d3d736b58e156b17c93290",
       "hash": "blake3",
       "path": "claude",
       "providers": [
         {
           "type": "http",
-          "url": "https://downloads.claude.ai/claude-code-releases/2.1.141/linux-x64/claude"
+          "url": "https://downloads.claude.ai/claude-code-releases/2.1.224/linux-x64/claude"
         }
       ],
-      "size": 232572624
+      "size": 295676936
     }
   }
 }

--- a/tools/dotslash/config/codex.json
+++ b/tools/dotslash/config/codex.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 199290214
+        "uncompressed_size": 275122046
       },
       "linux-x86_64": {
-        "uncompressed_size": 234632293
+        "uncompressed_size": 314797933
       }
     }
   },
   "name": "codex",
   "platforms": {
     "linux-aarch64": {
-      "digest": "fb2eeeb03c48950fb361c77d8a65c32b56aafdc1a1cc68e3ebd7b0db2c5ef117",
+      "digest": "49e87c0031a91e32693432dec34ceb59852e62c71a75303744a40ef2ebc115cb",
       "format": "tar.zst",
       "hash": "blake3",
       "path": "bin/codex",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/openai/codex/releases/download/rust-v0.137.0/codex-package-aarch64-unknown-linux-musl.tar.zst"
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-package-aarch64-unknown-linux-musl.tar.zst"
         }
       ],
-      "size": 60432262
+      "size": 80608473
     },
     "linux-x86_64": {
-      "digest": "717bb1c97ef8e98d440208b052da211329f1280dbb3d37722c622afff03591ee",
+      "digest": "bc66d10f26da00827ce7b0cc6447f2cf51dac2158913806d0745d152b614141e",
       "format": "tar.zst",
       "hash": "blake3",
       "path": "bin/codex",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/openai/codex/releases/download/rust-v0.137.0/codex-package-x86_64-unknown-linux-musl.tar.zst"
+          "url": "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-package-x86_64-unknown-linux-musl.tar.zst"
         }
       ],
-      "size": 65318495
+      "size": 86804357
     }
   }
 }

--- a/tools/dotslash/config/ddtool.json
+++ b/tools/dotslash/config/ddtool.json
@@ -2,42 +2,42 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 277359853
+        "uncompressed_size": 306558684
       },
       "linux-x86_64": {
-        "uncompressed_size": 277359853
+        "uncompressed_size": 306558684
       }
     }
   },
   "name": "ddtool",
   "platforms": {
     "linux-aarch64": {
-      "digest": "37ce8419d45fa87e9560243bb1151eeb62a4eabf8e42ad79187c8b2f9a61bc8f",
+      "digest": "5f3f673f2263c918d895ccafef164b642760696be4b6d2a8b066ada24c5f11e0",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "ddtool_linux_arm64",
       "providers": [
         {
           "type": "http",
-          "url": "https://binaries.ddbuild.io/ddtool/v1.110.0/ddtool.tar.gz"
+          "url": "https://binaries.ddbuild.io/ddtool/v1.122.1/ddtool.tar.gz"
         }
       ],
       "readonly": false,
-      "size": 85822742
+      "size": 93166942
     },
     "linux-x86_64": {
-      "digest": "37ce8419d45fa87e9560243bb1151eeb62a4eabf8e42ad79187c8b2f9a61bc8f",
+      "digest": "5f3f673f2263c918d895ccafef164b642760696be4b6d2a8b066ada24c5f11e0",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "ddtool_linux_amd64",
       "providers": [
         {
           "type": "http",
-          "url": "https://binaries.ddbuild.io/ddtool/v1.110.0/ddtool.tar.gz"
+          "url": "https://binaries.ddbuild.io/ddtool/v1.122.1/ddtool.tar.gz"
         }
       ],
       "readonly": false,
-      "size": 85822742
+      "size": 93166942
     }
   }
 }

--- a/tools/dotslash/config/delta.json
+++ b/tools/dotslash/config/delta.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 6338582
+        "uncompressed_size": 6498320
       },
       "linux-x86_64": {
-        "uncompressed_size": 7186734
+        "uncompressed_size": 7211344
       }
     }
   },
   "name": "delta",
   "platforms": {
     "linux-aarch64": {
-      "digest": "1a92c45e381d4d1423f21a47277ca477676fc581f66ad85e4ec66ec77647040e",
+      "digest": "1fe6af9f57dd38dd64bf0015f0049e870ef99b14baac23cf7e16d5b71ffedc9b",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "delta-0.18.2-aarch64-unknown-linux-gnu/delta",
+      "path": "delta-0.19.2-aarch64-unknown-linux-gnu/delta",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-aarch64-unknown-linux-gnu.tar.gz"
+          "url": "https://github.com/dandavison/delta/releases/download/0.19.2/delta-0.19.2-aarch64-unknown-linux-gnu.tar.gz"
         }
       ],
-      "size": 3040795
+      "size": 3166854
     },
     "linux-x86_64": {
-      "digest": "fdd1cd8e8d98a7f2bacc64c2fad07a048ede031be6cd03bde8922d8b8819db07",
+      "digest": "206c2b72d2a3563ae242f03db4f13480ce9bd0341bf5a1b7a77da532f431ecec",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "delta-0.18.2-x86_64-unknown-linux-musl/delta",
+      "path": "delta-0.19.2-x86_64-unknown-linux-musl/delta",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/dandavison/delta/releases/download/0.19.2/delta-0.19.2-x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 3301354
+      "size": 3403232
     }
   }
 }

--- a/tools/dotslash/config/diffnav.json
+++ b/tools/dotslash/config/diffnav.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 8725489
+        "uncompressed_size": 9060608
       },
       "linux-x86_64": {
-        "uncompressed_size": 9028593
+        "uncompressed_size": 9507072
       }
     }
   },
   "name": "diffnav",
   "platforms": {
     "linux-aarch64": {
-      "digest": "b65961bb36b006fa355a9f95569a7e33c0af2420af51b1628259eb885c643407",
+      "digest": "f2ef87204d39264b05fac32f62a672f38e7f672bd0deb705b7a484c364b6429e",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "diffnav",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/dlvhdr/diffnav/releases/download/v0.11.0/diffnav_Linux_arm64.tar.gz"
+          "url": "https://github.com/dlvhdr/diffnav/releases/download/v0.12.0/diffnav_Linux_arm64.tar.gz"
         }
       ],
-      "size": 2901560
+      "size": 3021001
     },
     "linux-x86_64": {
-      "digest": "7c10718e8073aa299bcae39108a21f1933cfd4c301080c28c6412617b881b27c",
+      "digest": "8fdd3a6bbe0b1ec4d972d65e1c60d533cbf1b1c467e4df5744e1d2ac5b9fa2f5",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "diffnav",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/dlvhdr/diffnav/releases/download/v0.11.0/diffnav_Linux_x86_64.tar.gz"
+          "url": "https://github.com/dlvhdr/diffnav/releases/download/v0.12.0/diffnav_Linux_x86_64.tar.gz"
         }
       ],
-      "size": 3181392
+      "size": 3325933
     }
   }
 }

--- a/tools/dotslash/config/eza.json
+++ b/tools/dotslash/config/eza.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 1268656
+        "uncompressed_size": 2341848
       },
       "linux-x86_64": {
-        "uncompressed_size": 2376520
+        "uncompressed_size": 2968992
       }
     }
   },
   "name": "eza",
   "platforms": {
     "linux-aarch64": {
-      "digest": "0f7df036275d5b68451bb9d4589f903c3009f04cc8728ea9538d1e8a6d9e719a",
+      "digest": "8e2ebaa5f661ab8107716e1602ce94f98af92f2e4945f71d93db9107baea7e93",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "eza",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/eza-community/eza/releases/download/v0.20.2/eza_aarch64-unknown-linux-gnu.tar.gz"
+          "url": "https://github.com/eza-community/eza/releases/download/v0.23.5/eza_aarch64-unknown-linux-gnu.tar.gz"
         }
       ],
-      "size": 607934
+      "size": 1137855
     },
     "linux-x86_64": {
-      "digest": "b4702fdb8e933eb67a6a4273aa60768ec4915b3ecf3957e1f3570d1be7d2cb91",
+      "digest": "c183c6b3c4df7eeb9ae4871f3ace5924683424785ba5d40a7ca0b18a9d6bf26e",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "eza",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/eza-community/eza/releases/download/v0.20.2/eza_x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/eza-community/eza/releases/download/v0.23.5/eza_x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 1156613
+      "size": 1412332
     }
   }
 }

--- a/tools/dotslash/config/fd.json
+++ b/tools/dotslash/config/fd.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 3396104
+        "uncompressed_size": 3564309
       },
       "linux-x86_64": {
-        "uncompressed_size": 4220144
+        "uncompressed_size": 4273645
       }
     }
   },
   "name": "fd",
   "platforms": {
     "linux-aarch64": {
-      "digest": "0c95cd925704d489bafa00c16d4f7085cc7f659500e2166aaf8263a836b55150",
+      "digest": "538ae7f910f4ad5965ffcc831ebdedb4f1b69238d1f26fed310a6b7cffe40a35",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "fd-v10.2.0-aarch64-unknown-linux-musl/fd",
+      "path": "fd-v10.4.2-aarch64-unknown-linux-musl/fd",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/sharkdp/fd/releases/download/v10.2.0/fd-v10.2.0-aarch64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/sharkdp/fd/releases/download/v10.4.2/fd-v10.4.2-aarch64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 1537874
+      "size": 1604562
     },
     "linux-x86_64": {
-      "digest": "67cc22c3a887c7cb55dec0f4f91243be0121d65b69ac4127f31abf57009c6760",
+      "digest": "0dedfeb8b2497dac173bd290e54cbc6209d24b2b8534bc7ea982a48834cc59e9",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "fd-v10.2.0-x86_64-unknown-linux-musl/fd",
+      "path": "fd-v10.4.2-x86_64-unknown-linux-musl/fd",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/sharkdp/fd/releases/download/v10.2.0/fd-v10.2.0-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/sharkdp/fd/releases/download/v10.4.2/fd-v10.4.2-x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 1681679
+      "size": 1754511
     }
   }
 }

--- a/tools/dotslash/config/fzf.json
+++ b/tools/dotslash/config/fzf.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 3735552
+        "uncompressed_size": 4718754
       },
       "linux-x86_64": {
-        "uncompressed_size": 3760128
+        "uncompressed_size": 4915362
       }
     }
   },
   "name": "fzf",
   "platforms": {
     "linux-aarch64": {
-      "digest": "59dc9d4e3bc780ce4dcd1aa3e425d857735c3ea17ed440fc1a9351d7b389fc73",
+      "digest": "e9f9a7116898cb187deb6c4d83a8be8619b8eb3b8607943f2d5ea8c960f2e98f",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "fzf",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/junegunn/fzf/releases/download/v0.55.0/fzf-0.55.0-linux_arm64.tar.gz"
+          "url": "https://github.com/junegunn/fzf/releases/download/v0.74.2/fzf-0.74.2-linux_arm64.tar.gz"
         }
       ],
-      "size": 1446020
+      "size": 1845580
     },
     "linux-x86_64": {
-      "digest": "85b10cf79042093b9fa75bd72220d13c122e5922e18e04ee5aa8548f96871e1f",
+      "digest": "c4f70441160ad87f0eb68de791383d73c3d131f30eca614fb86f009e189cff4e",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "fzf",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/junegunn/fzf/releases/download/v0.55.0/fzf-0.55.0-linux_amd64.tar.gz"
+          "url": "https://github.com/junegunn/fzf/releases/download/v0.74.2/fzf-0.74.2-linux_amd64.tar.gz"
         }
       ],
-      "size": 1556217
+      "size": 2013806
     }
   }
 }

--- a/tools/dotslash/config/gfold.json
+++ b/tools/dotslash/config/gfold.json
@@ -2,38 +2,38 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 1793592
+        "uncompressed_size": 1824680
       },
       "linux-x86_64": {
-        "uncompressed_size": 2081184
+        "uncompressed_size": 2079520
       }
     }
   },
   "name": "gfold",
   "platforms": {
     "linux-aarch64": {
-      "digest": "7ea8903b98d122e47078f95d9dba8687b2f021e142c182b720fdae8ba56f8e75",
+      "digest": "ce9e3b6dad90b2ab8d9fa2b13bfccf68e4a45e2da79a0f6c6f020573f5531314",
       "hash": "blake3",
       "path": "gfold-linux-musl-aarch64",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/nickgerace/gfold/releases/download/2025.2.1-ofek-1/gfold-linux-musl-aarch64"
+          "url": "https://github.com/nickgerace/gfold/releases/download/2026.3.0/gfold-linux-musl-aarch64"
         }
       ],
-      "size": 1793592
+      "size": 1824680
     },
     "linux-x86_64": {
-      "digest": "8058afcb64b9d41af2707c9bb55b945529468e6619b9759bf61e170f330bc3ca",
+      "digest": "587f6c4f69260bd04dc3e4fabd36bd129d63e377aec3352eed3625678df63566",
       "hash": "blake3",
       "path": "gfold-linux-musl-x86-64",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/nickgerace/gfold/releases/download/2025.2.1-ofek-1/gfold-linux-musl-x86-64"
+          "url": "https://github.com/nickgerace/gfold/releases/download/2026.3.0/gfold-linux-musl-x86-64"
         }
       ],
-      "size": 2081184
+      "size": 2079520
     }
   }
 }

--- a/tools/dotslash/config/gh-dash.json
+++ b/tools/dotslash/config/gh-dash.json
@@ -2,38 +2,38 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 21299384
+        "uncompressed_size": 22282402
       },
       "linux-x86_64": {
-        "uncompressed_size": 22458552
+        "uncompressed_size": 23716002
       }
     }
   },
   "name": "gh-dash",
   "platforms": {
     "linux-aarch64": {
-      "digest": "ee0abaaf645ac0f98008ccc0d4dda87803943beda8eb89db86f58ad802918185",
+      "digest": "a70b6260d66c8f5d82d2274b3f06943c9532199d81b9babecead3609d988ae63",
       "hash": "blake3",
       "path": "gh-dash",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/dlvhdr/gh-dash/releases/download/v4.24.1/gh-dash_v4.24.1_linux-arm64"
+          "url": "https://github.com/dlvhdr/gh-dash/releases/download/v4.25.2/gh-dash_v4.25.2_linux-arm64"
         }
       ],
-      "size": 21299384
+      "size": 22282402
     },
     "linux-x86_64": {
-      "digest": "72de8482da7643946801552e74bde25d707fdae2f71e8279c01f9ac9ff00c9ce",
+      "digest": "0eb2aac33bc5cab13baec81690af5f324b8b7943ac6784d37add64b8eadc0f95",
       "hash": "blake3",
       "path": "gh-dash",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/dlvhdr/gh-dash/releases/download/v4.24.1/gh-dash_v4.24.1_linux-amd64"
+          "url": "https://github.com/dlvhdr/gh-dash/releases/download/v4.25.2/gh-dash_v4.25.2_linux-amd64"
         }
       ],
-      "size": 22458552
+      "size": 23716002
     }
   }
 }

--- a/tools/dotslash/config/gh.json
+++ b/tools/dotslash/config/gh.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 37370746
+        "uncompressed_size": 38445929
       },
       "linux-x86_64": {
-        "uncompressed_size": 40147834
+        "uncompressed_size": 41362281
       }
     }
   },
   "name": "gh",
   "platforms": {
     "linux-aarch64": {
-      "digest": "63e5cbae9d50559e212f647bcc162d393e5d2fa00d0ea627958c03854f40a680",
+      "digest": "84c5901f0fd6509c530b41f3d577c9bae11dbd7e4cebeb1bf95562e3a66cbc9a",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "gh_2.92.0_linux_arm64/bin/gh",
+      "path": "gh_2.97.0_linux_arm64/bin/gh",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_linux_arm64.tar.gz"
+          "url": "https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_arm64.tar.gz"
         }
       ],
-      "size": 13002970
+      "size": 13428558
     },
     "linux-x86_64": {
-      "digest": "3946dd6596d9c17f53c314cf6c2282a9c380ad2e72a0695e5b51af8cc0382f16",
+      "digest": "9f41328dfe7d5f193f91b3fde9fc91c6c161ffafdd3339f0dbf4f5aa48ca51e1",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "gh_2.92.0_linux_amd64/bin/gh",
+      "path": "gh_2.97.0_linux_amd64/bin/gh",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_linux_amd64.tar.gz"
+          "url": "https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_amd64.tar.gz"
         }
       ],
-      "size": 14296784
+      "size": 14770812
     }
   }
 }

--- a/tools/dotslash/config/git-wt.json
+++ b/tools/dotslash/config/git-wt.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 36504708
+        "uncompressed_size": 49476834
       },
       "linux-x86_64": {
-        "uncompressed_size": 39036220
+        "uncompressed_size": 54256514
       }
     }
   },
   "name": "git-wt",
   "platforms": {
     "linux-aarch64": {
-      "digest": "598f289802974e287e1861805541a06dcc76a97732230910f8ddaf27dade5aa2",
+      "digest": "9994e7f5aeb4bfd787a873eff190c7dfc43fb074957da607fa77b07151df9090",
       "format": "tar.xz",
       "hash": "blake3",
       "path": "worktrunk-aarch64-unknown-linux-musl/git-wt",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/max-sixty/worktrunk/releases/download/v0.53.0/worktrunk-aarch64-unknown-linux-musl.tar.xz"
+          "url": "https://github.com/max-sixty/worktrunk/releases/download/v0.72.0/worktrunk-aarch64-unknown-linux-musl.tar.xz"
         }
       ],
-      "size": 5388516
+      "size": 7236548
     },
     "linux-x86_64": {
-      "digest": "7c0bc40dd114712022ae3e85b2cc380458c0b316e29b50f4e5f5e3262d97537f",
+      "digest": "adff2449a2bc82c0db46ac79846c023d9bed2176b677cc823488ce1aca6a80c0",
       "format": "tar.xz",
       "hash": "blake3",
       "path": "worktrunk-x86_64-unknown-linux-musl/git-wt",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/max-sixty/worktrunk/releases/download/v0.53.0/worktrunk-x86_64-unknown-linux-musl.tar.xz"
+          "url": "https://github.com/max-sixty/worktrunk/releases/download/v0.72.0/worktrunk-x86_64-unknown-linux-musl.tar.xz"
         }
       ],
-      "size": 5931036
+      "size": 8204876
     }
   }
 }

--- a/tools/dotslash/config/gitas.json
+++ b/tools/dotslash/config/gitas.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 1966384
+        "uncompressed_size": 1986856
       },
       "linux-x86_64": {
-        "uncompressed_size": 2356176
+        "uncompressed_size": 2372528
       }
     }
   },
   "name": "gitas",
   "platforms": {
     "linux-aarch64": {
-      "digest": "c37c619730d95504afd5c8a1eaabe59d0b6031a527c7e17e891b9e72b5f9c030",
+      "digest": "7d81d36abfd18731b6d69052d8ff47b9db8e8688c2f6fcdb205411606f9ad9d6",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "gitas",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/letmutex/gitas/releases/download/v0.0.7/gitas-v0.0.7-linux-arm64.tar.gz"
+          "url": "https://github.com/letmutex/gitas/releases/download/v0.1.0/gitas-v0.1.0-linux-arm64.tar.gz"
         }
       ],
-      "size": 1168295
+      "size": 1172741
     },
     "linux-x86_64": {
-      "digest": "2cd713ffb1c37e5d8a0ff44fff600d227313dbe82b5e399a0a91fb664d86aa2c",
+      "digest": "e4692591cc25182211aab5e7886fdc50b76f3f3989daf93cfca3d332d88f170c",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "gitas",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/letmutex/gitas/releases/download/v0.0.7/gitas-v0.0.7-linux-x64.tar.gz"
+          "url": "https://github.com/letmutex/gitas/releases/download/v0.1.0/gitas-v0.1.0-linux-x64.tar.gz"
         }
       ],
-      "size": 1234635
+      "size": 1239392
     }
   }
 }

--- a/tools/dotslash/config/gitui.json
+++ b/tools/dotslash/config/gitui.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 10560424
+        "uncompressed_size": 13272192
       },
       "linux-x86_64": {
-        "uncompressed_size": 11927552
+        "uncompressed_size": 14899808
       }
     }
   },
   "name": "gitui",
   "platforms": {
     "linux-aarch64": {
-      "digest": "73ca74dd68ea6e4a4dc328c287c68e5e5b97883b68d3722ea042d06607385636",
+      "digest": "e38feb6ee2cd56cd8b64fbf956473857be74ea3e4e6bb15cfe7e12cba1f3b73c",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "gitui",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/extrawurst/gitui/releases/download/v0.26.3/gitui-linux-aarch64.tar.gz"
+          "url": "https://github.com/extrawurst/gitui/releases/download/v0.28.1/gitui-linux-aarch64.tar.gz"
         }
       ],
-      "size": 5474533
+      "size": 6987794
     },
     "linux-x86_64": {
-      "digest": "c20eb7681418c8133382793f183cfc67f23fabad3741f284af0c774039cc2704",
+      "digest": "a89df61fe80adfedd9e3f683249648ca6b76d7b45070b4be69ae4cc9fd83e518",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "gitui",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/extrawurst/gitui/releases/download/v0.26.3/gitui-linux-x86_64.tar.gz"
+          "url": "https://github.com/extrawurst/gitui/releases/download/v0.28.1/gitui-linux-x86_64.tar.gz"
         }
       ],
-      "size": 5312821
+      "size": 6840775
     }
   }
 }

--- a/tools/dotslash/config/hk.json
+++ b/tools/dotslash/config/hk.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 21828696
+        "uncompressed_size": 11756480
       },
       "linux-x86_64": {
-        "uncompressed_size": 24862032
+        "uncompressed_size": 14948240
       }
     }
   },
   "name": "hk",
   "platforms": {
     "linux-aarch64": {
-      "digest": "cee647238545de8edba33a4a2647318c15756203d380462f99fdbdbd77735c8c",
+      "digest": "112e670a3f21dc695758063f7b539b5670a9b374da2833125470a3033448542c",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "hk",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/jdx/hk/releases/download/v1.45.0/hk-aarch64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/jdx/hk/releases/download/v1.54.1/hk-aarch64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 9062963
+      "size": 5690880
     },
     "linux-x86_64": {
-      "digest": "0bb958fecd588a4d0ccc4fe648bda9f682b80b12edc3869d5b0ef81a34fc1c9f",
+      "digest": "fb65cbbbeebc07cc2878e494b547da653fbc1e72e946226b195932f1fb405724",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "hk",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/jdx/hk/releases/download/v1.45.0/hk-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/jdx/hk/releases/download/v1.54.1/hk-x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 9255148
+      "size": 6244588
     }
   }
 }

--- a/tools/dotslash/config/hyperfine.json
+++ b/tools/dotslash/config/hyperfine.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 1231141
+        "uncompressed_size": 1274989
       },
       "linux-x86_64": {
-        "uncompressed_size": 1525709
+        "uncompressed_size": 1565581
       }
     }
   },
   "name": "hyperfine",
   "platforms": {
     "linux-aarch64": {
-      "digest": "eb6ba23e2507203bd11449491bdd7d522507675d126607e146d79efebe45bcc0",
+      "digest": "fb6456c5696b03e1d029be26ab1b336ce57e915686841150a097eda65829b024",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "hyperfine-v1.18.0-aarch64-unknown-linux-gnu/hyperfine",
+      "path": "hyperfine-v1.20.0-aarch64-unknown-linux-gnu/hyperfine",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/sharkdp/hyperfine/releases/download/v1.18.0/hyperfine-v1.18.0-aarch64-unknown-linux-gnu.tar.gz"
+          "url": "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-aarch64-unknown-linux-gnu.tar.gz"
         }
       ],
-      "size": 598999
+      "size": 607895
     },
     "linux-x86_64": {
-      "digest": "6bc74e270bbe27d04866cfb76f8c035454411842a681ec9e4243394e343337cf",
+      "digest": "680c2ffa41d3620fbc2a25be84c21afb96bf24014368fb9765096f6cf238d6f7",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "hyperfine-v1.18.0-x86_64-unknown-linux-musl/hyperfine",
+      "path": "hyperfine-v1.20.0-x86_64-unknown-linux-musl/hyperfine",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/sharkdp/hyperfine/releases/download/v1.18.0/hyperfine-v1.18.0-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 694152
+      "size": 710161
     }
   }
 }

--- a/tools/dotslash/config/jj.json
+++ b/tools/dotslash/config/jj.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 25571976
+        "uncompressed_size": 27534096
       },
       "linux-x86_64": {
-        "uncompressed_size": 28053456
+        "uncompressed_size": 30046560
       }
     }
   },
   "name": "jj",
   "platforms": {
     "linux-aarch64": {
-      "digest": "3c9cf55393962cba01a03545e1e71d4859a410b64b379b2441565fa21c81c967",
+      "digest": "de127313278d2f4c6f212a7e350543ce66a4ba536534082a56b16fb64ac0f604",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "jj",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/jj-vcs/jj/releases/download/v0.41.0/jj-v0.41.0-aarch64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/jj-vcs/jj/releases/download/v0.44.0/jj-v0.44.0-aarch64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 10041274
+      "size": 10071013
     },
     "linux-x86_64": {
-      "digest": "a3a2d5720879943387752afaf7243c604d1b9b6da76c228067a4597a8ab556c6",
+      "digest": "fc3fb82ab7373b157c33b1c9986fc90faf6ac8d8d2c8389abdf9fedaa7d62b63",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "jj",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/jj-vcs/jj/releases/download/v0.41.0/jj-v0.41.0-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/jj-vcs/jj/releases/download/v0.44.0/jj-v0.44.0-x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 10700500
+      "size": 10696461
     }
   }
 }

--- a/tools/dotslash/config/jq.json
+++ b/tools/dotslash/config/jq.json
@@ -2,38 +2,38 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 1709616
+        "uncompressed_size": 1797688
       },
       "linux-x86_64": {
-        "uncompressed_size": 2319424
+        "uncompressed_size": 2267912
       }
     }
   },
   "name": "jq",
   "platforms": {
     "linux-aarch64": {
-      "digest": "c195594f549766bfdf75127a7956980c1baa3fa9984ba6f5b5910ed946601d16",
+      "digest": "428869e0c7c8b86cc2422a2b1e034cb026776795fb5df707bca3f889c6256626",
       "hash": "blake3",
       "path": "jq-linux-arm64",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-arm64"
+          "url": "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-linux-arm64"
         }
       ],
-      "size": 1709616
+      "size": 1797688
     },
     "linux-x86_64": {
-      "digest": "f4f456f3a1a9a0dbcd9b0c2a77e29d14bc1f8bb036db4f6ff06d8c76a99e5ef2",
+      "digest": "4311c64431be63fb82189e7e0950b060b39046e865ebb796ec3fa974309c4986",
       "hash": "blake3",
       "path": "jq-linux-amd64",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64"
+          "url": "https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-linux-amd64"
         }
       ],
-      "size": 2319424
+      "size": 2267912
     }
   }
 }

--- a/tools/dotslash/config/kubectl.json
+++ b/tools/dotslash/config/kubectl.json
@@ -2,38 +2,38 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 58130616
+        "uncompressed_size": 55640226
       },
       "linux-x86_64": {
-        "uncompressed_size": 60559544
+        "uncompressed_size": 59556002
       }
     }
   },
   "name": "kubectl",
   "platforms": {
     "linux-aarch64": {
-      "digest": "74aef94d2132b4b007e81957f06444fb1dc59799dd5fe515c61b55e192232548",
+      "digest": "4f799865ffc68d72a80c2a0e41e8937d3586f6d71b2029194448ca54e7fe1278",
       "hash": "blake3",
       "path": "kubectl",
       "providers": [
         {
           "type": "http",
-          "url": "https://dl.k8s.io/release/v1.34.2/bin/linux/arm64/kubectl"
+          "url": "https://dl.k8s.io/release/v1.36.3/bin/linux/arm64/kubectl"
         }
       ],
-      "size": 58130616
+      "size": 55640226
     },
     "linux-x86_64": {
-      "digest": "6e0155179f71e23f6dca4e2256661b856841798e1c8db668416d1e5b87e40778",
+      "digest": "c3530650f7d0c8652634864db0b3a5a83dfb807387f33ebd2c5e36f89ac37588",
       "hash": "blake3",
       "path": "kubectl",
       "providers": [
         {
           "type": "http",
-          "url": "https://dl.k8s.io/release/v1.34.2/bin/linux/amd64/kubectl"
+          "url": "https://dl.k8s.io/release/v1.36.3/bin/linux/amd64/kubectl"
         }
       ],
-      "size": 60559544
+      "size": 59556002
     }
   }
 }

--- a/tools/dotslash/config/mise.json
+++ b/tools/dotslash/config/mise.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 79740500
+        "uncompressed_size": 91850257
       },
       "linux-x86_64": {
-        "uncompressed_size": 89569110
+        "uncompressed_size": 95289540
       }
     }
   },
   "name": "mise",
   "platforms": {
     "linux-aarch64": {
-      "digest": "34cd8e4dde34fbb1e63675210327048760d60955fdc39413939fc0a6f0a461b3",
+      "digest": "865af5460fc693277d5f02741df12981148cf3f6832d53ee7dbd73a04a8fa9f7",
       "format": "tar.xz",
       "hash": "blake3",
       "path": "mise/bin/mise",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/jdx/mise/releases/download/v2026.5.15/mise-v2026.5.15-linux-arm64-musl.tar.xz"
+          "url": "https://github.com/jdx/mise/releases/download/v2026.8.2/mise-v2026.8.2-linux-arm64-musl.tar.xz"
         }
       ],
-      "size": 17872456
+      "size": 20764264
     },
     "linux-x86_64": {
-      "digest": "73ea730e1a97f36f47b31a3ba8011818d7b35e9315bfe192ec95caedf86fe530",
+      "digest": "e71244483dcc1fecceed47f7443973c8546fc0769d98abf47b4c7602e06b9ae4",
       "format": "tar.xz",
       "hash": "blake3",
       "path": "mise/bin/mise",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/jdx/mise/releases/download/v2026.5.15/mise-v2026.5.15-linux-x64-musl.tar.xz"
+          "url": "https://github.com/jdx/mise/releases/download/v2026.8.2/mise-v2026.8.2-linux-x64-musl.tar.xz"
         }
       ],
-      "size": 20011732
+      "size": 20426324
     }
   }
 }

--- a/tools/dotslash/config/nu.json
+++ b/tools/dotslash/config/nu.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 257670265
+        "uncompressed_size": 264751489
       },
       "linux-x86_64": {
-        "uncompressed_size": 264646129
+        "uncompressed_size": 271714121
       }
     }
   },
   "name": "nu",
   "platforms": {
     "linux-aarch64": {
-      "digest": "d335056a4769607e52f0fee5b014186724b0805da66578dc39533ea00293b6d8",
+      "digest": "82b658ab5ac046a482fa6686a4958eb18b02f4bdbe63ee277a6433a6212b5ac6",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "nu-0.113.0-aarch64-unknown-linux-musl/nu",
+      "path": "nu-0.114.1-aarch64-unknown-linux-musl/nu",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/nushell/nushell/releases/download/0.113.0/nu-0.113.0-aarch64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/nushell/nushell/releases/download/0.114.1/nu-0.114.1-aarch64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 79156084
+      "size": 81702773
     },
     "linux-x86_64": {
-      "digest": "f4b19a5dba51fc67d2629174d741c36f2b748d07c08715c2e761da5e52be2539",
+      "digest": "46f918444e2f4a1bd88180c7d811add5f41592294ae0b56e2096a7be56130b40",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "nu-0.113.0-x86_64-unknown-linux-musl/nu",
+      "path": "nu-0.114.1-x86_64-unknown-linux-musl/nu",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/nushell/nushell/releases/download/0.113.0/nu-0.113.0-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/nushell/nushell/releases/download/0.114.1/nu-0.114.1-x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 82299419
+      "size": 84915650
     }
   }
 }

--- a/tools/dotslash/config/procs.json
+++ b/tools/dotslash/config/procs.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 5920408
+        "uncompressed_size": 6167592
       },
       "linux-x86_64": {
-        "uncompressed_size": 6701640
+        "uncompressed_size": 6811024
       }
     }
   },
   "name": "procs",
   "platforms": {
     "linux-aarch64": {
-      "digest": "13a062387d616d390678fc7af84e4637bb5cfe4a36f4580b0a469716231dde29",
+      "digest": "4291b722c9b4e771a93c3d41b5a2eb0487a571f698ef53af599e8ac9cd8a32f2",
       "format": "zip",
       "hash": "blake3",
       "path": "procs",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/dalance/procs/releases/download/v0.14.10/procs-v0.14.10-aarch64-linux.zip"
+          "url": "https://github.com/dalance/procs/releases/download/v0.14.12/procs-v0.14.12-aarch64-linux.zip"
         }
       ],
-      "size": 2282059
+      "size": 2400955
     },
     "linux-x86_64": {
-      "digest": "9433cce7a903a8d07b85c3d9b9520d699759b4dedc00d5d1123b348355682e15",
+      "digest": "ebf3bb6d0fb4d7c4ed56c9e93f96fac14e03491f27cf75ff516ac3687739e978",
       "format": "zip",
       "hash": "blake3",
       "path": "procs",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/dalance/procs/releases/download/v0.14.10/procs-v0.14.10-x86_64-linux.zip"
+          "url": "https://github.com/dalance/procs/releases/download/v0.14.12/procs-v0.14.12-x86_64-linux.zip"
         }
       ],
-      "size": 2483155
+      "size": 2565746
     }
   }
 }

--- a/tools/dotslash/config/rg.json
+++ b/tools/dotslash/config/rg.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 5597265
+        "uncompressed_size": 4884106
       },
       "linux-x86_64": {
-        "uncompressed_size": 6961825
+        "uncompressed_size": 5786018
       }
     }
   },
   "name": "rg",
   "platforms": {
     "linux-aarch64": {
-      "digest": "0b670b8fa0a3df2762af2fc82cc4932f684ca4c02dbd1260d4f3133fd4b2a515",
+      "digest": "37760abe1931486fb78ce2fab4b443e86a4f99014e8b9283bca8a60e3ce130ab",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "ripgrep-14.1.1-aarch64-unknown-linux-gnu/rg",
+      "path": "ripgrep-15.2.0-aarch64-unknown-linux-gnu/rg",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz"
+          "url": "https://github.com/BurntSushi/ripgrep/releases/download/15.2.0/ripgrep-15.2.0-aarch64-unknown-linux-gnu.tar.gz"
         }
       ],
-      "size": 2047405
+      "size": 1854661
     },
     "linux-x86_64": {
-      "digest": "f73cca4e54d78c31f832c7f6e2c0b4db8b04fa3eaa747915727d570893dbee76",
+      "digest": "85bc9b662e1868a010691ae699ac4fb7c87f79fa9075a0efa14478164aafd4e7",
       "format": "tar.gz",
       "hash": "blake3",
-      "path": "ripgrep-14.1.1-x86_64-unknown-linux-musl/rg",
+      "path": "ripgrep-15.2.0-x86_64-unknown-linux-musl/rg",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/BurntSushi/ripgrep/releases/download/15.2.0/ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 2566310
+      "size": 2265718
     }
   }
 }

--- a/tools/dotslash/config/rtk.json
+++ b/tools/dotslash/config/rtk.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 8478640
+        "uncompressed_size": 8742032
       },
       "linux-x86_64": {
-        "uncompressed_size": 10026176
+        "uncompressed_size": 10326432
       }
     }
   },
   "name": "rtk",
   "platforms": {
     "linux-aarch64": {
-      "digest": "75d9226191363426ba7233510280c182a843d2f72aa061e040ae70132a2d1f0d",
+      "digest": "d30eacfa497f34e2db4eab253af87f5dd61c6e8596efe06954c5adfd924b77c7",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "rtk",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/rtk-ai/rtk/releases/download/v0.42.0/rtk-aarch64-unknown-linux-gnu.tar.gz"
+          "url": "https://github.com/rtk-ai/rtk/releases/download/v0.45.0/rtk-aarch64-unknown-linux-gnu.tar.gz"
         }
       ],
-      "size": 4079178
+      "size": 4172388
     },
     "linux-x86_64": {
-      "digest": "d8897324f523fd0ef13cac418ebdb460c7f1da70ed2458ce5881bf34cd34f8f5",
+      "digest": "dbb04ceb25983f2fc457418bb032951b862d4e2b737619a715e54e52a4d2aca9",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "rtk",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/rtk-ai/rtk/releases/download/v0.42.0/rtk-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/rtk-ai/rtk/releases/download/v0.45.0/rtk-x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 4444925
+      "size": 4546484
     }
   }
 }

--- a/tools/dotslash/config/sk.json
+++ b/tools/dotslash/config/sk.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 4696562
+        "uncompressed_size": 7040108
       },
       "linux-x86_64": {
-        "uncompressed_size": 5692490
+        "uncompressed_size": 9608900
       }
     }
   },
   "name": "sk",
   "platforms": {
     "linux-aarch64": {
-      "digest": "d04ef2c935d28e5375949d385e788ed976d3758eee027b6f0192942594206cae",
+      "digest": "d8a9e902bc57bf272a23886529230459a135b2382e93a3e4ae564c482ff73653",
       "format": "tar.xz",
       "hash": "blake3",
       "path": "skim-aarch64-unknown-linux-musl/sk",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/skim-rs/skim/releases/download/v4.7.0/skim-aarch64-unknown-linux-musl.tar.xz"
+          "url": "https://github.com/skim-rs/skim/releases/download/v5.6.2/skim-aarch64-unknown-linux-musl.tar.xz"
         }
       ],
-      "size": 1454288
+      "size": 2013632
     },
     "linux-x86_64": {
-      "digest": "9957ef0436bf18d85591f5f7998a253f2688279cf5f323a48914194b618775b1",
+      "digest": "c52c6ca83dc9deb135e0bc465ba8b369e7f32547d550ae0ca840fb67d70e1741",
       "format": "tar.xz",
       "hash": "blake3",
       "path": "skim-x86_64-unknown-linux-musl/sk",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/skim-rs/skim/releases/download/v4.7.0/skim-x86_64-unknown-linux-musl.tar.xz"
+          "url": "https://github.com/skim-rs/skim/releases/download/v5.6.2/skim-x86_64-unknown-linux-musl.tar.xz"
         }
       ],
-      "size": 1733232
+      "size": 2636720
     }
   }
 }

--- a/tools/dotslash/config/starship.json
+++ b/tools/dotslash/config/starship.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 10241792
+        "uncompressed_size": 10516352
       },
       "linux-x86_64": {
-        "uncompressed_size": 12147096
+        "uncompressed_size": 12491224
       }
     }
   },
   "name": "starship",
   "platforms": {
     "linux-aarch64": {
-      "digest": "381f67a78f3d72a7db83063bf06476e112db3ee31a070fc6b06b2cffaaf59994",
+      "digest": "b3ed65e9064ef992f87e5ed9bed102ecb46299299478f8b90193d81b2b155780",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "starship",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/starship/starship/releases/download/v1.25.1/starship-aarch64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/starship/starship/releases/download/v1.26.0/starship-aarch64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 4652881
+      "size": 4784551
     },
     "linux-x86_64": {
-      "digest": "e62bacfa45b92e0cc58f26c77994bc76eb9db08199f26a1f221107d1cf430b8c",
+      "digest": "e12fcee8ffeb54f99501f7cfce780ae25438487d5a01d7181b63c198ea862258",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "starship",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/starship/starship/releases/download/v1.25.1/starship-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/starship/starship/releases/download/v1.26.0/starship-x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 5046130
+      "size": 5191063
     }
   }
 }

--- a/tools/dotslash/config/staticcheck.json
+++ b/tools/dotslash/config/staticcheck.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 14532121
+        "uncompressed_size": 15653537
       },
       "linux-x86_64": {
-        "uncompressed_size": 15274595
+        "uncompressed_size": 16897950
       }
     }
   },
   "name": "staticcheck",
   "platforms": {
     "linux-aarch64": {
-      "digest": "570824c498b48d6c7da84b83f6511acd2911d46bd1dbb7cfb6077453bee77303",
+      "digest": "eab06475a9592c57cdcd6c0ef0c8381c27100fc45511987cd14fc66b7c3721fb",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "staticcheck/staticcheck",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/dominikh/go-tools/releases/download/2025.1.1/staticcheck_linux_arm64.tar.gz"
+          "url": "https://github.com/dominikh/go-tools/releases/download/2026.1/staticcheck_linux_arm64.tar.gz"
         }
       ],
-      "size": 7690871
+      "size": 8192439
     },
     "linux-x86_64": {
-      "digest": "9dac6a08af4ac9e836c86783c9e488d86b0bfb37622d063eb25e380c746171b3",
+      "digest": "d4e262911a96c82972e987fbc912758c95ea82db17bb3c949f2202e94cad203d",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "staticcheck/staticcheck",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/dominikh/go-tools/releases/download/2025.1.1/staticcheck_linux_amd64.tar.gz"
+          "url": "https://github.com/dominikh/go-tools/releases/download/2026.1/staticcheck_linux_amd64.tar.gz"
         }
       ],
-      "size": 8275442
+      "size": 9017497
     }
   }
 }

--- a/tools/dotslash/config/uv.json
+++ b/tools/dotslash/config/uv.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 47645584
+        "uncompressed_size": 47705360
       },
       "linux-x86_64": {
-        "uncompressed_size": 55166304
+        "uncompressed_size": 56483776
       }
     }
   },
   "name": "uv",
   "platforms": {
     "linux-aarch64": {
-      "digest": "43527cd462e0358c335fbddc93373432cad33a336095cf72089b3ae16f0b68e3",
+      "digest": "761f72553d6c2dd15ac103231919bf724ec1f97477cd929490c09cb8fffa29f4",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "uv-aarch64-unknown-linux-gnu/uv",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/astral-sh/uv/releases/download/0.9.28/uv-aarch64-unknown-linux-gnu.tar.gz"
+          "url": "https://github.com/astral-sh/uv/releases/download/0.12.2/uv-aarch64-unknown-linux-gnu.tar.gz"
         }
       ],
-      "size": 20863191
+      "size": 20441968
     },
     "linux-x86_64": {
-      "digest": "00fc71b55282f8135706976975f356fec2f1306d9cecd7c6fe6fde33cc45a727",
+      "digest": "49b4174b742f8c1dc2c1901bf12989c6a8e9755207d6f2e503ad960e386c4ac2",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "uv-x86_64-unknown-linux-musl/uv",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/astral-sh/uv/releases/download/0.9.28/uv-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/astral-sh/uv/releases/download/0.12.2/uv-x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 22361559
+      "size": 21883005
     }
   }
 }

--- a/tools/dotslash/config/uvx.json
+++ b/tools/dotslash/config/uvx.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 47645584
+        "uncompressed_size": 47705360
       },
       "linux-x86_64": {
-        "uncompressed_size": 55166304
+        "uncompressed_size": 56483776
       }
     }
   },
   "name": "uvx",
   "platforms": {
     "linux-aarch64": {
-      "digest": "43527cd462e0358c335fbddc93373432cad33a336095cf72089b3ae16f0b68e3",
+      "digest": "761f72553d6c2dd15ac103231919bf724ec1f97477cd929490c09cb8fffa29f4",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "uv-aarch64-unknown-linux-gnu/uvx",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/astral-sh/uv/releases/download/0.9.28/uv-aarch64-unknown-linux-gnu.tar.gz"
+          "url": "https://github.com/astral-sh/uv/releases/download/0.12.2/uv-aarch64-unknown-linux-gnu.tar.gz"
         }
       ],
-      "size": 20863191
+      "size": 20441968
     },
     "linux-x86_64": {
-      "digest": "00fc71b55282f8135706976975f356fec2f1306d9cecd7c6fe6fde33cc45a727",
+      "digest": "49b4174b742f8c1dc2c1901bf12989c6a8e9755207d6f2e503ad960e386c4ac2",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "uv-x86_64-unknown-linux-musl/uvx",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/astral-sh/uv/releases/download/0.9.28/uv-x86_64-unknown-linux-musl.tar.gz"
+          "url": "https://github.com/astral-sh/uv/releases/download/0.12.2/uv-x86_64-unknown-linux-musl.tar.gz"
         }
       ],
-      "size": 22361559
+      "size": 21883005
     }
   }
 }

--- a/tools/dotslash/config/watchexec.json
+++ b/tools/dotslash/config/watchexec.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 8050178
+        "uncompressed_size": 8119826
       },
       "linux-x86_64": {
-        "uncompressed_size": 9402538
+        "uncompressed_size": 9451706
       }
     }
   },
   "name": "watchexec",
   "platforms": {
     "linux-aarch64": {
-      "digest": "1eb8779f1d300ab5475f19a0c5084a641af38dbeb6fa86b2a0ccb77d69c8cdf6",
+      "digest": "0a4b668e0fb9a63cd32caaf0cda7d252c408e905dbf71373bfb1f575e38a6e3c",
       "format": "tar.xz",
       "hash": "blake3",
-      "path": "watchexec-2.4.3-aarch64-unknown-linux-musl/watchexec",
+      "path": "watchexec-2.5.1-aarch64-unknown-linux-musl/watchexec",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/watchexec/watchexec/releases/download/v2.4.3/watchexec-2.4.3-aarch64-unknown-linux-musl.tar.xz"
+          "url": "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-aarch64-unknown-linux-musl.tar.xz"
         }
       ],
-      "size": 2460472
+      "size": 2481320
     },
     "linux-x86_64": {
-      "digest": "46cd1a654dc5de3a0789a4717961e836986504da7157ce25ff2e831402644532",
+      "digest": "5c204127309d70ac24f514e6b7fefd02cb8db3be97e429dd1bcab0d338bb60b7",
       "format": "tar.xz",
       "hash": "blake3",
-      "path": "watchexec-2.4.3-x86_64-unknown-linux-musl/watchexec",
+      "path": "watchexec-2.5.1-x86_64-unknown-linux-musl/watchexec",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/watchexec/watchexec/releases/download/v2.4.3/watchexec-2.4.3-x86_64-unknown-linux-musl.tar.xz"
+          "url": "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-unknown-linux-musl.tar.xz"
         }
       ],
-      "size": 2892712
+      "size": 2910140
     }
   }
 }

--- a/tools/dotslash/config/workspaces-tool-helper.json
+++ b/tools/dotslash/config/workspaces-tool-helper.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 24408162
+        "uncompressed_size": 18269746
       },
       "linux-x86_64": {
-        "uncompressed_size": 24408162
+        "uncompressed_size": 18269746
       }
     }
   },
   "name": "workspaces-tool-helper",
   "platforms": {
     "linux-aarch64": {
-      "digest": "68d4b57464984b7c1407e975b128f3bf2b51cdd1a49bd114eeaa427ec912daed",
+      "digest": "391bed45bd601a60cb338594f8e9c4ad5b2f809578402acb96097d81119252be",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "workspaces-tool-helper-linux-arm64",
       "providers": [
         {
           "type": "http",
-          "url": "https://binaries.ddbuild.io/dd-source/workspaces-tool-helper/v0.3.1/workspaces-tool-helper-tar.tar.gz"
+          "url": "https://binaries.ddbuild.io/dd-source/workspaces-tool-helper/v0.3.2/workspaces-tool-helper-tar.tar.gz"
         }
       ],
-      "size": 12913279
+      "size": 9633622
     },
     "linux-x86_64": {
-      "digest": "68d4b57464984b7c1407e975b128f3bf2b51cdd1a49bd114eeaa427ec912daed",
+      "digest": "391bed45bd601a60cb338594f8e9c4ad5b2f809578402acb96097d81119252be",
       "format": "tar.gz",
       "hash": "blake3",
       "path": "workspaces-tool-helper-linux-amd64",
       "providers": [
         {
           "type": "http",
-          "url": "https://binaries.ddbuild.io/dd-source/workspaces-tool-helper/v0.3.1/workspaces-tool-helper-tar.tar.gz"
+          "url": "https://binaries.ddbuild.io/dd-source/workspaces-tool-helper/v0.3.2/workspaces-tool-helper-tar.tar.gz"
         }
       ],
-      "size": 12913279
+      "size": 9633622
     }
   }
 }

--- a/tools/dotslash/config/ya.json
+++ b/tools/dotslash/config/ya.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 14097845
+        "uncompressed_size": 22074322
       },
       "linux-x86_64": {
-        "uncompressed_size": 17236957
+        "uncompressed_size": 26634810
       }
     }
   },
   "name": "ya",
   "platforms": {
     "linux-aarch64": {
-      "digest": "dc28ee0843e7efb6b152945d4a43d48b063318d6720d6fad438a8fa88ede0558",
+      "digest": "98af801ada40864013efc31a15568d1b2a90e06354c228a2a75206973e012800",
       "format": "zip",
       "hash": "blake3",
       "path": "yazi-aarch64-unknown-linux-musl/ya",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/sxyazi/yazi/releases/download/v0.3.3/yazi-aarch64-unknown-linux-musl.zip"
+          "url": "https://github.com/sxyazi/yazi/releases/download/v26.5.6/yazi-aarch64-unknown-linux-musl.zip"
         }
       ],
-      "size": 6775212
+      "size": 10570424
     },
     "linux-x86_64": {
-      "digest": "d037cdced2bb8cfdf5530e6b5d0f3b2021a0fce5df6cd5360d3475f953a37862",
+      "digest": "4353f33bcbebad9698e3bc922bc66a28074c738bfa9465f6aa485bd950c732ef",
       "format": "zip",
       "hash": "blake3",
       "path": "yazi-x86_64-unknown-linux-musl/ya",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/sxyazi/yazi/releases/download/v0.3.3/yazi-x86_64-unknown-linux-musl.zip"
+          "url": "https://github.com/sxyazi/yazi/releases/download/v26.5.6/yazi-x86_64-unknown-linux-musl.zip"
         }
       ],
-      "size": 7372800
+      "size": 11394377
     }
   }
 }

--- a/tools/dotslash/config/yazi.json
+++ b/tools/dotslash/config/yazi.json
@@ -2,40 +2,40 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 11623208
+        "uncompressed_size": 20445643
       },
       "linux-x86_64": {
-        "uncompressed_size": 14089936
+        "uncompressed_size": 24727003
       }
     }
   },
   "name": "yazi",
   "platforms": {
     "linux-aarch64": {
-      "digest": "dc28ee0843e7efb6b152945d4a43d48b063318d6720d6fad438a8fa88ede0558",
+      "digest": "98af801ada40864013efc31a15568d1b2a90e06354c228a2a75206973e012800",
       "format": "zip",
       "hash": "blake3",
       "path": "yazi-aarch64-unknown-linux-musl/yazi",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/sxyazi/yazi/releases/download/v0.3.3/yazi-aarch64-unknown-linux-musl.zip"
+          "url": "https://github.com/sxyazi/yazi/releases/download/v26.5.6/yazi-aarch64-unknown-linux-musl.zip"
         }
       ],
-      "size": 6775212
+      "size": 10570424
     },
     "linux-x86_64": {
-      "digest": "d037cdced2bb8cfdf5530e6b5d0f3b2021a0fce5df6cd5360d3475f953a37862",
+      "digest": "4353f33bcbebad9698e3bc922bc66a28074c738bfa9465f6aa485bd950c732ef",
       "format": "zip",
       "hash": "blake3",
       "path": "yazi-x86_64-unknown-linux-musl/yazi",
       "providers": [
         {
           "type": "http",
-          "url": "https://github.com/sxyazi/yazi/releases/download/v0.3.3/yazi-x86_64-unknown-linux-musl.zip"
+          "url": "https://github.com/sxyazi/yazi/releases/download/v26.5.6/yazi-x86_64-unknown-linux-musl.zip"
         }
       ],
-      "size": 7372800
+      "size": 11394377
     }
   }
 }


### PR DESCRIPTION
## Summary

- update 37 DotSlash-managed tools to their latest available releases
- refresh BLAKE3 digests, compressed sizes, uncompressed sizes, and archive paths
- keep Delve at 1.26.3 because newer releases do not publish the required Linux binary assets

## Impact

Developer-environment images will fetch current tool releases while retaining DotSlash integrity verification for both Linux architectures.

## Validation

- `dda run tools check` — all 45 schemas validated
- integrity scan processed all 90 platform artifacts; a transient GitHub disconnect on Codex ARM64 was retried directly, with both Codex artifacts' BLAKE3 digests, sizes, uncompressed sizes, and `bin/codex` paths verified
- generated the Linux ARM64 `jq` DotSlash launcher and successfully executed `jq-1.8.2` plus a functional assertion
- `git diff --check`