### PR TITLE
feat: add pup to devenvs

### DIFF
--- a/dev-envs/linux/tools.txt
+++ b/dev-envs/linux/tools.txt
@@ -31,6 +31,7 @@ kubectl
 mise
 nu
 procs
+pup
 rg
 rtk
 sd

--- a/tools/dotslash/config/pup.json
+++ b/tools/dotslash/config/pup.json
@@ -2,10 +2,10 @@
   "__extra_metadata": {
     "platforms": {
       "linux-aarch64": {
-        "uncompressed_size": 0
+        "uncompressed_size": 84221459
       },
       "linux-x86_64": {
-        "uncompressed_size": 0
+        "uncompressed_size": 92938091
       }
     }
   },

--- a/tools/dotslash/config/pup.json
+++ b/tools/dotslash/config/pup.json
@@ -1,0 +1,41 @@
+{
+  "__extra_metadata": {
+    "platforms": {
+      "linux-aarch64": {
+        "uncompressed_size": 0
+      },
+      "linux-x86_64": {
+        "uncompressed_size": 0
+      }
+    }
+  },
+  "name": "pup",
+  "platforms": {
+    "linux-aarch64": {
+      "digest": "06a866960e5efd49bdce2720bbb0198c414fd72ce91bf561a3e078b46885cfc9",
+      "format": "tar.gz",
+      "hash": "blake3",
+      "path": "pup",
+      "providers": [
+        {
+          "type": "http",
+          "url": "https://github.com/DataDog/pup/releases/download/v1.18.1/pup_1.18.1_Linux_arm64.tar.gz"
+        }
+      ],
+      "size": 28243727
+    },
+    "linux-x86_64": {
+      "digest": "6558c70b0910c4463b3ad2ff90d58d9964349ba6160b495822e91f3d7ce7d824",
+      "format": "tar.gz",
+      "hash": "blake3",
+      "path": "pup",
+      "providers": [
+        {
+          "type": "http",
+          "url": "https://github.com/DataDog/pup/releases/download/v1.18.1/pup_1.18.1_Linux_x86_64.tar.gz"
+        }
+      ],
+      "size": 29352559
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Add the first-party DD CLI, `pup` to the set of tools installed in developer environments via Dotslash.

### Motivation

Required for DataDog/datadog-agent#55947, and it's just an overall useful tool :)

### Possible Drawbacks / Trade-offs

### Additional Notes
