### PR TITLE
[AGENTRUN-1173] fix(ci): dynamic resolution of PR base branch when pushing Go update to datadog-agent

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -92,6 +92,7 @@ jobs:
         with:
           token: ${{ steps.octo-sts.outputs.token }}
           commit-message: "Update Go version to ${{ inputs.go_version }}"
+          base: ${{ github.ref_name }}
           branch: ${{ env.BRANCH_NAME }}
           sign-commits: true
           title: "Update Go version to ${{ inputs.go_version }}"

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -146,7 +146,6 @@ update_datadog_agent_pr_with_test_images:
     - job: build_windows_ltsc2025_x64
       optional: true
   variables:
-    REF: main
     BRANCH: buildimages/$CI_COMMIT_BRANCH
     IMAGES_ID: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
   id_tokens:
@@ -168,6 +167,15 @@ update_datadog_agent_pr_with_test_images:
     - pip install "dda==${DDA_VERSION}"
     - dda -v self dep sync -f legacy-build
     - export GITHUB_TOKEN=$(cat token.txt)
+    # Look up the open buildimages PR for this commit and read its base branch.
+    - >-
+      REF=$(curl
+      -sfH "Authorization: Bearer $GITHUB_TOKEN"
+      -H "Accept: application/vnd.github+json"
+      "https://api.github.com/repos/DataDog/datadog-agent-buildimages/commits/${CI_COMMIT_SHA}/pulls"
+      | jq -r '.[0].base.ref // empty') ||
+      { echo "GitHub API lookup failed while resolving PR for commit $CI_COMMIT_SHA" >&2; exit 1; }
+    - if [[ -z "$REF" ]]; then echo "No open PR found for commit $CI_COMMIT_SHA" >&2; exit 1; fi
     - dda run update agent-build-images "$IMAGES_ID" "$BRANCH" --ref "$REF" --test-version
   after_script:
     # Revoke the token after usage


### PR DESCRIPTION
### What does this PR do?

Fixes the base branch for `datadog-agent` Go update PR automatically opened by the `datadog-agent-buildimages` CI. It fetches the base branch from the PR associated to the commit the Gitlab pipeline is based on. This only concerns pipelines on PRs.

The base branch fetch is replicated from the other job that pushes the CI final images.

### Motivation

Fix automated workflow for release branches, PR base branch is currently always `main`.

### Possible Drawbacks / Trade-offs

### Additional Notes