### PR TITLE
[SINT-5606] Install Datadog CA Certs in the agent-deploy Image

### DIFF
--- a/.gitlab/setup.yml
+++ b/.gitlab/setup.yml
@@ -3,7 +3,7 @@ lint_dockerfiles:
   tags: ["arch:amd64"]
   stage: setup
   needs: []
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/images:v26997867-ebc48a76
+  image: registry.ddbuild.io/ci/images:v129830789-4ab6358-1.2.10
   script:
     - hadolint dev-envs/linux/Dockerfile
 

--- a/agent-deploy/Dockerfile
+++ b/agent-deploy/Dockerfile
@@ -221,6 +221,12 @@ COPY --from=dd_pkg /usr/local/bin/dd-pkg /usr/local/bin/dd-pkg
 # Install dd-octo-sts
 COPY --from=registry.ddbuild.io/dd-octo-sts:v1.9.3@sha256:f8412df42db2e1879182c820ea4ef600ab4375c5b696a24151c7f0dd931ffee6 /usr/local/bin/dd-octo-sts /usr/local/bin/dd-octo-sts
 
+# Install Datadog private CA certificates
+# (to be able to use services via Fabric)
+COPY --from=registry.ddbuild.io/images/datadog-ca-certs:standard /certs/ /usr/local/share/ca-certificates/
+RUN chmod -R o-w /usr/local/share/ca-certificates \
+    && update-ca-certificates
+
 # Entrypoint
 COPY ./agent-deploy/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Required to be able to reach out to internal services via Fabric DNS (needed in https://github.com/DataDog/agent-release-management/pull/478)

Note that another solution would be to base the image on a Golden Base Image (GBI) such as `registry.ddbuild.io/images/base/gbi-ubuntu_2604:release`, however there is a larger risk of regression due to the change of OS version (from Ubuntu 18 to Ubuntu 26).