### PR TITLE
Exclude OTEL_* environment variable from workspace image

### DIFF
--- a/dev-envs/linux/variants/workspaces/setup.sh
+++ b/dev-envs/linux/variants/workspaces/setup.sh
@@ -12,7 +12,7 @@ workspace_env_file="${DD_BUILD_CONFIG_ROOT}/dd-agent-workspace-env.sh"
 install -d -m 0775 "$(dirname "${workspace_env_file}")"
 while IFS= read -r line; do
     printf 'export %s=%q\n' "${line%%=*}" "${line#*=}"
-done < <(env | grep -Ev "^(CODEX_HOME=|CLAUDE_CONFIG_DIR=|HOME=|USER=|MAIL=|LS_COLORS=|HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|_=)") > "${workspace_env_file}"
+done < <(env | grep -Ev "^(CODEX_HOME=|CLAUDE_CONFIG_DIR=|HOME=|USER=|MAIL=|LS_COLORS=|HOSTNAME=|PWD=|TERM=|SHLVL=|LANGUAGE=|OTEL_.*=|TRACEPARENT=|_=)") > "${workspace_env_file}"
 
 seed_home() {
     local home="$1"


### PR DESCRIPTION
### What does this PR do?

Exclude OTEL_* env var from the env snapshot. Because they are injected by buildkit and we 

### Motivation

When BuildKit tracing is enabled, it injects OpenTelemetry vars into each build step, including:

OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=unix:///dev/otel-grpc.sock
OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
OTEL_TRACES_EXPORTER=otlp
OTEL_TRACE_PARENT / TRACEPARENT
/dev/otel-grpc.sock is BuildKit’s in-container gRPC socket for nested traces, not something defined in the Dockerfiles.


### Possible Drawbacks / Trade-offs

### Additional Notes
