### PR TITLE
Add post-merge job to update datadog-agent with final image tag

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -26,7 +26,7 @@ on:
         type: boolean
         default: false
       branch:
-        description: 'Git branch to use (defaults to "gobot/go-update-<go_version>")'
+        description: 'Git branch to use (defaults to "automation/go-update-<go_version>-<target_branch>")'
         required: false
         type: string
         default: ''
@@ -34,7 +34,7 @@ on:
 permissions: {}
 
 env:
-  BRANCH_NAME: ${{ inputs.branch || format('gobot/go-update-{0}', inputs.go_version) }}
+  BRANCH_NAME: ${{ inputs.branch || format('automation/go-update-{0}-{1}', inputs.go_version, github.ref_name) }}
 
 jobs:
   open-go-update-pr:

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -88,9 +88,10 @@ push_to_datadog_agent_go_update_post_merge:
     - pip install "dda==${DDA_VERSION}"
     - dda -v self dep sync -f legacy-build
     - export GITHUB_TOKEN=$(cat token.txt)
-    - PR_NUMBER=$(curl -sfH "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/DataDog/datadog-agent-buildimages/commits/${CI_COMMIT_SHA}/pulls" | jq -r --arg sha "$CI_COMMIT_SHA" '.[] | select(.merge_commit_sha == $sha) | .number' | head -1)
-    - if [[ -z "$PR_NUMBER" ]]; then echo "No merged PR found for commit $CI_COMMIT_SHA" >&2; exit 1; fi
-    - HEAD_REF=$(curl -sfH "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/DataDog/datadog-agent-buildimages/pulls/${PR_NUMBER}" | jq -r '.head.ref')
+    # Look up the buildimages PR that produced this merge commit and read its source branch.
+    - HEAD_REF=$(curl -sfH "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/DataDog/datadog-agent-buildimages/commits/${CI_COMMIT_SHA}/pulls" | jq -r --arg sha "$CI_COMMIT_SHA" '.[] | select(.merge_commit_sha == $sha) | .head.ref' | head -1)
+    - if [[ -z "$HEAD_REF" ]]; then echo "No merged PR found for commit $CI_COMMIT_SHA" >&2; exit 1; fi
+    # The datadog-agent branch mirrors the buildimages branch with a "buildimages/" prefix.
     - BRANCH="buildimages/${HEAD_REF}"
     - dda run update agent-build-images "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" "$BRANCH" --ref "$CI_COMMIT_BRANCH"
   after_script:

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -59,7 +59,7 @@ push_to_datadog_agent_post_merge:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
-    - if: $CI_COMMIT_MESSAGE !~ /^\[push_to_datadog_agent\]/
+    - if: $CI_COMMIT_MESSAGE !~ /\[push_to_datadog_agent\]/
       when: never
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       when: always

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -54,7 +54,7 @@ trigger_tests:
     project: DataDog/datadog-agent
     strategy: depend
 
-push_to_datadog_agent_go_update_post_merge:
+update_datadog_agent_pr_with_final_images:
   stage: test
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -59,7 +59,9 @@ push_to_datadog_agent_go_update_post_merge:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
-    - if: $CI_COMMIT_MESSAGE !~ /\[push_to_datadog_agent_go_update\]/
+    - if: $CI_COMMIT_AUTHOR !~ /^dd-octo-sts\[bot\]/
+      when: never
+    - if: $CI_COMMIT_TITLE !~ /^Update Go version to [0-9]+\.[0-9]+\.[0-9]+$/
       when: never
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       when: always
@@ -86,7 +88,10 @@ push_to_datadog_agent_go_update_post_merge:
     - pip install "dda==${DDA_VERSION}"
     - dda -v self dep sync -f legacy-build
     - export GITHUB_TOKEN=$(cat token.txt)
-    - BRANCH=$(printf '%s' "$CI_COMMIT_MESSAGE" | grep -oP '(?<=\[da-branch:)[^\]]+' | head -1)
+    - PR_NUMBER=$(curl -sfH "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/DataDog/datadog-agent-buildimages/commits/${CI_COMMIT_SHA}/pulls" | jq -r --arg sha "$CI_COMMIT_SHA" '.[] | select(.merge_commit_sha == $sha) | .number' | head -1)
+    - if [[ -z "$PR_NUMBER" ]]; then echo "No merged PR found for commit $CI_COMMIT_SHA" >&2; exit 1; fi
+    - HEAD_REF=$(curl -sfH "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/DataDog/datadog-agent-buildimages/pulls/${PR_NUMBER}" | jq -r '.head.ref')
+    - BRANCH="buildimages/${HEAD_REF}"
     - dda run update agent-build-images "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" "$BRANCH" --ref "$CI_COMMIT_BRANCH"
   after_script:
     - dd-octo-sts revoke -t $(cat token.txt)

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -68,7 +68,6 @@ push_to_datadog_agent_post_merge:
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$ECR_TEST_ONLY:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
   dependencies: []
-  needs: [build_multiarch_linux]
   id_tokens:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -90,6 +90,8 @@ push_to_datadog_agent_post_merge:
   after_script:
     - dd-octo-sts revoke -t $(cat token.txt)
 
+# Creates a draft PR in datadog-agent with test-only image tags before buildimages merges.
+# Particularly useful for minor Go updates which take longer to merge.
 update_datadog_agent_pr_with_test_images:
   stage: test
   rules:

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -54,6 +54,43 @@ trigger_tests:
     project: DataDog/datadog-agent
     strategy: depend
 
+push_to_datadog_agent_post_merge:
+  stage: test
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: never
+    - if: $CI_COMMIT_MESSAGE !~ /^\[push_to_datadog_agent\]/
+      when: never
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      when: always
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
+      when: always
+  tags: ["arch:amd64"]
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$ECR_TEST_ONLY:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+  dependencies: []
+  needs: [build_multiarch_linux]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
+  before_script:
+    - dd-octo-sts version
+    - dd-octo-sts token --scope DataDog/datadog-agent --policy self.buildimages-ci.push-to-datadog-agent > token.txt
+  script:
+    - source /root/.bashrc
+    - set -o pipefail
+    - >
+      for line in $(cat go.env); do
+        export $line
+      done
+    - export DDA_VERSION=$(grep DDA_VERSION dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')
+    - pip install "dda==${DDA_VERSION}"
+    - dda -v self dep sync -f legacy-build
+    - export GITHUB_TOKEN=$(cat token.txt)
+    - BRANCH=$(printf '%s' "$CI_COMMIT_MESSAGE" | grep -oP '(?<=\[da-branch:)[^\]]+' | head -1)
+    - dda run update agent-build-images "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}" "$BRANCH" --ref "$CI_COMMIT_BRANCH"
+  after_script:
+    - dd-octo-sts revoke -t $(cat token.txt)
+
 update_datadog_agent_pr_with_test_images:
   stage: test
   rules:

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -61,7 +61,7 @@ push_to_datadog_agent_go_update_post_merge:
       when: never
     - if: $CI_COMMIT_AUTHOR !~ /^dd-octo-sts\[bot\]/
       when: never
-    - if: $CI_COMMIT_TITLE !~ /^Update Go version to [0-9]+\.[0-9]+\.[0-9]+$/
+    - if: $CI_COMMIT_TITLE !~ /^Update Go version to [0-9]+\.[0-9]+\.[0-9]+( \(#[0-9]+\))?$/
       when: never
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       when: always

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -89,7 +89,14 @@ update_datadog_agent_pr_with_final_images:
     - dda -v self dep sync -f legacy-build
     - export GITHUB_TOKEN=$(cat token.txt)
     # Look up the buildimages PR that produced this merge commit and read its source branch.
-    - HEAD_REF=$(curl -sfH "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/DataDog/datadog-agent-buildimages/commits/${CI_COMMIT_SHA}/pulls" | jq -r --arg sha "$CI_COMMIT_SHA" '.[] | select(.merge_commit_sha == $sha) | .head.ref' | head -1) || { echo "GitHub API lookup failed while resolving merged PR for commit $CI_COMMIT_SHA" >&2; exit 1; }
+    - >-
+      HEAD_REF=$(curl
+      -sfH "Authorization: Bearer $GITHUB_TOKEN"
+      -H "Accept: application/vnd.github+json"
+      "https://api.github.com/repos/DataDog/datadog-agent-buildimages/commits/${CI_COMMIT_SHA}/pulls"
+      | jq -r --arg sha "$CI_COMMIT_SHA" '.[] | select(.merge_commit_sha == $sha) | .head.ref'
+      | head -1) ||
+      { echo "GitHub API lookup failed while resolving merged PR for commit $CI_COMMIT_SHA" >&2; exit 1; }
     - if [[ -z "$HEAD_REF" ]]; then echo "No merged PR found for commit $CI_COMMIT_SHA" >&2; exit 1; fi
     # The datadog-agent branch mirrors the buildimages branch with a "buildimages/" prefix.
     - BRANCH="buildimages/${HEAD_REF}"

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -89,7 +89,7 @@ update_datadog_agent_pr_with_final_images:
     - dda -v self dep sync -f legacy-build
     - export GITHUB_TOKEN=$(cat token.txt)
     # Look up the buildimages PR that produced this merge commit and read its source branch.
-    - HEAD_REF=$(curl -sfH "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/DataDog/datadog-agent-buildimages/commits/${CI_COMMIT_SHA}/pulls" | jq -r --arg sha "$CI_COMMIT_SHA" '.[] | select(.merge_commit_sha == $sha) | .head.ref' | head -1)
+    - HEAD_REF=$(curl -sfH "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/DataDog/datadog-agent-buildimages/commits/${CI_COMMIT_SHA}/pulls" | jq -r --arg sha "$CI_COMMIT_SHA" '.[] | select(.merge_commit_sha == $sha) | .head.ref' | head -1) || { echo "GitHub API lookup failed while resolving merged PR for commit $CI_COMMIT_SHA" >&2; exit 1; }
     - if [[ -z "$HEAD_REF" ]]; then echo "No merged PR found for commit $CI_COMMIT_SHA" >&2; exit 1; fi
     # The datadog-agent branch mirrors the buildimages branch with a "buildimages/" prefix.
     - BRANCH="buildimages/${HEAD_REF}"

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -68,6 +68,7 @@ push_to_datadog_agent_post_merge:
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$ECR_TEST_ONLY:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
   dependencies: []
+  needs: [build_multiarch_linux]
   id_tokens:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -54,12 +54,12 @@ trigger_tests:
     project: DataDog/datadog-agent
     strategy: depend
 
-push_to_datadog_agent_post_merge:
+push_to_datadog_agent_go_update_post_merge:
   stage: test
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
-    - if: $CI_COMMIT_MESSAGE !~ /\[push_to_datadog_agent\]/
+    - if: $CI_COMMIT_MESSAGE !~ /\[push_to_datadog_agent_go_update\]/
       when: never
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       when: always


### PR DESCRIPTION
## What does this PR do?
Adds `push_to_datadog_agent_go_update_post_merge`, a GitLab CI job that runs on the buildimages merge commit produced by the automated Go update workflow. It calls `dda run update agent-build-images` with the final image tag (`v{PIPELINE_ID}-{SHORT_COMMIT_SHA}`, e.g. `v112652147-27dacf01`) to update the existing datadog-agent PR.

The job derives the datadog-agent branch by looking up the merged PR's `head.ref` via `GET /repos/DataDog/datadog-agent-buildimages/commits/{sha}/pulls`. Nothing needs to be embedded in the commit message.

## Motivation
The existing pre-merge job (`push_to_datadog_agent_go_update`) runs on the buildimages feature branch and updates the datadog-agent PR with test-only image tags (particularly useful for minor Go updates which take longer to merge). After buildimages merges, the datadog-agent PR had to be updated manually with the final tag. This job automates that step.

## Describe how you validated your changes
- Verified the commit → PR lookup against three merged Go-update PRs (both single-commit and multi-commit squash): #1308, #1182, #1159. All returned the correct original `head.ref` even after the source branch was deleted.
- Pre-merge and post-merge rules now share the same author + title match: `CI_COMMIT_AUTHOR = dd-octo-sts[bot]` and `CI_COMMIT_TITLE =~ /^Update Go version to X.Y.Z$/`. The post-merge title rule additionally allows a (#NNN) suffix because GitHub appends the PR number on squash merge.

## Additional Notes
- The buildimages branch is now `automation/go-update-<version>-<ref_name>` (e.g. `automation/go-update-1.26.7-main`, `automation/go-update-1.26.7-7.83.x`). This avoids collisions when the same Go version is updated on `main` and a release branch simultaneously.
- The post-merge job runs after `build_multiarch_linux` completes, so the linux image is available when the datadog-agent pipeline runs.
- The GitHub API lookup uses the existing `dd-octo-sts` token (scoped to `DataDog/datadog-agent`). Buildimages is public, and GitHub App installation tokens are documented to authenticate GET requests to public repos regardless of scope, giving 5000/hr rate limit. If this turns out to be unreliable in practice, add a second STS token scoped to buildimages.
- Once #1312 lands, this PR needs a small rebase to pick up the pre-merge job rename (`push_to_datadog_agent_go_update` → `update_datadog_agent_pr_with_test_images`).