### PR TITLE
Bump Pulumi CLI to 3.255.0

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -30,7 +30,7 @@ variable "versions" {
     MACOSX_SDK_VERSION       = "14.0"
     OSXCROSS_COMMIT          = "e6ab3fa7423f9235ce9ed6381d6d3af191b46b59"
     AIX_CROSS_VERSION        = "gcc13.4.0-aix7.3-2"
-    PULUMI_VERSION         = "3.207.0"
+    PULUMI_VERSION         = "3.253.0"
     DD_OCTO_STS_VERSION    = "v1.9.3"
     MOLD_VERSION           = "2.40.4"
   }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -30,7 +30,7 @@ variable "versions" {
     MACOSX_SDK_VERSION       = "14.0"
     OSXCROSS_COMMIT          = "e6ab3fa7423f9235ce9ed6381d6d3af191b46b59"
     AIX_CROSS_VERSION        = "gcc13.4.0-aix7.3-2"
-    PULUMI_VERSION         = "3.253.0"
+    PULUMI_VERSION         = "3.255.0"
     DD_OCTO_STS_VERSION    = "v1.9.3"
     MOLD_VERSION           = "2.40.4"
   }


### PR DESCRIPTION
### What does this PR do?
Bumps PULUMI_VERSION from 3.207.0 to 3.255.0.

### Motivation
Needed for onError resource hook support (requires Pulumi >= 3.219.0), used by a datadog-agent e2e test fix for WINA-2095. PULUMI_SHA256 checksums the version-agnostic get-pulumi.sh installer script, not the Pulumi release itself, so it's unchanged.

### Describe how you validated your changes
N/A - version bump only.