### PR TITLE
[ACIX-1708] Update ddgl version used in devenvs + fix config

### DIFF
--- a/dev-envs/linux/ddgl.sh
+++ b/dev-envs/linux/ddgl.sh
@@ -8,7 +8,7 @@ export UV_PYTHON_INSTALL_DIR="${DD_BUILD_INSTALL_ROOT}/uv/base"
 export UV_TOOL_DIR="${DD_BUILD_INSTALL_ROOT}/uv/venv"
 export UV_TOOL_BIN_DIR="/usr/local/bin"
 
-DDGL_VERSION=v0.2.0
+DDGL_VERSION=v0.3.0
 
 (
     umask 0002

--- a/dev-envs/linux/ddgl.sh
+++ b/dev-envs/linux/ddgl.sh
@@ -21,5 +21,5 @@ mkdir -p "${ddgl_config_dir}"
 cat <<'EOF' > "${ddgl_config_dir}/config.toml"
 gitlab_url="https://gitlab.ddbuild.io"
 github_fallback = true
-token_command = ["ddtool", "auth", "token", "gitlab", "--datacenter", "us1.ddbuild.io"]
+token_command = ["ddtool", "auth", "gitlab", "token"]
 EOF


### PR DESCRIPTION
### What does this PR do?

Updates the version of `ddgl` shipped in dev envs to `v0.3.0` + fix the config so that it can actually obtain gitlab tokens automatically

### Motivation

Making the new retry feature available for DataDog/datadog-agent#55947
Make ddgl work properly in devenvs/workspaces even without manually setting `GITLAB_TOKEN`

### Possible Drawbacks / Trade-offs

### Additional Notes
