### PR TITLE
chore(ci): add backport label to automated Go update PR

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -94,7 +94,7 @@ jobs:
           commit-message: "Update Go version to ${{ inputs.go_version }}"
           branch: ${{ env.BRANCH_NAME }}
           sign-commits: true
-          title: "Update Go version to ${{ inputs.go_version }}"
+          title: ${{ github.ref_name == 'main' && format('Update Go version to {0}', inputs.go_version) || format('[Backport {0}] Update Go version to {1}', github.ref_name, inputs.go_version) }}
           body: |
               ## Update docker images to Go ${{ inputs.go_version }}
               For more information about this version, see the [Go release notes](https://golang.org/doc/devel/release.html#go${{ inputs.go_version }}) and the [Github milestone](https://github.com/golang/go/issues?q=milestone%3AGo${{ inputs.go_version }}+label%3ACherryPickApproved)


### PR DESCRIPTION
### What does this PR do?

Indicates with a label the release branch targeted by the Go update PR directly in its title.

Replicated from https://github.com/DataDog/datadog-agent/blob/b1844b7d78e0b3f475ed96d711707a9093d4542c/.github/workflows/buildimages-update.yml#L140

### Motivation

Differentiate Go update PRs. Currently, they all have the same title.

### Possible Drawbacks / Trade-offs

### Additional Notes
