### PR TITLE
Prevent possible key exposure in Docker container logs

### DIFF
--- a/dev-envs/linux/init/startup.sh
+++ b/dev-envs/linux/init/startup.sh
@@ -104,10 +104,10 @@ set-ev AWS_VAULT_BACKEND "pass"
 dda config restore
 
 # Configure telemetry if enabled
+set +x
 if [[ -n "${DDA_TELEMETRY_API_KEY:-}" ]]; then
     # Avoid exposing the API key in startup logs while persisting it for later sessions.
-    set +x
     set-ev DDA_TELEMETRY_API_KEY "${DDA_TELEMETRY_API_KEY}"
-    set -x
     dda self telemetry enable
 fi
+set -x

--- a/dev-envs/linux/init/startup.sh
+++ b/dev-envs/linux/init/startup.sh
@@ -105,6 +105,9 @@ dda config restore
 
 # Configure telemetry if enabled
 if [[ -n "${DDA_TELEMETRY_API_KEY:-}" ]]; then
+    # Avoid exposing the API key in startup logs while persisting it for later sessions.
+    set +x
     set-ev DDA_TELEMETRY_API_KEY "${DDA_TELEMETRY_API_KEY}"
+    set -x
     dda self telemetry enable
 fi


### PR DESCRIPTION
### Motivation

I came across this while working on https://github.com/DataDog/datadog-agent-dev/pull/305