### PR TITLE
Fail fast when MsGo has not published the target Go release yet

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -36,6 +36,14 @@ jobs:
       id-token: write # needed for dd-octo-sts token exchange
 
     steps:
+      - name: Check MsGo has published the release
+        run: |
+          RESPONSE=$(curl -sL "https://aka.ms/golang/release/latest/go${{ inputs.go_version }}-1.linux-amd64.tar.gz.sha256")
+          if ! echo "$RESPONSE" | grep -qE '^[0-9a-f]{64}'; then
+            echo "MsGo has not published go${{ inputs.go_version }} yet. Check: https://github.com/microsoft/go/releases"
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## What does this PR do?
Adds a curl check as the first step of the go-update workflow that verifies MsGo has published the target Go version before running any setup.

## Motivation
When MsGo hasn't published a release yet, the workflow currently fails inside `dda run update go --check-archive`, after checkout, Python setup, token exchange, and dda install have already run. The new step fails immediately
with a clear message and a link to the MsGo releases page.

## Describe how you validated your changes
Tested the check locally against:
- `1.26.5` (published) — passes silently
- `1.26.6` (not yet published) — fails with clear message
- `9.99.99` (fake version) — fails with clear message
- `notaversion` (malformed) — fails with clear message

## Additional Notes
The `-1` suffix is MsGo's default patch number (`msgo_patch=1` in the dda command). Only linux-amd64 is checked since all platforms are published together.