### PR TITLE
[Go-update Workflow] Add run-name to display Go version in workflow runs

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -1,5 +1,8 @@
 name: Open Go Update PR
 
+# TODO: append "on ${{ inputs.target_branches }}" once target_branches input is added
+run-name: "Open Go ${{ inputs.go_version }} Update PR"
+
 on:
   workflow_dispatch:
     inputs:
@@ -7,6 +10,11 @@ on:
         description: 'Go version'
         required: true
         type: string
+      # TODO: uncomment when multi-branch support is implemented
+      # target_branches:
+      #   description: 'Branches to update, e.g. "main, 7.83.x, 7.82.x"'
+      #   required: true
+      #   type: string
       open_pr:
         description: 'Whether to open a PR'
         required: false


### PR DESCRIPTION
## What does this PR do?
Adds a `run-name` to the go-update workflow so each run is labelled
"Open Go X.X.X Update PR" instead of the generic workflow name.

## Motivation
Currently all runs in the Open Go Update PR workflow show the same name
"Open Go Update PR", with no indication of which Go version was targeted.

## Additional Notes
`run-name` is an official GitHub Actions field:
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#run-name

Leaves commented-out `target_branches` input and the "on ${{ inputs.target_branches }}"
suffix as a reminder for the upcoming multi-branch support PR.