### PR TITLE
[Backport 7.83.x] [Go-update Workflow] Add run-name to display Go version in workflow runs

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -1,5 +1,8 @@
 name: Open Go Update PR
 
+# TODO: append "on ${{ inputs.target_branches }}" once target_branches input is added
+run-name: "Open Go ${{ inputs.go_version }} Update PR"
+
 on:
   workflow_dispatch:
     inputs:
@@ -7,6 +10,11 @@ on:
         description: 'Go version'
         required: true
         type: string
+      # TODO: uncomment when multi-branch support is implemented
+      # target_branches:
+      #   description: 'Branches to update, e.g. "main, 7.83.x, 7.82.x"'
+      #   required: true
+      #   type: string
       open_pr:
         description: 'Whether to open a PR'
         required: false


### PR DESCRIPTION
Backport of #1305 to 7.83.x.

## What does this PR do?
Adds `run-name` to `.github/workflows/go-update.yml` so individual workflow runs show the Go version being updated instead of the generic workflow name.

## Motivation
Makes it easier to identify runs in the GitHub Actions UI when multiple go-update runs are queued.

## Describe how you validated your changes
Cherry-picked from #1305 which was validated on main.