### PR TITLE
Simplify Go-update trigger and rename push_to_datadog_agent job

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       go_version:
-        description: 'Go version'
+        description: 'Go version (format X.Y.Z, e.g. 1.27.0)'
         required: true
         type: string
       # TODO: uncomment when multi-branch support is implemented
@@ -44,6 +44,13 @@ jobs:
       id-token: write # needed for dd-octo-sts token exchange
 
     steps:
+      - name: Validate go_version
+        run: |
+          if [[ ! "${{ inputs.go_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::go_version must be X.Y.Z (e.g. 1.27.0). Got: '${{ inputs.go_version }}'"
+            exit 1
+          fi
+
       - name: Check MsGo has published the release
         run: |
           RESPONSE=$(curl -sL "https://aka.ms/golang/release/latest/go${{ inputs.go_version }}-1.linux-amd64.tar.gz.sha256")
@@ -84,7 +91,7 @@ jobs:
         if: ${{ inputs.open_pr }}
         with:
           token: ${{ steps.octo-sts.outputs.token }}
-          commit-message: "[push_to_datadog_agent] Update go version to ${{ inputs.go_version }}"
+          commit-message: "Update Go version to ${{ inputs.go_version }}"
           branch: ${{ env.BRANCH_NAME }}
           sign-commits: true
           title: "Update Go version to ${{ inputs.go_version }}"

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -54,10 +54,12 @@ trigger_tests:
     project: DataDog/datadog-agent
     strategy: depend
 
-push_to_datadog_agent:
+update_datadog_agent_pr_with_test_images:
   stage: test
   rules:
-    - if: $CI_COMMIT_MESSAGE !~ /^\[push_to_datadog_agent\]/
+    - if: $CI_COMMIT_AUTHOR !~ /^dd-octo-sts\[bot\]/
+      when: never
+    - if: $CI_COMMIT_TITLE !~ /^Update Go version to [0-9]+\.[0-9]+\.[0-9]+$/
       when: never
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       when: never


### PR DESCRIPTION
## What does this PR do?
Renames the job from `push_to_datadog_agent` to `update_datadog_agent_pr_with_test_images`. Removes the unnecessary `[push_to_datadog_agent]` bracket trigger and matches instead on author (`dd-octo-sts[bot]`) and exact commit title (`^Update Go version to X.Y.Z$`).

## Motivation
The workflow writes two different strings into GitHub's commit-message and PR-title fields:
- `commit-message: "[push_to_datadog_agent] Update go version to 1.26.6"`
- `title: "Update Go version to 1.26.6"`

GitHub squash-merge picks one or the other depending on squash mode, so the resulting subject on main is inconsistent (see validation list below). The bracket-tag rule works today because the job runs on the feature branch before squash, but any future rule that needs to fire post-merge (e.g. #1310) hits the squash-mode divergence. This PR fixes the trigger at the source so the same rule works before and after merge.

## Describe how you validated your changes
Verified the last 10 Go-update merges. Author on main is always dd-octo-sts[bot]; version format is always three-part (X.Y.Z); commit subject alternates between the two forms above:

- [Update Go version to 1.26.6](https://github.com/DataDog/datadog-agent-buildimages/pull/1308)
- [Update Go version to 1.26.5](https://github.com/DataDog/datadog-agent-buildimages/pull/1251)
- [Update Go version to 1.26.4](https://github.com/DataDog/datadog-agent-buildimages/pull/1182)
- [[push_to_datadog_agent] Update go version to 1.25.10](https://github.com/DataDog/datadog-agent-buildimages/pull/1159)
- [Update go version to 1.25.9](https://github.com/DataDog/datadog-agent-buildimages/pull/1125)
- [Update go version to 1.25.8](https://github.com/DataDog/datadog-agent-buildimages/pull/1112)
- [Update go version to 1.25.7](https://github.com/DataDog/datadog-agent-buildimages/pull/1087)
- [[push_to_datadog_agent] Update go version to 1.25.6](https://github.com/DataDog/datadog-agent-buildimages/pull/1069)
- [[push_to_datadog_agent] Update go version to 1.24.10](https://github.com/DataDog/datadog-agent-buildimages/pull/1012)
- [Update go version to 1.24.9](https://github.com/DataDog/datadog-agent-buildimages/pull/1004)

## Additional Notes
All of the above assumes the autogenerated PR title is not modified by humans at merge time. PR #1310 needs a small rebase after this lands.